### PR TITLE
Pydantic-first tables and typed AppendResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Pydantic-first tables and typed AppendResult
+
+- Pydantic `BaseModel` classes are now a first-class table schema source for
+  `ava.IcebergTable(schema=...)` and `ava.LanceTable(schema=...)`: nested models
+  become struct columns, lists become list columns, `Field(description=...)`
+  becomes column documentation, and unmappable fields fail loudly with a
+  per-field `ava.Json` JSON-string opt-out.
+- Model-declared tables accept model instances (single or list) in `append(...)`
+  and read back as validated models via `read_models()`.
+- `ava.AppendResult` is generic over the row model and adds `to_models()`,
+  `one()` (asserts exactly-one-row cardinality), and `one_or_none()`.
+- New `ava.input.<field>` build-time placeholder for feeding validated run
+  input into any node's arguments.
+- Fix: futures passed explicitly as keyword arguments are no longer re-bound
+  implicitly by position.
+- See [docs/data-model-api.md](docs/data-model-api.md#pydantic-model-schemas).
+
 ## 0.1.0-rc0
 
 Initial team release candidate for Avalanche as a local-first Python data-flow

--- a/docs/data-model-api.md
+++ b/docs/data-model-api.md
@@ -7,7 +7,8 @@ The current release candidate supports:
   `TableGroup`, and `ScanResult`;
 - Iceberg-backed namespaces and tables;
 - Lance-backed namespaces and tables when the optional Lance extra is installed;
-- DataFramely schemas converted to backend-native table schemas.
+- DataFramely schemas converted to backend-native table schemas;
+- pydantic `BaseModel` schemas for model-first pipelines.
 
 ## Define schemas
 
@@ -33,6 +34,68 @@ DataFramely can validate or cast data before it is appended:
 ```python
 validated = DocumentSchema.validate(df, cast=True)
 ```
+
+## Pydantic model schemas
+
+Tables can be declared directly from a pydantic `BaseModel` subclass anywhere a
+DataFramely schema is accepted. This is the recommended source of truth for
+model-first pipelines: one declaration serves the table schema and the
+validation contract.
+
+```python
+from pydantic import BaseModel, Field
+
+class Address(BaseModel):
+    city: str = Field(description="City name")
+    zip_code: str | None = None
+
+class Person(BaseModel):
+    id: int
+    name: str = Field(description="Display name")
+    address: Address
+    tags: list[str]
+
+class PeopleNamespace(ava.IcebergNs):
+    ns_config = ava.IcebergNsConfig(name="people", base_location="...")
+
+    people = ava.IcebergTable(schema=Person)
+```
+
+Type mapping is struct-first so the lake stays queryable: scalars map to native
+columns, nested models to struct columns, and `list[...]` to list columns.
+`Field(description=...)` becomes Arrow column documentation at every nesting
+level. Fields that cannot map cleanly to Arrow (bare `Any`, non-optional
+unions, heterogeneous dicts) fail loudly at declaration; opt into a JSON-string
+column per field with the `ava.Json` marker:
+
+```python
+from typing import Annotated, Any
+
+class Event(BaseModel):
+    kind: str
+    payload: Annotated[dict[str, Any], ava.Json]
+```
+
+Model-declared tables accept model instances in `append` and read back as
+validated models:
+
+```python
+result = ns.people.append(Person(id=1, name="ada", address=Address(city="Toronto"), tags=[]))
+ns.people.append([person_a, person_b])
+
+people = ns.people.read_models()   # list[Person]
+```
+
+The returned `ava.AppendResult` is typed by the table's row model and adds
+model accessors to the frame accessors:
+
+- `to_models()` — the appended rows as validated model instances;
+- `one()` — exactly one appended model; raises on zero or multiple rows
+  (asserts the step's cardinality contract at the boundary);
+- `one_or_none()` — the lenient variant for optional-output steps.
+
+Row provenance columns (`_ava_*`) behave identically to DataFramely-schema'd
+tables, and DataFramely remains fully supported for dataframe-native pipelines.
 
 ## Iceberg namespace
 

--- a/src/avalanche/__init__.py
+++ b/src/avalanche/__init__.py
@@ -20,6 +20,7 @@ from .iceberg import (
     IcebergTable,
     IcebergTableGroup,
 )
+from .input_ref import INPUT as input  # noqa: N811
 from .lance import (
     LanceNamespace,
     LanceNamespaceConfig,
@@ -65,6 +66,7 @@ __all__ = [
     "dest",
     "workflow",
     "pipeline",
+    "input",
     # Workflow
     "Workflow",
     "Pipeline",

--- a/src/avalanche/__init__.py
+++ b/src/avalanche/__init__.py
@@ -27,6 +27,7 @@ from .lance import (
     LanceNsConfig,
     LanceTable,
 )
+from .model_frame import Json
 
 # Progress tracking
 from .progress import ProgressStore
@@ -54,6 +55,7 @@ from .storage import Namespace, NamespaceConfig, ScanResult, Table, TableGroup
 from .types import AppendResult, SnapshotMetadata, SnapshotState
 
 __version__ = "0.1.0rc0"
+
 
 __all__ = [
     # Decorators
@@ -90,6 +92,7 @@ __all__ = [
     "AppendResult",
     "SnapshotState",
     "SnapshotMetadata",
+    "Json",
     # Storage contracts
     "Namespace",
     "NamespaceConfig",

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -57,6 +57,8 @@ from typing import TYPE_CHECKING, Any, Callable, DefaultDict, TypeVar, get_type_
 
 from ulid import ULID
 
+from .input_ref import InputRef
+
 if TYPE_CHECKING:
     from .executor import Executor
     from .operator.hooks import RunHooks
@@ -714,6 +716,42 @@ def _resolve_to_ref(arg, result_refs, executor=None):
     return ref[arg.tuple_index]
 
 
+def _resolve_input_refs(
+    resolved_args: list,
+    resolved_kwargs: dict,
+    run_input: Any,
+    node_name: str,
+    workflow_name: str,
+) -> tuple[list, dict]:
+    """Resolve top-level ava.input references against the workflow run input."""
+
+    def resolve_value(value: Any) -> Any:
+        if not isinstance(value, InputRef):
+            return value
+        if run_input is None:
+            raise ValueError(
+                f"Node '{node_name}' references {value!r} in workflow '{workflow_name}', "
+                "but no run input is available. Declare @workflow(input=...) and/or "
+                "pass input= to run()."
+            )
+
+        current = run_input
+        for attr in value.path:
+            try:
+                current = getattr(current, attr)
+            except AttributeError as exc:
+                raise AttributeError(
+                    f"Node '{node_name}' references {value!r} in workflow '{workflow_name}', "
+                    f"but attribute '{attr}' is missing on {type(current).__name__}."
+                ) from exc
+        return current
+
+    return (
+        [resolve_value(value) for value in resolved_args],
+        {key: resolve_value(value) for key, value in resolved_kwargs.items()},
+    )
+
+
 def _reverse_graph(parent_to_children: dict[str, list[str]]) -> dict[str, list[str]]:
     """
     Reverse a directed graph from parent -> children to child -> parents mapping.
@@ -1351,6 +1389,7 @@ def _with_current_run_context(
 
 def _inspect_runtime_params(
     fn: Callable,
+    args: tuple[Any, ...],
     kwargs: dict[str, Any],
     run_input: Any,
     run_context: Any,
@@ -1369,9 +1408,25 @@ def _inspect_runtime_params(
     except Exception:
         type_hints = {}
 
+    position_bound_param_names: set[str] = set()
+    positional_count = len(args)
+    consumed_positionals = 0
+    for param in sig.parameters.values():
+        if consumed_positionals >= positional_count:
+            break
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            position_bound_param_names.add(param.name)
+            consumed_positionals += 1
+        elif param.kind is inspect.Parameter.VAR_POSITIONAL:
+            position_bound_param_names.add(param.name)
+            break
+
     injected: dict[str, Any] = {}
     for param_name, param in sig.parameters.items():
-        if param_name in kwargs:
+        if param_name in kwargs or param_name in position_bound_param_names:
             continue
         annotation = type_hints.get(param_name, param.annotation)
         if annotation is inspect.Parameter.empty:
@@ -1902,6 +1957,7 @@ class Workflow:
             )
             runtime_params = _inspect_runtime_params(
                 node_ref.node.fn,
+                node_ref.args,
                 node_ref.kwargs,
                 run_input,
                 node_run_context,
@@ -1974,6 +2030,13 @@ class Workflow:
                 # Exclude injectable params from normal resolution
                 if k not in injectable_params and k not in runtime_params
             }
+            resolved_args, resolved_kwargs = _resolve_input_refs(
+                resolved_args,
+                resolved_kwargs,
+                run_input,
+                node_ref.node.fn.__name__,
+                self.name,
+            )
 
             # Get original function, optionally wrapped by hooks
             actual_fn = node_ref.node.fn

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -1613,13 +1613,25 @@ def _collect_implicit_parent_results(
     *,
     executor: Any = None,
 ) -> list[Any]:
-    """Collect flattened parent results for implicit data passing."""
+    """Collect flattened parent results for implicit data passing.
+
+    Parents whose NodeFuture was passed explicitly (as a positional or keyword
+    argument) are excluded: their results already flow through normal argument
+    resolution, so re-binding them implicitly would double-pass them.
+    """
+    explicit_ids = {
+        value.future_id
+        for value in (*node_ref.args, *node_ref.kwargs.values())
+        if isinstance(value, NodeFuture)
+    }
     auto_values: list[Any] = []
 
     # Use _incoming_refs if available (preserves tuple_index info).
     # Otherwise fall back to dependencies_map.
     if node_ref._incoming_refs:
         for incoming in node_ref._incoming_refs:
+            if incoming.future_id in explicit_ids:
+                continue
             presult = result_refs.get(incoming.future_id)
             if presult is not None:
                 if incoming.tuple_index is not None:
@@ -1633,6 +1645,8 @@ def _collect_implicit_parent_results(
     else:
         parent_ids = dependencies_map.get(node_id, [])
         for pid in parent_ids:
+            if pid in explicit_ids:
+                continue
             presult = result_refs.get(pid)
             if presult is not None:
                 auto_values.extend(_implicit_items_from_parent_result(presult))

--- a/src/avalanche/iceberg/schema.py
+++ b/src/avalanche/iceberg/schema.py
@@ -8,7 +8,10 @@ from typing import Any, Type, Union
 
 import dataframely as dy
 import pyarrow as pa
+from pydantic import BaseModel
+from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
 from pyiceberg.schema import Schema as IcebergSchema
+from pyiceberg.schema import assign_fresh_schema_ids
 from pyiceberg.types import (
     BinaryType,
     BooleanType,
@@ -21,6 +24,8 @@ from pyiceberg.types import (
     StringType,
     TimestampType,
 )
+
+from avalanche.model_frame import model_to_arrow_schema
 
 
 def _pyarrow_type_to_iceberg_type(arrow_type: pa.DataType) -> Any:
@@ -99,7 +104,9 @@ def dataframely_to_iceberg_schema(schema: Type[dy.Schema]) -> IcebergSchema:
     return IcebergSchema(*iceberg_fields)
 
 
-def normalize_schema(schema: Union[Type[dy.Schema], IcebergSchema]) -> IcebergSchema:
+def normalize_schema(
+    schema: Union[Type[dy.Schema], IcebergSchema, type[BaseModel]],
+) -> IcebergSchema:
     """
     Normalize a schema to PyIceberg Schema.
 
@@ -136,8 +143,12 @@ def normalize_schema(schema: Union[Type[dy.Schema], IcebergSchema]) -> IcebergSc
     if isinstance(schema, type) and issubclass(schema, dy.Schema):
         return dataframely_to_iceberg_schema(schema)
 
+    if isinstance(schema, type) and issubclass(schema, BaseModel):
+        arrow_schema = model_to_arrow_schema(schema)
+        return assign_fresh_schema_ids(_pyarrow_to_schema_without_ids(arrow_schema))
+
     # Unsupported type
     raise TypeError(
-        f"Schema must be either PyIceberg Schema or DataFramely Schema class, "
-        f"got {type(schema)}"
+        "Schema must be either PyIceberg Schema, DataFramely Schema class, "
+        f"or pydantic BaseModel class, got {type(schema)}"
     )

--- a/src/avalanche/iceberg/table.py
+++ b/src/avalanche/iceberg/table.py
@@ -15,10 +15,12 @@ All PyIceberg Table methods are accessible through this wrapper:
 - And all other PyIceberg Table methods
 """
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 import polars as pl
 import pyarrow as pa
+from pydantic import BaseModel
 from pyiceberg.schema import Schema as IcebergSchema
 from pyiceberg.table import ALWAYS_TRUE, EMPTY_DICT, BooleanExpression, Properties, Table
 from pyiceberg.types import NestedField, StringType, TimestampType
@@ -43,7 +45,7 @@ def _with_row_lineage_schema(schema: IcebergSchema) -> IcebergSchema:
             f"remove or rename: {joined}"
         )
 
-    next_field_id = max((field.field_id for field in schema.fields), default=0) + 1
+    next_field_id = schema.highest_field_id + 1
     lineage_fields = []
     for offset, name in enumerate(ROW_LINEAGE_COLUMNS):
         field_type = TimestampType() if name == "_ava_updated_at" else StringType()
@@ -63,6 +65,7 @@ def _reconnect_table(
     catalog_props: dict,
     identifier: str,
     row_lineage: bool,
+    row_model: type | None = None,
 ) -> "IcebergTable":
     """Rebuild a live IcebergTable handle after crossing a process boundary.
 
@@ -76,7 +79,14 @@ def _reconnect_table(
     table._ns = None
     table._table_name = identifier
     table.row_lineage = row_lineage
-    table._reconnect_spec = (catalog_name, catalog_props, identifier, row_lineage)
+    table.row_model = row_model
+    table._reconnect_spec = (
+        catalog_name,
+        catalog_props,
+        identifier,
+        row_lineage,
+        row_model,
+    )
     table._table = catalog.load_table(identifier)
     table.schema = table._table.schema()
     return table
@@ -117,6 +127,9 @@ class IcebergTable(StorageTable):
             schema: DataFramely Schema class or PyIceberg Schema instance
         """
         super().__init__(row_lineage=row_lineage)
+        self.row_model = (
+            schema if isinstance(schema, type) and issubclass(schema, BaseModel) else None
+        )
 
         # Convert schema if needed
         self.schema: IcebergSchema = normalize_schema(schema)
@@ -124,7 +137,7 @@ class IcebergTable(StorageTable):
             self.schema = _with_row_lineage_schema(self.schema)
 
         self._table: Table | None = None
-        self._reconnect_spec: tuple[str, dict, str, bool] | None = None
+        self._reconnect_spec: tuple[str, dict, str, bool, type | None] | None = None
 
     def __reduce__(self) -> tuple[Any, tuple]:
         """Pickle as a reconnect recipe (catalog address + identifier).
@@ -154,7 +167,13 @@ class IcebergTable(StorageTable):
 
         return (
             _reconnect_table,
-            (str(catalog.name), properties, self.identifier, self.row_lineage),
+            (
+                str(catalog.name),
+                properties,
+                self.identifier,
+                self.row_lineage,
+                self.row_model,
+            ),
         )
 
     @property
@@ -192,7 +211,16 @@ class IcebergTable(StorageTable):
             return None
         return snapshot.snapshot_id
 
-    def append(self, df: Union[pl.DataFrame, pa.Table, "pa.RecordBatch"]) -> AppendResult:
+    def append(
+        self,
+        df: Union[
+            pl.DataFrame,
+            pa.Table,
+            "pa.RecordBatch",
+            BaseModel,
+            Sequence[BaseModel],
+        ],
+    ) -> AppendResult:
         """
         Append data to the table and return AppendResult.
 
@@ -212,6 +240,7 @@ class IcebergTable(StorageTable):
                 result = documents.append(docs.to_arrow())
                 return result  # AppendResult for zero-copy passing
         """
+        df = self._coerce_append_input(df)
         if self._table is None:
             raise AttributeError(
                 "Cannot append - table has not been created yet. Call namespace.push() first."
@@ -246,6 +275,7 @@ class IcebergTable(StorageTable):
             data=arrow_data,
             snapshot_id=snapshot_id,
             table_identity=self.identifier,
+            row_model=self.row_model,
         )
 
     def _cast_to_table_schema(self, arrow_data: pa.Table | pa.RecordBatch) -> pa.Table:
@@ -253,7 +283,8 @@ class IcebergTable(StorageTable):
         if isinstance(arrow_data, pa.RecordBatch):
             arrow_data = pa.Table.from_batches([arrow_data])
 
-        return arrow_data.cast(self.schema.as_arrow())
+        schema = self._table.schema() if self._table is not None else self.schema
+        return arrow_data.cast(schema.as_arrow())
 
     def _refresh_table_metadata(self) -> None:
         """Reload catalog metadata so reads see commits from other processes.

--- a/src/avalanche/iceberg/table.pyi
+++ b/src/avalanche/iceberg/table.pyi
@@ -5,10 +5,16 @@ This file provides type hints indicating that IcebergTable proxies
 all methods from pyiceberg.table.Table.
 """
 
+from collections.abc import Sequence
 from typing import Any, Optional, Tuple, Union
 
+import polars as pl
+import pyarrow as pa
+from pydantic import BaseModel
 from pyiceberg.schema import Schema as IcebergSchema
 from pyiceberg.table import BooleanExpression, Properties, Table
+
+from avalanche.types import AppendResult
 
 from .namespace import IcebergAppendScan, IcebergNamespace
 
@@ -23,6 +29,7 @@ class IcebergTable(Table):
     _table_name: str  # Simple table name (not full identifier)
     _ns: IcebergNamespace | None
     _table: Table | None
+    row_model: type[BaseModel] | None
 
     def __init__(self, schema: Any, *, row_lineage: bool = ...) -> None: ...
 
@@ -40,6 +47,11 @@ class IcebergTable(Table):
         filter: Any = ...,
         **kwargs: Any,
     ) -> Any: ...
+    def append(
+        self,
+        df: pl.DataFrame | pa.Table | pa.RecordBatch | BaseModel | Sequence[BaseModel],
+    ) -> AppendResult: ...
+    def read_models(self) -> list[BaseModel]: ...
     def append_scan(
         self,
         row_filter: Union[str, BooleanExpression] = ...,

--- a/src/avalanche/input_ref.py
+++ b/src/avalanche/input_ref.py
@@ -1,0 +1,19 @@
+class InputRef:
+    __slots__ = ("path",)
+
+    def __init__(self, path: tuple[str, ...]) -> None:
+        object.__setattr__(self, "path", tuple(path))
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("InputRef is immutable")
+
+    def __getattr__(self, name: str) -> "InputRef":
+        if name.startswith("_"):
+            raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
+        return InputRef(self.path + (name,))
+
+    def __repr__(self) -> str:
+        return "ava.input" + "".join(f".{part}" for part in self.path)
+
+
+INPUT = InputRef(())

--- a/src/avalanche/lance/schema.py
+++ b/src/avalanche/lance/schema.py
@@ -6,6 +6,9 @@ from typing import Type
 
 import dataframely as dy
 import pyarrow as pa
+from pydantic import BaseModel
+
+from avalanche.model_frame import model_to_arrow_schema
 
 
 def dataframely_to_lance_schema(schema: Type[dy.Schema]) -> pa.Schema:
@@ -13,7 +16,7 @@ def dataframely_to_lance_schema(schema: Type[dy.Schema]) -> pa.Schema:
     return schema.pyarrow_schema()
 
 
-def normalize_schema(schema: Type[dy.Schema] | pa.Schema) -> pa.Schema:
+def normalize_schema(schema: Type[dy.Schema] | pa.Schema | type[BaseModel]) -> pa.Schema:
     """Normalize supported Avalanche schema declarations for Lance."""
     if isinstance(schema, pa.Schema):
         return schema
@@ -21,6 +24,10 @@ def normalize_schema(schema: Type[dy.Schema] | pa.Schema) -> pa.Schema:
     if isinstance(schema, type) and issubclass(schema, dy.Schema):
         return dataframely_to_lance_schema(schema)
 
+    if isinstance(schema, type) and issubclass(schema, BaseModel):
+        return model_to_arrow_schema(schema)
+
     raise TypeError(
-        f"Schema must be either PyArrow Schema or DataFramely Schema class, got {type(schema)}"
+        "Schema must be either PyArrow Schema, DataFramely Schema class, "
+        f"or pydantic BaseModel class, got {type(schema)}"
     )

--- a/src/avalanche/lance/table.py
+++ b/src/avalanche/lance/table.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import Any
 
 import polars as pl
 import pyarrow as pa
+from pydantic import BaseModel
 from pyiceberg.exceptions import CommitFailedException
 
 from avalanche.lineage import add_row_lineage_to_arrow_schema, add_row_lineage_to_data
@@ -201,6 +203,7 @@ def _reconnect_lance_table(
     schema: pa.Schema,
     row_lineage: bool,
     table_name: str,
+    row_model: type | None = None,
 ) -> "LanceTable":
     """Rebuild a LanceTable handle after crossing a process boundary.
 
@@ -211,6 +214,7 @@ def _reconnect_lance_table(
     table._ns = None
     table._table_name = table_name
     table.row_lineage = row_lineage
+    table.row_model = row_model
     table.schema = schema
     table._location_override = location
     return table
@@ -221,6 +225,9 @@ class LanceTable(Table):
 
     def __init__(self, schema: Any, *, row_lineage: bool = True):
         super().__init__(row_lineage=row_lineage)
+        self.row_model = (
+            schema if isinstance(schema, type) and issubclass(schema, BaseModel) else None
+        )
         self.schema: pa.Schema = normalize_schema(schema)
         if self.row_lineage:
             self.schema = add_row_lineage_to_arrow_schema(self.schema)
@@ -242,7 +249,7 @@ class LanceTable(Table):
             )
         return (
             _reconnect_lance_table,
-            (location, self.schema, self.row_lineage, self._table_name),
+            (location, self.schema, self.row_lineage, self._table_name, self.row_model),
         )
 
     @property
@@ -263,7 +270,11 @@ class LanceTable(Table):
             return {}
         return dict(self._dataset().metadata)
 
-    def append(self, df: pl.DataFrame | pa.Table | pa.RecordBatch) -> AppendResult:
+    def append(
+        self,
+        df: pl.DataFrame | pa.Table | pa.RecordBatch | BaseModel | Sequence[BaseModel],
+    ) -> AppendResult:
+        df = self._coerce_append_input(df)
         if not self.location:
             raise AttributeError(
                 "Cannot append - table has not been bound to a namespace. "
@@ -289,6 +300,7 @@ class LanceTable(Table):
             data=arrow_data,
             snapshot_id=snapshot_id,
             table_identity=getattr(self, "identifier", None) or self.location,
+            row_model=self.row_model,
         )
 
     def snapshot_by_id(self, snapshot_id: int) -> LanceSnapshot | None:

--- a/src/avalanche/model_frame.py
+++ b/src/avalanche/model_frame.py
@@ -1,0 +1,300 @@
+"""Pydantic model conversion helpers for Arrow-backed model frames."""
+
+from __future__ import annotations
+
+import json
+import types
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum, IntEnum, StrEnum
+from typing import Annotated, Any, Sequence, Union, final, get_args, get_origin
+
+import polars as pl
+import pyarrow as pa
+from pydantic import BaseModel, TypeAdapter
+
+
+@final
+class Json:
+    """Mark a pydantic field to be stored as a JSON string column."""
+
+
+class UnsupportedModelFieldError(ValueError):
+    """Raised when a pydantic field annotation cannot be represented in Arrow."""
+
+
+@dataclass(frozen=True)
+class _ValueSpec:
+    is_json: bool = False
+    fields: tuple[_FieldSpec, ...] = ()
+    item: _ValueSpec | None = None
+
+
+@dataclass(frozen=True)
+class _FieldSpec:
+    name: str
+    arrow_field: pa.Field
+    value: _ValueSpec
+
+
+_UNION_ORIGINS = (Union, types.UnionType)
+
+
+def model_to_arrow_schema(model: type[BaseModel]) -> pa.Schema:
+    """Return the Arrow schema for a pydantic model class."""
+    specs = _model_specs(model)
+    return pa.schema([spec.arrow_field for spec in specs])
+
+
+def models_to_arrow(models: Sequence[BaseModel], model: type[BaseModel]) -> pa.Table:
+    """Serialize pydantic model instances into a PyArrow table."""
+    specs = _model_specs(model)
+    schema = pa.schema([spec.arrow_field for spec in specs])
+    rows = []
+    for item in models:
+        python_row = item.model_dump(mode="python")
+        json_row = item.model_dump(mode="json")
+        rows.append(_dump_fields(python_row, json_row, specs))
+
+    return pa.Table.from_pylist(rows, schema=schema)
+
+
+def arrow_to_models(data: pa.Table | pl.DataFrame, model: type[BaseModel]) -> list[BaseModel]:
+    """Deserialize a PyArrow table or Polars DataFrame into pydantic models."""
+    table = data.to_arrow() if isinstance(data, pl.DataFrame) else data
+    specs = _model_specs(model)
+
+    models = []
+    for row in table.to_pylist():
+        model_row = {
+            spec.name: _load_json_value(row[spec.name], spec.value)
+            for spec in specs
+            if spec.name in row
+        }
+        models.append(model.model_validate(model_row))
+    return models
+
+
+def _model_specs(model: type[BaseModel], parent_path: str = "") -> tuple[_FieldSpec, ...]:
+    specs = []
+    for name, field_info in model.model_fields.items():
+        annotation = field_info.annotation
+        metadata = tuple(field_info.metadata)
+        path = f"{parent_path}.{name}" if parent_path else name
+        specs.append(
+            _field_spec(
+                name=name,
+                annotation=annotation,
+                field_info_metadata=metadata,
+                description=field_info.description,
+                path=path,
+            )
+        )
+    return tuple(specs)
+
+
+def _field_spec(
+    *,
+    name: str,
+    annotation: Any,
+    field_info_metadata: tuple[Any, ...],
+    description: str | None,
+    path: str,
+) -> _FieldSpec:
+    annotation, annotated_metadata = _unwrap_annotated(annotation)
+    metadata = (*field_info_metadata, *annotated_metadata)
+
+    if _has_json_marker(metadata):
+        nullable = _lenient_nullable(annotation)
+        arrow_type = pa.string()
+        value = _ValueSpec(is_json=True)
+    else:
+        annotation, nullable = _unwrap_optional(annotation, path)
+        arrow_type, value = _arrow_type_for_annotation(annotation, path)
+
+    return _FieldSpec(
+        name=name,
+        arrow_field=pa.field(
+            name,
+            arrow_type,
+            nullable=nullable,
+            metadata=_description_metadata(description),
+        ),
+        value=value,
+    )
+
+
+def _arrow_type_for_annotation(annotation: Any, path: str) -> tuple[pa.DataType, _ValueSpec]:
+    annotation, metadata = _unwrap_annotated(annotation)
+
+    if _has_json_marker(metadata):
+        return pa.string(), _ValueSpec(is_json=True)
+
+    annotation, _ = _unwrap_optional(annotation, path)
+
+    if annotation is Any:
+        _raise_unsupported(path, annotation)
+    if annotation is str:
+        return pa.string(), _ValueSpec()
+    if annotation is bool:
+        return pa.bool_(), _ValueSpec()
+    if annotation is int:
+        return pa.int64(), _ValueSpec()
+    if annotation is float:
+        return pa.float64(), _ValueSpec()
+    if annotation is datetime:
+        return pa.timestamp("us"), _ValueSpec()
+    if annotation is date:
+        return pa.date32(), _ValueSpec()
+    if annotation is bytes:
+        return pa.binary(), _ValueSpec()
+
+    origin = get_origin(annotation)
+    if _is_union_origin(origin):
+        _raise_unsupported(path, annotation)
+
+    if _is_enum(annotation):
+        if issubclass(annotation, StrEnum) or issubclass(annotation, str):
+            return pa.string(), _ValueSpec()
+        if issubclass(annotation, IntEnum) or issubclass(annotation, int):
+            return pa.int64(), _ValueSpec()
+
+    if _is_pydantic_model(annotation):
+        fields = _model_specs(annotation, parent_path=path)
+        return pa.struct([spec.arrow_field for spec in fields]), _ValueSpec(fields=fields)
+
+    if origin is list:
+        args = get_args(annotation)
+        if not args:
+            _raise_unsupported(path, annotation)
+        item_annotation, item_metadata = _unwrap_annotated(args[0])
+        if _has_json_marker(item_metadata):
+            item_type = pa.string()
+            item_value = _ValueSpec(is_json=True)
+        else:
+            item_annotation, _ = _unwrap_optional(item_annotation, path)
+            item_type, item_value = _arrow_type_for_annotation(item_annotation, path)
+        return pa.list_(item_type), _ValueSpec(item=item_value)
+
+    return _arrow_type_for_custom_scalar(annotation, path)
+
+
+def _arrow_type_for_custom_scalar(annotation: Any, path: str) -> tuple[pa.DataType, _ValueSpec]:
+    try:
+        schema = TypeAdapter(annotation).json_schema(mode="serialization")
+    except Exception as exc:
+        raise _unsupported_error(path, annotation) from exc
+
+    schema_type = schema.get("type")
+    if schema_type == "string":
+        return pa.string(), _ValueSpec()
+    if schema_type == "integer":
+        return pa.int64(), _ValueSpec()
+    if schema_type == "number":
+        return pa.float64(), _ValueSpec()
+    if schema_type == "boolean":
+        return pa.bool_(), _ValueSpec()
+
+    _raise_unsupported(path, annotation)
+
+
+def _unwrap_annotated(annotation: Any) -> tuple[Any, tuple[Any, ...]]:
+    metadata = []
+    while get_origin(annotation) is Annotated:
+        args = get_args(annotation)
+        annotation = args[0]
+        metadata.extend(args[1:])
+    return annotation, tuple(metadata)
+
+
+def _unwrap_optional(annotation: Any, path: str) -> tuple[Any, bool]:
+    origin = get_origin(annotation)
+    if not _is_union_origin(origin):
+        return annotation, False
+
+    args = get_args(annotation)
+    non_none_args = tuple(arg for arg in args if arg is not types.NoneType)
+    if len(non_none_args) == 1:
+        return non_none_args[0], True
+
+    _raise_unsupported(path, annotation)
+
+
+def _lenient_nullable(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    return _is_union_origin(origin) and types.NoneType in get_args(annotation)
+
+
+def _is_union_origin(origin: Any) -> bool:
+    return origin in _UNION_ORIGINS
+
+
+def _is_enum(annotation: Any) -> bool:
+    return isinstance(annotation, type) and issubclass(annotation, Enum)
+
+
+def _is_pydantic_model(annotation: Any) -> bool:
+    return isinstance(annotation, type) and issubclass(annotation, BaseModel)
+
+
+def _has_json_marker(metadata: tuple[Any, ...]) -> bool:
+    return any(item is Json or isinstance(item, Json) for item in metadata)
+
+
+def _description_metadata(description: str | None) -> dict[bytes, bytes] | None:
+    if description is None:
+        return None
+    return {b"description": description.encode("utf-8")}
+
+
+def _dump_fields(
+    python_row: dict[str, Any],
+    json_row: dict[str, Any],
+    specs: tuple[_FieldSpec, ...],
+) -> dict[str, Any]:
+    return {
+        spec.name: _dump_value(python_row.get(spec.name), json_row.get(spec.name), spec.value)
+        for spec in specs
+    }
+
+
+def _dump_value(python_value: Any, json_value: Any, spec: _ValueSpec) -> Any:
+    if python_value is None:
+        return None
+    if spec.is_json:
+        return json.dumps(json_value)
+    if spec.fields:
+        return _dump_fields(python_value, json_value, spec.fields)
+    if spec.item is not None:
+        return [
+            _dump_value(python_item, json_item, spec.item)
+            for python_item, json_item in zip(python_value, json_value, strict=True)
+        ]
+    return python_value
+
+
+def _load_json_value(value: Any, spec: _ValueSpec) -> Any:
+    if value is None:
+        return None
+    if spec.is_json:
+        return json.loads(value)
+    if spec.fields:
+        return {
+            field_spec.name: _load_json_value(value[field_spec.name], field_spec.value)
+            for field_spec in spec.fields
+            if field_spec.name in value
+        }
+    if spec.item is not None:
+        return [_load_json_value(item, spec.item) for item in value]
+    return value
+
+
+def _unsupported_error(path: str, annotation: Any) -> UnsupportedModelFieldError:
+    return UnsupportedModelFieldError(
+        f"Field '{path}' has unsupported annotation {annotation!r}; "
+        "use Annotated[..., avalanche.Json] to store it as a JSON string column."
+    )
+
+
+def _raise_unsupported(path: str, annotation: Any) -> None:
+    raise _unsupported_error(path, annotation)

--- a/src/avalanche/storage.py
+++ b/src/avalanche/storage.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Any
 
 import polars as pl
 import pyarrow as pa
+from pydantic import BaseModel
 
 from .types import AppendResult
 from .utils import urljoin
@@ -64,6 +66,7 @@ class Table(ABC):
         self._ns: Namespace | None = None
         self._table_name = ""
         self.row_lineage = row_lineage
+        self.row_model: type[BaseModel] | None = None
 
     @property
     def identifier(self) -> str:
@@ -103,7 +106,10 @@ class Table(ABC):
         """Current table snapshot/version identity, if one exists."""
 
     @abstractmethod
-    def append(self, df: pl.DataFrame | pa.Table | pa.RecordBatch) -> AppendResult:
+    def append(
+        self,
+        df: pl.DataFrame | pa.Table | pa.RecordBatch | BaseModel | Sequence[BaseModel],
+    ) -> AppendResult:
         """Append data and return the created version identity."""
 
     @abstractmethod
@@ -113,6 +119,60 @@ class Table(ABC):
     def read(self) -> pl.DataFrame:
         """Read the current table contents as a Polars DataFrame."""
         return self.scan().to_polars()
+
+    def read_models(self) -> list[BaseModel]:
+        """Read the current table contents as pydantic model instances."""
+        if self.row_model is None:
+            raise TypeError(
+                "read_models() is unavailable because this table was not declared "
+                "with a pydantic model schema."
+            )
+
+        from .model_frame import arrow_to_models
+
+        data = self.scan().to_arrow()
+        return arrow_to_models(data, self.row_model)
+
+    def _coerce_append_input(
+        self,
+        df: pl.DataFrame | pa.Table | pa.RecordBatch | BaseModel | Sequence[BaseModel],
+    ) -> pl.DataFrame | pa.Table | pa.RecordBatch:
+        if isinstance(df, BaseModel):
+            return self._models_to_arrow([df])
+
+        if isinstance(df, (pl.DataFrame, pa.Table, pa.RecordBatch)):
+            return df
+
+        if isinstance(df, Sequence) and not isinstance(df, (str, bytes)):
+            return self._models_to_arrow(df)
+
+        return df
+
+    def _models_to_arrow(self, models: Sequence[BaseModel]) -> pa.Table:
+        if self.row_model is None:
+            raise TypeError(
+                "Cannot append pydantic model instances because this table was not "
+                "declared with a pydantic model schema."
+            )
+
+        model_list = list(models)
+        if not model_list:
+            raise ValueError(
+                "Cannot append zero rows; appending zero rows is rejected because it is "
+                "meaningless for the backend and would make the returned AppendResult's "
+                "cardinality ambiguous."
+            )
+
+        for item in model_list:
+            if not isinstance(item, self.row_model):
+                raise TypeError(
+                    f"Expected instances of {self.row_model.__name__} when appending "
+                    f"pydantic models; got {type(item).__name__}."
+                )
+
+        from .model_frame import models_to_arrow
+
+        return models_to_arrow(model_list, self.row_model)
 
 
 class TableGroup:

--- a/src/avalanche/types.py
+++ b/src/avalanche/types.py
@@ -10,19 +10,23 @@ Defines core types used throughout the framework:
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, ClassVar, Union
+from typing import Any, Callable, ClassVar, Generic, TypeVar, Union, cast
 
 import polars as pl
 import pyarrow as pa
+from pydantic import BaseModel
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
 @dataclass
-class AppendResult:
+class AppendResult(Generic[ModelT]):
     """
     Result of an append operation to an Iceberg table.
 
     Contains both the appended data (for zero-copy passing) and the
-    snapshot_id (for progress tracking).
+    snapshot_id (for progress tracking), plus an optional row_model for
+    typed model access through to_models(), one(), and one_or_none().
 
     This enables the framework to:
     - Pass data in-memory to downstream tasks (zero-copy)
@@ -32,6 +36,7 @@ class AppendResult:
     Attributes:
         data: The appended data (Polars DataFrame, PyArrow Table, or RecordBatch)
         snapshot_id: The snapshot ID created by this append
+        row_model: Optional pydantic model type for typed row access
 
     Example:
         @ava.source
@@ -44,6 +49,7 @@ class AppendResult:
     data: Union[pl.DataFrame, pa.Table, pa.RecordBatch]
     snapshot_id: int
     table_identity: str | None = None
+    row_model: type[ModelT] | None = None
 
     def to_polars(self) -> pl.DataFrame:
         """Convert data to Polars DataFrame if needed."""
@@ -64,6 +70,44 @@ class AppendResult:
     def to_dicts(self) -> list[dict[str, Any]]:
         """Return appended rows as Python dictionaries."""
         return self.to_polars().to_dicts()
+
+    def to_models(self) -> list[ModelT]:
+        """Return appended rows as pydantic model instances."""
+        from avalanche.model_frame import arrow_to_models
+
+        model = self._require_row_model()
+        return cast(list[ModelT], arrow_to_models(self.to_arrow(), model))
+
+    def one(self) -> ModelT:
+        """Return exactly one appended row as a pydantic model instance."""
+        model = self._require_row_model()
+        row_count = self.to_arrow().num_rows
+        if row_count != 1:
+            raise self._cardinality_error(model, row_count)
+        return self.to_models()[0]
+
+    def one_or_none(self) -> ModelT | None:
+        """Return one appended model row, or None when no rows were appended."""
+        model = self._require_row_model()
+        row_count = self.to_arrow().num_rows
+        if row_count == 0:
+            return None
+        if row_count > 1:
+            raise self._cardinality_error(model, row_count)
+        return self.to_models()[0]
+
+    def _require_row_model(self) -> type[ModelT]:
+        if self.row_model is None:
+            raise TypeError(
+                "Typed access is unavailable because this AppendResult did not come from "
+                "a table declared with a pydantic model schema."
+            )
+        return self.row_model
+
+    def _cardinality_error(self, model: type[ModelT], row_count: int) -> ValueError:
+        return ValueError(
+            f"Expected exactly one row for {model.__name__}; got {row_count} rows."
+        )
 
 
 @dataclass

--- a/test/append_result_test.py
+++ b/test/append_result_test.py
@@ -1,0 +1,110 @@
+"""Tests for AppendResult conversion and typed row access."""
+
+import polars as pl
+import pyarrow as pa
+import pytest
+from pydantic import BaseModel
+
+import avalanche as ava
+
+
+class Row(BaseModel):
+    id: int
+    name: str
+
+
+def _arrow_table(rows: list[tuple[int, str]]) -> pa.Table:
+    return pa.table(
+        {
+            "id": pa.array([row_id for row_id, _ in rows], type=pa.int64()),
+            "name": pa.array([name for _, name in rows], type=pa.string()),
+        }
+    )
+
+
+def _typed_result(rows: list[tuple[int, str]]) -> ava.AppendResult[Row]:
+    return ava.AppendResult(data=_arrow_table(rows), snapshot_id=1, row_model=Row)
+
+
+def test_to_models_from_arrow_table_preserves_order():
+    result = _typed_result([(2, "second"), (1, "first")])
+
+    models = result.to_models()
+
+    assert all(isinstance(model, Row) for model in models)
+    assert [(model.id, model.name) for model in models] == [(2, "second"), (1, "first")]
+
+
+def test_to_models_from_polars_dataframe_ignores_ava_columns():
+    df = pl.DataFrame(
+        {
+            "id": [3, 4],
+            "name": ["third", "fourth"],
+            "_ava_run_id": ["run-a", "run-b"],
+        }
+    )
+    result = ava.AppendResult(data=df, snapshot_id=2, row_model=Row)
+
+    models = result.to_models()
+
+    assert all(isinstance(model, Row) for model in models)
+    assert [(model.id, model.name) for model in models] == [(3, "third"), (4, "fourth")]
+
+
+def test_one_returns_single_model():
+    model = _typed_result([(1, "only")]).one()
+
+    assert isinstance(model, Row)
+    assert model == Row(id=1, name="only")
+
+
+def test_one_raises_for_zero_rows():
+    with pytest.raises(ValueError, match="Expected exactly one row for Row; got 0 rows"):
+        _typed_result([]).one()
+
+
+def test_one_raises_for_two_rows():
+    with pytest.raises(ValueError, match="Expected exactly one row for Row; got 2 rows"):
+        _typed_result([(1, "first"), (2, "second")]).one()
+
+
+def test_one_or_none_returns_none_for_zero_rows():
+    assert _typed_result([]).one_or_none() is None
+
+
+def test_one_or_none_returns_single_model():
+    model = _typed_result([(1, "only")]).one_or_none()
+
+    assert isinstance(model, Row)
+    assert model == Row(id=1, name="only")
+
+
+def test_one_or_none_raises_for_two_rows():
+    with pytest.raises(ValueError, match="Expected exactly one row for Row; got 2 rows"):
+        _typed_result([(1, "first"), (2, "second")]).one_or_none()
+
+
+def test_typed_methods_raise_type_error_without_row_model():
+    result = ava.AppendResult(data=_arrow_table([(1, "first")]), snapshot_id=1)
+
+    for method_name in ("to_models", "one", "one_or_none"):
+        with pytest.raises(TypeError, match="did not come from a table declared"):
+            getattr(result, method_name)()
+
+
+def test_backward_compatible_construction_and_conversion_helpers():
+    df = pl.DataFrame({"id": [1, 2], "name": ["first", "second"]})
+
+    keyword_result = ava.AppendResult(data=df, snapshot_id=3)
+    positional_result = ava.AppendResult(df, 7)
+
+    assert keyword_result.snapshot_id == 3
+    assert positional_result.snapshot_id == 7
+    assert keyword_result.row_model is None
+    assert positional_result.row_model is None
+    assert keyword_result.to_polars().equals(df)
+    assert positional_result.to_arrow().to_pydict() == df.to_arrow().to_pydict()
+    assert positional_result.to_dicts() == [
+        {"id": 1, "name": "first"},
+        {"id": 2, "name": "second"},
+    ]

--- a/test/input_ref_test.py
+++ b/test/input_ref_test.py
@@ -1,0 +1,129 @@
+import pytest
+from pydantic import BaseModel
+
+import avalanche as ava
+
+
+class NestedInput(BaseModel):
+    value: str
+
+
+class RunInput(ava.BaseInput):
+    question: str
+    nested: NestedInput | None = None
+
+
+def test_input_ref_resolves_kwarg():
+    @ava.step
+    def collect(q: str):
+        return q
+
+    @ava.workflow(input=RunInput)
+    def input_workflow():
+        return collect(q=ava.input.question)
+
+    result = input_workflow().run(
+        executor=ava.LocalExecutor(),
+        input=RunInput(question="hi"),
+    )
+
+    assert result == "hi"
+
+
+def test_input_ref_resolves_positional_arg():
+    @ava.step
+    def collect(q: str):
+        return q
+
+    @ava.workflow(input=RunInput)
+    def input_workflow():
+        return collect(ava.input.question)
+
+    result = input_workflow().run(
+        executor=ava.LocalExecutor(),
+        input=RunInput(question="hi"),
+    )
+
+    assert result == "hi"
+
+
+def test_input_ref_resolves_chained_access():
+    @ava.step
+    def collect(value: str):
+        return value
+
+    @ava.workflow(input=RunInput)
+    def input_workflow():
+        return collect(ava.input.nested.value)
+
+    result = input_workflow().run(
+        executor=ava.LocalExecutor(),
+        input=RunInput(question="ignored", nested=NestedInput(value="deep")),
+    )
+
+    assert result == "deep"
+
+
+def test_bare_input_ref_resolves_to_run_input_instance():
+    @ava.step
+    def collect(payload: RunInput):
+        return payload
+
+    @ava.workflow(input=RunInput)
+    def input_workflow():
+        return collect(ava.input)
+
+    result = input_workflow().run(
+        executor=ava.LocalExecutor(),
+        input=RunInput(question="hi", nested=NestedInput(value="deep")),
+    )
+
+    assert isinstance(result, RunInput)
+    assert result.question == "hi"
+    assert result.nested == NestedInput(value="deep")
+
+
+def test_input_ref_missing_attribute_names_node_and_attribute():
+    @ava.step
+    def collect(q: str):
+        return q
+
+    @ava.workflow(input=RunInput)
+    def missing_input_workflow():
+        return collect(q=ava.input.nope)
+
+    with pytest.raises(AttributeError, match=r"collect.*nope"):
+        missing_input_workflow().run(
+            executor=ava.LocalExecutor(),
+            input=RunInput(question="hi"),
+        )
+
+
+def test_input_ref_without_run_input_raises_value_error():
+    @ava.step
+    def collect(q: str):
+        return q
+
+    @ava.workflow
+    def no_input_workflow():
+        return collect(q=ava.input.question)
+
+    with pytest.raises(ValueError, match="input"):
+        no_input_workflow().run(executor=ava.LocalExecutor())
+
+
+def test_input_ref_resolves_validated_dict_input():
+    @ava.step
+    def collect(q: str):
+        return q
+
+    @ava.workflow(input=RunInput)
+    def input_workflow():
+        return collect(q=ava.input.question)
+
+    result = input_workflow().run(
+        executor=ava.LocalExecutor(),
+        input={"question": "hi", "nested": {"value": "deep"}},
+    )
+
+    assert result == "hi"

--- a/test/model_frame_test.py
+++ b/test/model_frame_test.py
@@ -1,0 +1,348 @@
+"""Tests for pydantic model frame conversion."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import IntEnum, StrEnum
+from typing import Annotated, Any
+
+import polars as pl
+import pyarrow as pa
+import pytest
+from pydantic import BaseModel, Field
+from pydantic_core import core_schema
+
+from avalanche import Json
+from avalanche.model_frame import (
+    UnsupportedModelFieldError,
+    arrow_to_models,
+    model_to_arrow_schema,
+    models_to_arrow,
+)
+
+
+class ScalarModel(BaseModel):
+    name: str
+    count: int
+    ratio: float
+    active: bool
+    created_at: datetime
+    starts_on: date
+    content: bytes
+
+
+class NestedModel(BaseModel):
+    label: str
+    value: int
+
+
+class NestedContainer(BaseModel):
+    nested: NestedModel
+
+
+class ListContainer(BaseModel):
+    tags: list[str]
+    nested_items: list[NestedModel]
+
+
+class OptionalModel(BaseModel):
+    required: int
+    maybe: int | None
+
+
+class Status(StrEnum):
+    READY = "ready"
+    DONE = "done"
+
+
+class Rank(IntEnum):
+    LOW = 1
+    HIGH = 2
+
+
+class EnumModel(BaseModel):
+    status: Status
+    rank: Rank
+
+
+def test_scalar_mapping_uses_expected_arrow_types():
+    schema = model_to_arrow_schema(ScalarModel)
+
+    expected = {
+        "name": pa.string(),
+        "count": pa.int64(),
+        "ratio": pa.float64(),
+        "active": pa.bool_(),
+        "created_at": pa.timestamp("us"),
+        "starts_on": pa.date32(),
+        "content": pa.binary(),
+    }
+    for name, arrow_type in expected.items():
+        field = schema.field(name)
+        assert field.type == arrow_type
+        assert field.nullable is False
+
+    empty = models_to_arrow([], ScalarModel)
+    assert empty.schema == schema
+    assert empty.num_rows == 0
+
+
+def test_nested_model_maps_to_struct_with_child_types():
+    schema = model_to_arrow_schema(NestedContainer)
+    nested = schema.field("nested")
+
+    assert nested.type == pa.struct(
+        [
+            pa.field("label", pa.string(), nullable=False),
+            pa.field("value", pa.int64(), nullable=False),
+        ]
+    )
+
+
+def test_list_fields_map_to_arrow_lists():
+    schema = model_to_arrow_schema(ListContainer)
+
+    assert schema.field("tags").type == pa.list_(pa.string())
+    assert schema.field("nested_items").type == pa.list_(
+        pa.struct(
+            [
+                pa.field("label", pa.string(), nullable=False),
+                pa.field("value", pa.int64(), nullable=False),
+            ]
+        )
+    )
+
+
+def test_optional_fields_are_nullable_and_round_trip_none():
+    schema = model_to_arrow_schema(OptionalModel)
+
+    assert schema.field("required").type == pa.int64()
+    assert schema.field("required").nullable is False
+    assert schema.field("maybe").type == pa.int64()
+    assert schema.field("maybe").nullable is True
+
+    rows = [OptionalModel(required=1, maybe=None)]
+    assert arrow_to_models(models_to_arrow(rows, OptionalModel), OptionalModel) == rows
+
+
+def test_enums_map_to_scalars_and_round_trip_to_members():
+    schema = model_to_arrow_schema(EnumModel)
+
+    assert schema.field("status").type == pa.string()
+    assert schema.field("rank").type == pa.int64()
+
+    rows = [EnumModel(status=Status.READY, rank=Rank.HIGH)]
+    restored = arrow_to_models(models_to_arrow(rows, EnumModel), EnumModel)
+
+    assert restored == rows
+    assert restored[0].status is Status.READY
+    assert restored[0].rank is Rank.HIGH
+
+
+def test_field_descriptions_are_arrow_metadata_at_every_level():
+    class DescribedChild(BaseModel):
+        detail: str = Field(description="child detail")
+
+    class DescribedParent(BaseModel):
+        title: str = Field(description="top detail")
+        child: DescribedChild
+
+    schema = model_to_arrow_schema(DescribedParent)
+
+    assert schema.field("title").metadata[b"description"] == b"top detail"
+    child_metadata = schema.field("child").type.field("detail").metadata
+    assert child_metadata[b"description"] == b"child detail"
+
+
+def test_models_round_trip_with_nested_lists_optional_enums_and_datetimes():
+    class Comment(BaseModel):
+        body: str
+        created_at: datetime
+
+    class Profile(BaseModel):
+        handle: str
+        visits: int
+
+    class Record(BaseModel):
+        name: str
+        when: datetime
+        maybe: int | None
+        status: Status
+        rank: Rank
+        profile: Profile
+        tags: list[str]
+        comments: list[Comment]
+
+    rows = [
+        Record(
+            name="first",
+            when=datetime(2026, 1, 2, 3, 4, 5, 6),
+            maybe=None,
+            status=Status.READY,
+            rank=Rank.LOW,
+            profile=Profile(handle="alpha", visits=4),
+            tags=["a", "b"],
+            comments=[Comment(body="ok", created_at=datetime(2026, 1, 3, 4, 5, 6))],
+        ),
+        Record(
+            name="second",
+            when=datetime(2026, 2, 3, 4, 5, 6),
+            maybe=9,
+            status=Status.DONE,
+            rank=Rank.HIGH,
+            profile=Profile(handle="beta", visits=5),
+            tags=[],
+            comments=[],
+        ),
+    ]
+
+    assert arrow_to_models(models_to_arrow(rows, Record), Record) == rows
+
+
+def test_json_marker_stores_json_string_and_round_trips_dict():
+    class JsonModel(BaseModel):
+        payload: Annotated[dict[str, Any], Json]
+        payload_instance: Annotated[dict[str, Any], Json()]
+
+    row = JsonModel(
+        payload={"name": "ava", "count": 3},
+        payload_instance={"items": [1, {"ok": True}]},
+    )
+    table = models_to_arrow([row], JsonModel)
+
+    assert table.schema.field("payload").type == pa.string()
+    assert table.schema.field("payload_instance").type == pa.string()
+
+    stored = table.column("payload").to_pylist()[0]
+    assert isinstance(stored, str)
+    assert stored == '{"name": "ava", "count": 3}'
+    assert arrow_to_models(table, JsonModel) == [row]
+
+
+def test_json_marker_maps_non_optional_union_to_string_and_round_trips():
+    class JsonUnionModel(BaseModel):
+        v: Annotated[int | str, Json]
+
+    schema = model_to_arrow_schema(JsonUnionModel)
+    field = schema.field("v")
+
+    assert field.type == pa.string()
+    assert field.nullable is False
+
+    rows = [JsonUnionModel(v=7), JsonUnionModel(v="seven")]
+    restored = arrow_to_models(models_to_arrow(rows, JsonUnionModel), JsonUnionModel)
+
+    assert restored == rows
+    assert restored[0].v == 7
+    assert isinstance(restored[0].v, int)
+    assert restored[1].v == "seven"
+    assert isinstance(restored[1].v, str)
+
+
+def test_json_marker_maps_optional_union_to_nullable_string_and_round_trips():
+    class OptionalJsonUnionModel(BaseModel):
+        payload: Annotated[dict[str, Any] | None, Json]
+
+    schema = model_to_arrow_schema(OptionalJsonUnionModel)
+    field = schema.field("payload")
+
+    assert field.type == pa.string()
+    assert field.nullable is True
+
+    rows = [
+        OptionalJsonUnionModel(payload=None),
+        OptionalJsonUnionModel(payload={"name": "ava", "items": [1, {"ok": True}]}),
+    ]
+
+    assert (
+        arrow_to_models(models_to_arrow(rows, OptionalJsonUnionModel), OptionalJsonUnionModel)
+        == rows
+    )
+
+
+def test_unsupported_fields_raise_with_field_path():
+    class BadAny(BaseModel):
+        x: Any
+
+    with pytest.raises(UnsupportedModelFieldError, match="x"):
+        model_to_arrow_schema(BadAny)
+
+    class BadUnion(BaseModel):
+        y: int | str
+
+    with pytest.raises(UnsupportedModelFieldError, match="y"):
+        model_to_arrow_schema(BadUnion)
+
+    class BadNested(BaseModel):
+        settings: dict[str, Any]
+
+    class BadOuter(BaseModel):
+        profile: BadNested
+
+    with pytest.raises(UnsupportedModelFieldError, match=r"profile\.settings"):
+        model_to_arrow_schema(BadOuter)
+
+
+def test_arrow_to_models_ignores_extra_columns():
+    rows = [OptionalModel(required=1, maybe=None)]
+    table = models_to_arrow(rows, OptionalModel)
+    table = table.append_column(
+        pa.field("_ava_run_id", pa.string()),
+        pa.array(["run-1"], type=pa.string()),
+    )
+
+    assert arrow_to_models(table, OptionalModel) == rows
+
+
+def test_arrow_to_models_accepts_polars_dataframe():
+    rows = [NestedContainer(nested=NestedModel(label="x", value=2))]
+    table = models_to_arrow(rows, NestedContainer)
+    frame = pl.from_arrow(table)
+
+    assert arrow_to_models(frame, NestedContainer) == rows
+
+
+class FileRef:
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, FileRef) and self.path == other.path
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: object,
+        handler: object,
+    ) -> core_schema.CoreSchema:
+        def validate(value: object) -> FileRef:
+            if isinstance(value, FileRef):
+                return value
+            if isinstance(value, str):
+                return FileRef(value)
+            raise ValueError("FileRef must be a string or FileRef")
+
+        return core_schema.no_info_plain_validator_function(
+            validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda ref: ref.path,
+                return_schema=core_schema.str_schema(),
+            ),
+        )
+
+
+def test_custom_scalar_serializing_type_maps_to_string_and_round_trips():
+    class FileModel(BaseModel):
+        ref: FileRef
+
+    rows = [FileModel(ref=FileRef("/tmp/input.txt"))]
+    schema = model_to_arrow_schema(FileModel)
+
+    assert schema.field("ref").type == pa.string()
+    assert arrow_to_models(models_to_arrow(rows, FileModel), FileModel) == rows
+
+
+def test_json_is_importable_from_top_level():
+    from avalanche import Json as TopLevelJson
+
+    assert TopLevelJson is Json

--- a/test/model_tables_test.py
+++ b/test/model_tables_test.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import dataframely as dy
+import polars as pl
+import pytest
+from pydantic import BaseModel
+
+from avalanche.iceberg import IcebergNs, IcebergNsConfig, IcebergTable
+from avalanche.lance import LanceNamespace, LanceNamespaceConfig, LanceTable
+from avalanche.lineage import ROW_LINEAGE_COLUMNS
+
+
+class Address(BaseModel):
+    city: str
+    zip_code: str | None = None
+
+
+class Person(BaseModel):
+    id: int
+    name: str
+    address: Address
+    tags: list[str]
+
+
+class OtherModel(BaseModel):
+    id: int
+
+
+class FrameSchema(dy.Schema):
+    id = dy.Int64(nullable=False)
+    name = dy.String(nullable=False)
+
+
+@dataclass(frozen=True)
+class BackendCase:
+    name: str
+    table_cls: type
+    namespace_cls: type
+    namespace_config_cls: type
+    namespace_kwargs: Callable[[str], dict[str, Any]]
+    requires: tuple[str, ...] = ()
+
+
+BACKENDS = [
+    BackendCase(
+        name="iceberg",
+        table_cls=IcebergTable,
+        namespace_cls=IcebergNs,
+        namespace_config_cls=IcebergNsConfig,
+        namespace_kwargs=lambda tmpdir: {
+            "catalog": "model-catalog",
+            "load_catalog_props": {"type": "sql", "uri": "sqlite:///:memory:"},
+        },
+    ),
+    BackendCase(
+        name="lance",
+        table_cls=LanceTable,
+        namespace_cls=LanceNamespace,
+        namespace_config_cls=LanceNamespaceConfig,
+        namespace_kwargs=lambda tmpdir: {},
+        requires=("lance",),
+    ),
+]
+
+
+def _skip_missing_backend(case: BackendCase) -> None:
+    for module_name in case.requires:
+        pytest.importorskip(module_name)
+
+
+@pytest.fixture(params=BACKENDS, ids=lambda case: case.name)
+def backend(request: pytest.FixtureRequest) -> BackendCase:
+    case = request.param
+    _skip_missing_backend(case)
+    return case
+
+
+@pytest.fixture
+def namespace(backend: BackendCase, tmp_path):
+    class ModelNamespace(backend.namespace_cls):
+        ns_config = backend.namespace_config_cls(
+            name=f"model-{backend.name}",
+            base_location=str(tmp_path),
+        )
+        people = backend.table_cls(schema=Person)
+        frame_rows = backend.table_cls(schema=FrameSchema)
+
+    ns = ModelNamespace(**backend.namespace_kwargs(str(tmp_path)))
+    ns.push()
+    return ns
+
+
+def _person(row_id: int, name: str, city: str, zip_code: str | None, tags: list[str]) -> Person:
+    return Person(
+        id=row_id,
+        name=name,
+        address=Address(city=city, zip_code=zip_code),
+        tags=tags,
+    )
+
+
+def _people() -> list[Person]:
+    return [
+        _person(1, "ada", "Toronto", "M5V", ["founder", "math"]),
+        _person(2, "grace", "Arlington", None, ["compiler"]),
+        _person(3, "katherine", "White Sulphur Springs", "24986", []),
+    ]
+
+
+def test_model_table_appends_single_and_list_then_reads_models(namespace):
+    people = _people()
+
+    namespace.people.append(people[0])
+    namespace.people.append(people[1:])
+
+    models = namespace.people.read_models()
+    assert all(isinstance(model, Person) for model in models)
+    assert sorted(models, key=lambda person: person.id) == sorted(
+        people, key=lambda person: person.id
+    )
+
+
+def test_nested_struct_and_list_survive_backend_round_trip(namespace):
+    person = _person(10, "dorothy", "Kansas City", None, ["navigation", "radar"])
+
+    namespace.people.append(person)
+
+    restored = namespace.people.read_models()
+    assert restored == [person]
+    assert restored[0].address == Address(city="Kansas City", zip_code=None)
+    assert restored[0].tags == ["navigation", "radar"]
+
+
+def test_model_table_stores_row_lineage_columns(namespace):
+    namespace.people.append(_people()[0])
+
+    column_names = namespace.people.scan().to_arrow().schema.names
+    for column in ROW_LINEAGE_COLUMNS:
+        assert column in column_names
+
+
+def test_model_append_result_exposes_typed_rows(namespace):
+    person = _people()[0]
+
+    result = namespace.people.append(person)
+
+    assert result.row_model is Person
+    assert result.to_models() == [person]
+    assert result.one() == person
+
+
+def test_wrong_model_instance_append_raises_type_error(namespace):
+    with pytest.raises(TypeError, match="Person"):
+        namespace.people.append(OtherModel(id=1))
+
+
+def test_empty_model_list_append_raises_value_error(namespace):
+    with pytest.raises(ValueError, match="zero rows"):
+        namespace.people.append([])
+
+
+def test_model_append_on_dataframely_table_raises_type_error(namespace):
+    with pytest.raises(TypeError, match="pydantic model schema"):
+        namespace.frame_rows.append(_people()[0])
+
+
+def test_read_models_on_dataframely_table_raises_type_error(namespace):
+    with pytest.raises(TypeError, match="pydantic model schema"):
+        namespace.frame_rows.read_models()
+
+
+def test_dataframely_table_still_accepts_polars_dataframe(namespace):
+    rows = pl.DataFrame({"id": [1, 2], "name": ["one", "two"]})
+
+    result = namespace.frame_rows.append(rows)
+    stored = namespace.frame_rows.read().select(["id", "name"])
+
+    assert result.to_polars().select(["id", "name"]).to_dicts() == rows.to_dicts()
+    assert stored.to_dicts() == rows.to_dicts()

--- a/test/stream_serialization_test.py
+++ b/test/stream_serialization_test.py
@@ -13,6 +13,7 @@ from typing import Any
 import dataframely as dy
 import polars as pl
 import pytest
+from pydantic import BaseModel
 
 import avalanche as ava
 from avalanche.iceberg import IcebergNs, IcebergNsConfig, IcebergTable
@@ -55,6 +56,55 @@ def test_iceberg_table_pickle_roundtrip_reconnects(file_backed_namespace):
     # The restored handle must support writes too (ProgressStore needs them)
     restored.append(pl.DataFrame({"id": [2], "value": ["b"]}))
     assert restored.read().sort("id")["id"].to_list() == [1, 2]
+
+
+class RecordModel(BaseModel):
+    id: int
+    value: str
+
+
+def test_iceberg_model_table_pickle_roundtrip_keeps_row_model(tmp_path):
+    class ModelPickleNamespace(IcebergNs):
+        ns_config = IcebergNsConfig(
+            name="pickle_model_ns",
+            base_location=str(tmp_path / "warehouse"),
+        )
+        rows = IcebergTable(schema=RecordModel)
+
+    ns = ModelPickleNamespace(
+        catalog="pickle-model-catalog",
+        load_catalog_props={"type": "sql", "uri": f"sqlite:///{tmp_path}/catalog.db"},
+    )
+    ns.push()
+
+    restored = pickle.loads(pickle.dumps(ns.rows))
+
+    assert restored.row_model is RecordModel
+    result = restored.append(RecordModel(id=1, value="a"))
+    assert result.one() == RecordModel(id=1, value="a")
+    assert restored.read_models() == [RecordModel(id=1, value="a")]
+
+
+def test_lance_model_table_pickle_roundtrip_keeps_row_model(tmp_path):
+    pytest.importorskip("lance")
+    from avalanche.lance import LanceNamespace, LanceNamespaceConfig, LanceTable
+
+    class ModelLanceNamespace(LanceNamespace):
+        ns_config = LanceNamespaceConfig(
+            name="pickle_model_lance",
+            base_location=str(tmp_path),
+        )
+        rows = LanceTable(schema=RecordModel)
+
+    ns = ModelLanceNamespace()
+    ns.push()
+
+    restored = pickle.loads(pickle.dumps(ns.rows))
+
+    assert restored.row_model is RecordModel
+    result = restored.append(RecordModel(id=1, value="a"))
+    assert result.one() == RecordModel(id=1, value="a")
+    assert restored.read_models() == [RecordModel(id=1, value="a")]
 
 
 def test_stream_marker_pickle_roundtrip(file_backed_namespace):

--- a/test/workflow_data_passing_test.py
+++ b/test/workflow_data_passing_test.py
@@ -114,6 +114,51 @@ class TestDataPassingBetweenTasks:
         assert b_result == [4, 5, 6]
         assert merged_result == [1, 2, 3, 4, 5, 6]
 
+    def test_keyword_only_future_wiring_skips_implicit_binding(self):
+        """Futures passed as kwargs must not be re-bound implicitly by position."""
+
+        @source
+        def load_a():
+            return [1, 2, 3]
+
+        @source
+        def load_b():
+            return [4, 5, 6]
+
+        @step
+        def merge(data_a, data_b):
+            return data_a + data_b
+
+        @workflow
+        def keyword_wired():
+            a = load_a()
+            b = load_b()
+            # Both upstream futures arrive as keyword arguments only.
+            return merge(data_a=a, data_b=b)
+
+        result = keyword_wired().run(executor=LocalExecutor())
+
+        assert result == [1, 2, 3, 4, 5, 6]
+
+    def test_partial_keyword_future_wiring_with_plain_kwarg(self):
+        """A future kwarg and a plain-value kwarg coexist without double-binding."""
+
+        @source
+        def load_a():
+            return [1, 2, 3]
+
+        @step
+        def merge(data_a, suffix):
+            return data_a + suffix
+
+        @workflow
+        def mixed_wired():
+            return merge(data_a=load_a(), suffix=[9])
+
+        result = mixed_wired().run(executor=LocalExecutor())
+
+        assert result == [1, 2, 3, 9]
+
     def test_tuple_unpacking_local(self):
         """Test unpacking tuple results from tasks."""
 


### PR DESCRIPTION
Implements the core (non-agent) portion of #6: pydantic models become a first-class schema source for tables, and `AppendResult` becomes generic with typed extraction. The `@ava.agent_step` layer (Modules 4–5 of the PRD) is intentionally **not** in this PR; it is parked on a separate branch pending a design pass.

## What's included

- **`avalanche.model_frame`** — pure pydantic↔Arrow converter: scalars map to native columns, nested models to struct columns, lists to list columns; `Field(description=...)` propagates to Arrow field metadata at every nesting level; unmappable annotations fail loudly with a per-field `ava.Json` JSON-string opt-out; custom scalar-serializing pydantic types round-trip generically with no special cases.
- **Pydantic-schema'd tables** — `IcebergTable(schema=Model)` / `LanceTable(schema=Model)` accepted anywhere DataFramely schemas are today; `append()` takes a model instance or a list; new `read_models()` returns validated models; `_ava_*` provenance behaves identically; DataFramely paths unchanged. Nested arrow→iceberg conversion goes through pyiceberg's own visitor; pickle reconnect recipes carry `row_model` across process boundaries (Ray).
- **Typed `AppendResult[ModelT]`** — new `row_model` field plus `to_models()`, `one()` (asserts exactly-one-row cardinality at the step boundary), and `one_or_none()`. Fully backward compatible.
- **`ava.input.<field>`** — build-time placeholder resolving against the validated run input at node execution, for any node type.
- **dag fix** — futures passed explicitly as keyword arguments are no longer re-bound implicitly by position (kwarg-only wiring previously collided).

No new dependencies: the core carries no predict-rlm or DSPy dependency.

## Testing

~75 new tests across the converter, both table backends (local Iceberg catalog + local Lance), typed `AppendResult`, `ava.input` resolution, and pickle/Ray round-trips of model-declared tables. Full matrix green locally: 524 (`not tmux and not ray`) + 20 (`ray`), ruff clean, `uv lock --check` clean.

## Field validation

The `first_pass_copy` belt in hyperbelt was migrated onto these features as the canonical before/after fixture: pydantic-first tables + typed `AppendResult` deleted the belt's entire adapter module and all JSON-blob plumbing, with each consume site collapsing to `result.one().<field>`.

## Docs

Pydantic-schema section in `docs/data-model-api.md`, CHANGELOG entry.
