### PR TITLE
fix: import package-resident flow files under their canonical module name

### DIFF
--- a/src/runtime/operator/registry.py
+++ b/src/runtime/operator/registry.py
@@ -61,36 +61,75 @@ class WorkflowRegistry:
         if self._scan_paths:
             self.scan(self._scan_paths)
 
+    @staticmethod
+    def _package_module_name(file_path: Path) -> tuple[str, Path] | None:
+        """Resolve a file inside a package to (dotted module name, sys.path root)."""
+        parts = [file_path.stem]
+        parent = file_path.parent
+        while (parent / "__init__.py").exists():
+            parts.append(parent.name)
+            parent = parent.parent
+        if len(parts) == 1:
+            return None
+        return ".".join(reversed(parts)), parent
+
     def _scan_file(self, file_path: Path) -> None:
-        """Import a Python file and discover @workflow functions in it."""
-        module_name = f"_avalanche_discovered_.{file_path.stem}"
+        """Import a Python file and discover @workflow functions in it.
 
-        # Remove cached module so re-scans pick up file changes
-        sys.modules.pop(module_name, None)
+        Files inside a package (a chain of __init__.py up from the file) are
+        imported under their canonical dotted name so relative imports work;
+        standalone files are loaded under a synthetic module name.
+        """
+        file_path = file_path.resolve()
+        package_info = self._package_module_name(file_path)
 
-        spec = importlib.util.spec_from_file_location(module_name, file_path)
-        if spec is None or spec.loader is None:
-            self._add_skipped_diagnostic(
-                file_path,
-                "Python import machinery could not load this file.",
-            )
-            return
-
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-        try:
-            spec.loader.exec_module(module)
-        except Exception as exc:
-            self._diagnostics.append(
-                WorkflowDiscoveryDiagnostic(
-                    path=str(file_path),
-                    kind="import_error",
-                    message=self._format_exception(exc),
-                )
-            )
-            return
-        finally:
+        if package_info is not None:
+            module_name, root = package_info
+            root_str = str(root)
+            if root_str not in sys.path:
+                sys.path.insert(0, root_str)
+            # Remove cached module so re-scans pick up file changes
             sys.modules.pop(module_name, None)
+            try:
+                module = importlib.import_module(module_name)
+            except Exception as exc:
+                self._diagnostics.append(
+                    WorkflowDiscoveryDiagnostic(
+                        path=str(file_path),
+                        kind="import_error",
+                        message=self._format_exception(exc),
+                    )
+                )
+                return
+        else:
+            module_name = f"_avalanche_discovered_.{file_path.stem}"
+
+            # Remove cached module so re-scans pick up file changes
+            sys.modules.pop(module_name, None)
+
+            spec = importlib.util.spec_from_file_location(module_name, file_path)
+            if spec is None or spec.loader is None:
+                self._add_skipped_diagnostic(
+                    file_path,
+                    "Python import machinery could not load this file.",
+                )
+                return
+
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            except Exception as exc:
+                self._diagnostics.append(
+                    WorkflowDiscoveryDiagnostic(
+                        path=str(file_path),
+                        kind="import_error",
+                        message=self._format_exception(exc),
+                    )
+                )
+                return
+            finally:
+                sys.modules.pop(module_name, None)
 
         found_workflow = False
         for attr_name in dir(module):

--- a/test/operator_tests/test_registry.py
+++ b/test/operator_tests/test_registry.py
@@ -91,6 +91,31 @@ class TestWorkflowRegistry:
             )
         ]
 
+    def test_scan_discovers_workflow_in_package_with_relative_imports(self, tmp_path):
+        pkg = tmp_path / "my_pkg" / "my_belt"
+        pkg.mkdir(parents=True)
+        (tmp_path / "my_pkg" / "__init__.py").write_text("")
+        (pkg / "__init__.py").write_text("")
+        (pkg / "helpers.py").write_text("VALUE = 41\n")
+        (pkg / "flow.py").write_text(
+            "import avalanche as ava\n"
+            "from .helpers import VALUE\n"
+            "\n"
+            "@ava.source\n"
+            "def load():\n"
+            "    return VALUE + 1\n"
+            "\n"
+            "@ava.workflow\n"
+            "def package_workflow():\n"
+            "    return load()\n"
+        )
+
+        registry = WorkflowRegistry()
+        registry.scan([str(pkg / "flow.py")])
+
+        assert [w.name for w in registry.list_workflows()] == ["package_workflow"]
+        assert registry.list_diagnostics() == []
+
     def test_scan_records_skipped_diagnostic_for_file_with_no_workflows(self, tmp_path):
         no_workflow_file = tmp_path / "no_workflows.py"
         no_workflow_file.write_text("VALUE = 1\n")


### PR DESCRIPTION
Fixes #3

## Problem

`WorkflowRegistry._scan_file` imported every flow file via `spec_from_file_location` under a synthetic top-level module name (`_avalanche_discovered_.<stem>`), even when the file lives inside a real package. Flow files therefore could not use relative imports: discovery failed and recorded the misleading diagnostic `ModuleNotFoundError: No module named '_avalanche_discovered_'`, silently dropping the workflow from the operator/TUI.

## Change

- `_scan_file` now detects package membership (unbroken `__init__.py` chain up from the file). Package-resident files are imported under their **canonical dotted name**: the package root's parent goes on `sys.path`, the module entry is popped for rescan freshness, then `importlib.import_module(dotted_name)`. Relative imports resolve, and the scanned module is the same `sys.modules` entry the rest of the process uses.
- Standalone files keep the existing synthetic-name path — byte-for-byte the old behavior.
- Regression test `test_scan_discovers_workflow_in_package_with_relative_imports`: a two-level package whose flow file relatively imports a sibling; scan must register the workflow with zero diagnostics.

## Semantics notes

- Rescan parity: only the flow module is popped before re-import, so flow-file edits are picked up; transitively imported siblings stay cached — same as before for any transitively imported module.
- Parent `__init__.py` side effects execute during scan; they execute on any canonical import anyway.
- PEP 420 namespace packages (no `__init__.py`) stop the walk and take the standalone path.

## Verification

- `uv run pytest test/operator_tests/ test/operator_example_discovery_test.py -q` — 49 passed, 2 skipped (new test included; it fails on main with the `_avalanche_discovered_` ModuleNotFoundError).
- Live check against a real package-resident flow file using relative imports: discovered by name, zero diagnostics.
