### PR TITLE
fix: bind existing tables in IcebergNamespace.push()

### DIFF
--- a/src/avalanche/iceberg/namespace.py
+++ b/src/avalanche/iceberg/namespace.py
@@ -283,7 +283,8 @@ class IcebergNamespace(Namespace):
                 location=location,
             )
         else:
-            logger.warning(f"Table {table.identifier} already exists. Skipping creation.")
+            logger.debug(f"Table {table.identifier} already exists. Loading it.")
+            table._table = self.catalog.load_table(table.identifier)
 
     def drop(self, *, drop_tables: bool = False) -> None:
         """

--- a/test/iceberg/namespace_test.py
+++ b/test/iceberg/namespace_test.py
@@ -4,6 +4,7 @@ import os
 from tempfile import TemporaryDirectory
 
 import dataframely as dy
+import polars as pl
 import pytest
 
 from avalanche.iceberg import (
@@ -95,6 +96,38 @@ class TestIcebergNamespace:
         print_directory_tree(tmpdir, level=1)
 
         assert os.path.exists(f"{tmpdir}/test-namespace/test_table")
+
+    def test_push_binds_existing_tables_across_instances(self, tmpdir: str):
+        """Test that push() binds tables that already exist in the catalog."""
+
+        def make_ns():
+            class ReproNamespace(IcebergNs):
+                ns_config = IcebergNsConfig(
+                    name="repush-namespace",
+                    base_location=tmpdir,
+                )
+                tables: IcebergTableGroup = IcebergTableGroup(
+                    test_table=IcebergTable(schema=TestSchema)
+                )
+
+            return ReproNamespace(
+                catalog="test-catalog",
+                load_catalog_props=dict(
+                    type="sql",
+                    uri=f"sqlite:///{tmpdir}/catalog.db",
+                ),
+            )
+
+        first = make_ns()
+        first.push()
+        first.tables.test_table.append(pl.DataFrame({"id": ["1"], "name": ["a"]}))
+
+        second = make_ns()
+        second.push()
+
+        assert second.tables.test_table._table is not None
+        second.tables.test_table.append(pl.DataFrame({"id": ["2"], "name": ["b"]}))
+        assert sorted(second.tables.test_table.read()["id"].to_list()) == ["1", "2"]
 
 
 class TestIcebergTable:


### PR DESCRIPTION
Fixes #1

## Problem

`IcebergNamespace.push()` only bound `IcebergTable._table` on the create path. When a table already existed in the catalog, `_push_table` logged "already exists. Skipping creation." and left `_table = None`, so any subsequent `append()` / `scan()` / proxied attribute access raised:

```
AttributeError: Cannot append - table has not been created yet. Call namespace.push() first.
```

In effect `push()` only worked in the first process to ever touch a persistent catalog. Any later process (script rerun, operator/TUI scanning a flow file, Ray worker) hit the already-exists path for every table and failed on first table access — with an error message suggesting the one call that can't fix it.

## Change

- `_push_table`: in the already-exists branch, bind the table via `self.catalog.load_table(table.identifier)`; downgrade the log line to debug since this is the normal steady-state path.
- Regression test `test_push_binds_existing_tables_across_instances`: two namespace instances against the same file-backed SQLite catalog — second instance pushes, asserts binding, appends, and reads back rows written by both instances.

`LanceNamespace.push()` does not have this gap — it's idempotent mkdirs, and Lance table binding happens in `Namespace.__init__`.

## Verification

- `uv run pytest test/iceberg/ -q` — 39 passed (new test included; fails without the fix with the AttributeError above).
- Re-ran the original failing scenario from #1 (fresh process importing a namespace module that pushes against an existing persistent catalog): all tables now bound after `push()`.
