### PR TITLE
feat(runtime): add execution services

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -320,6 +320,47 @@ The operator connects to Ray; the TUI does not.
 - `src/avalanche/runtime/`
 - `src/runtime/operator/hooks.py`
 
+## Execution services
+
+Execution services are an executor-owned worker lifecycle for platform-provided
+resources such as immutable input snapshots, task-local filesystems, output
+reservations, and commit receipts. They are separate from runtime providers such
+as `ava.Stream`: runtime providers inject task arguments from Avalanche-owned
+data systems, while execution services surround the entire user task.
+
+```text
+Workflow.run(execution_services=spec)
+  -> executor submits one service-managed task
+     -> probe -> negotiate -> open
+     -> materialize_input
+     -> user task
+     -> finalize -> receipt
+     -> teardown
+```
+
+The service request is immutable executor metadata. It must not carry credentials,
+user-facing storage URIs, absolute worker paths, open handles, actors, or affinity
+tokens. The provider acquires worker-local capabilities after scheduling. Input
+materialization may be eager or lazy; for example, a provider can return paths in
+an attempt-local filesystem whose bytes are fetched on first access.
+
+Local execution carries values directly. Ray execution returns user payloads, small
+service receipts, and status markers through separate object-reference channels. The
+driver observes statuses, while parent receipts remain worker-side dependencies of
+downstream service sessions. Fan-in follows the DAG without fetching intermediate
+payloads or receipts on the driver. `RunHandle` exposes only deterministically ordered
+terminal receipts.
+
+Any failure after `open` requests abort and then tears the session down exactly once.
+Cleanup errors are attached as notes instead of masking the primary failure. Providers
+may preserve explicit recovery state when destructive cleanup is unsafe. If an executor
+retries a task, the whole worker lifecycle starts again; Avalanche does not reuse an
+opened session. There is no fallback to ordinary execution when service negotiation or
+materialization fails.
+
+See [docs/execution-services.md](docs/execution-services.md) for the public
+protocol, provider contract, and workflow-author experience.
+
 ## Cross-component boundaries
 
 ### State provider boundary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Worker execution services
+
+- Added the versioned `ava.ExecutionServicesSpec` and worker-side
+  `probe -> negotiate -> open -> materialize_input -> finalize/abort -> teardown`
+  lifecycle for platform-managed task resources.
+- Local and Ray executors carry service receipts separately from user payloads;
+  terminal receipts are available through `RunHandle.execution_receipts()`.
+- Input materialization happens in the consuming worker and may be eager or lazy.
+  Failures do not silently fall back to ordinary execution.
+- See [docs/execution-services.md](docs/execution-services.md).
+
 ### Awaitable workflow run handles
 
 - Breaking: `Workflow.run(...)` now immediately returns a generic, awaitable

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Use the `ava` command for operator and TUI flows. The package does not expose an
 For the full getting-started guide, see [docs/getting-started.md](docs/getting-started.md).
 For API guides, see [docs/dag-api.md](docs/dag-api.md),
 [docs/data-model-api.md](docs/data-model-api.md), and
-[docs/agent-steps.md](docs/agent-steps.md).
+[docs/agent-steps.md](docs/agent-steps.md). Platform integrations that materialize
+worker inputs or publish task-scoped outputs should start with
+[docs/execution-services.md](docs/execution-services.md).
 For implementation boundaries, see [ARCHITECTURE.md](ARCHITECTURE.md).
 For release notes, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/dag-api.md
+++ b/docs/dag-api.md
@@ -290,6 +290,12 @@ wins before cancellation is observed, that outcome remains authoritative. A
 registry and cannot recover state after process exit. Operator-managed runs own
 durable-facing status and control separately.
 
+Advanced platforms can pass an `ava.ExecutionServicesSpec` to materialize typed
+inputs and task-scoped resources inside the actual Local or Ray worker. Workflow
+task code still receives its declared `BaseInput`; platform lifecycle metadata
+travels separately from workflow outputs. See
+[Execution services](execution-services.md) for provider and workflow-author DX.
+
 ### Reruns
 
 Use `ava.Rerun` when you want to re-execute a previous workflow run from one or

--- a/docs/execution-services.md
+++ b/docs/execution-services.md
@@ -1,0 +1,223 @@
+# Execution services
+
+Execution services let a platform materialize worker-visible inputs, open task-scoped
+resources, and publish a small commit receipt around each Avalanche node invocation.
+They keep storage credentials, durable snapshot identity, and platform lifecycle state
+out of workflow code.
+
+This is an advanced platform integration API. Most workflow authors only declare typed
+input and use the paths or capabilities delivered by their platform.
+
+## User experience
+
+Workflow code stays ordinary Avalanche code:
+
+```python
+import avalanche as ava
+
+
+class DocumentInput(ava.BaseInput):
+    source_path: str
+
+
+@ava.source
+def read_document(payload: DocumentInput) -> str:
+    with open(payload.source_path, encoding="utf-8") as source:
+        return source.read()
+
+
+@ava.workflow(input=DocumentInput)
+def document_flow():
+    return read_document()
+```
+
+A platform starts the same workflow with an execution-services request:
+
+```python
+handle = document_flow().run(
+    executor=ava.RayExecutor(),
+    input={"source_path": {"artifact_id": "artifact_123"}},
+    execution_services=ava.ExecutionServicesSpec(
+        service=platform_services,
+        request=platform_request,
+    ),
+)
+
+result = handle.result()
+receipts = handle.execution_receipts()
+```
+
+The raw `input` may contain immutable platform descriptors that are not valid
+`DocumentInput` values on the driver. The service materializes those descriptors in the
+actual worker and returns a valid `DocumentInput` or mapping before the task runs.
+
+An `ava.input.<field>` selector resolves against that same worker-materialized input:
+
+```python
+@ava.source
+def read_path(source_path: str) -> str:
+    with open(source_path, encoding="utf-8") as source:
+        return source.read()
+
+
+@ava.workflow(input=DocumentInput)
+def selected_document_flow():
+    return read_path(ava.input.source_path)
+```
+
+Without `execution_services=`, input validation and execution retain their ordinary
+behavior. `handle.execution_receipts()` returns an empty tuple.
+
+## Materialization semantics
+
+`materialize_input` means “make the declared task input available through the worker.”
+It does not require an eager byte copy.
+
+A provider may:
+
+- eagerly download immutable objects into an attempt directory;
+- return paths in an attempt-local lazy filesystem that fetches bytes on first access;
+- bind task-local output reservations or other capabilities while constructing input;
+- validate the returned value directly as the workflow's `BaseInput` type.
+
+The returned value must expose every path and value required by the task. A lazy
+filesystem may defer backing-byte fetches until those paths are opened.
+
+## Architecture
+
+Execution services surround the actual user task:
+
+```text
+Driver
+  |
+  | Workflow.run(execution_services=spec)
+  v
+LocalExecutor or RayExecutor
+  |
+  | submit service request + task identity + parent receipts
+  v
+Actual worker
+  probe
+    -> negotiate
+    -> open
+    -> materialize_input
+    -> resolve ava.input selectors and typed input injection
+    -> run user task
+    -> normalize declared return values
+    -> finalize
+    -> teardown
+```
+
+The lifecycle is provider-neutral. Avalanche owns when methods run and how their values
+move through the DAG. The provider owns resource allocation, materialization,
+publication, and cleanup.
+
+### Public types
+
+`ava.ExecutionServices` is the provider protocol. It defines:
+
+```python
+class ExecutionServices(Protocol):
+    def probe(self, *, request, task): ...
+    def negotiate(self, *, request, task, probe): ...
+    def open(self, *, request, task, negotiation, upstream_receipts): ...
+    def materialize_input(self, *, session, input_type, input): ...
+    def finalize(self, *, session): ...
+    def abort(self, *, session, error): ...
+    def teardown(self, *, session): ...
+```
+
+Provider lifecycle methods are synchronous. `ExecutionServicesSpec` rejects declared
+async methods, and runtime invocation rejects a synchronous wrapper that returns an
+awaitable. Workflow task functions may still be synchronous or asynchronous.
+
+`ava.ExecutionServicesSpec` combines a serializable provider with an immutable request.
+Its version is currently `avalanche.execution-services/v1`.
+
+`ava.ExecutionTaskSpec` identifies the consuming task with:
+
+- run ID;
+- workflow name;
+- node ID and function name;
+- stable node slug;
+- executor type (`local` or `ray`).
+
+`ava.ExecutionServiceReceipt` exposes one deterministic terminal receipt through the
+run handle. It contains the terminal node ID, node slug, and provider-returned value.
+
+### Request and session ownership
+
+The request crosses the executor boundary. It must be immutable and serializable, and
+must not contain:
+
+- credentials or secret values;
+- user-facing storage URIs;
+- absolute worker-local paths;
+- open files, sockets, or other process-local handles;
+- actors, placement handles, or scheduler-affinity tokens.
+
+The provider acquires credentials and process-local capabilities after the executor has
+placed the task. `open` returns the task-scoped session used by the remaining lifecycle
+methods. Sessions never cross from one task attempt to another.
+
+### Local and Ray execution
+
+`LocalExecutor` invokes the lifecycle synchronously and carries values directly.
+
+`RayExecutor` runs the complete lifecycle inside one Ray task. The task returns three
+separate channels: user payloads, one small receipt, and one status marker. The driver
+fetches status markers to observe progress and failure. Receipt references remain in the
+DAG as worker-side dependencies and are fetched only for terminal publication, so
+intermediate receipts and user payloads are not materialized on the driver.
+
+For a fan-in node, `open(..., upstream_receipts=...)` receives parent receipts in DAG
+dependency order. Only terminal-node receipts are fetched and exposed through
+`RunHandle.execution_receipts()`.
+
+## Failure and cleanup contract
+
+The lifecycle is strict:
+
+- `probe`, `negotiate`, or `open` failure stops execution; there is no fallback;
+- after `open` succeeds, any materialization, user-task, return-normalization, or
+  finalization failure calls `abort`;
+- `teardown` runs exactly once after every opened session;
+- successful finalization is not followed by `abort`;
+- a finalization failure requests `abort`; providers may preserve explicit recovery state
+  when another destructive cleanup attempt would be unsafe;
+- abort or teardown failures are attached as exception notes and never mask the primary
+  materialization, task, normalization, or finalization error;
+- teardown failure after an otherwise successful lifecycle fails the task;
+- failure or cancellation propagates to both `result()` and `execution_receipts()`.
+
+If an executor retries a task, the entire lifecycle starts again with a new session.
+Avalanche does not reuse a partially opened or finalized session. Providers should make
+requests idempotent and use attempt-specific ownership or winner fencing where multiple
+attempts can race.
+
+Cancellation is cooperative between node submissions. An already running Local or Ray
+task may finish its lifecycle. Completed receipts remain valid, while unscheduled
+downstream tasks do not open sessions.
+
+## Provider implementation checklist
+
+Before enabling a provider, verify that it:
+
+1. serializes its service and request without credentials or local handles;
+2. negotiates an explicit supported mode and fails closed otherwise;
+3. acquires worker-local capabilities only after scheduling;
+4. returns the declared `BaseInput` type or a mapping Pydantic can validate;
+5. supports `ava.input` selectors, scalar/list/optional/empty values, and fan-in;
+6. keeps user payloads, receipts, and status markers on separate channels;
+7. aborts partial publication or preserves explicit recovery state, then tears down every
+   opened session exactly once;
+8. restarts cleanly under retries and preserves winner fencing;
+9. behaves equivalently under Local and Ray execution;
+10. documents whether its materialization is eager or lazy.
+
+## Current boundary
+
+Execution services do not define a storage model, credential system, retry budget,
+retention policy, or shared filesystem. Those remain platform responsibilities.
+Avalanche provides the worker lifecycle and DAG control channel needed to implement them
+without exposing platform state to workflow code.

--- a/src/avalanche/__init__.py
+++ b/src/avalanche/__init__.py
@@ -7,6 +7,13 @@ with local and distributed execution.
 
 # DAG primitives
 from .dag import Pipeline, Workflow, dest, pipeline, source, step, transform, workflow
+from .execution_services import (
+    EXECUTION_SERVICES_V1,
+    ExecutionServiceReceipt,
+    ExecutionServices,
+    ExecutionServicesSpec,
+    ExecutionTaskSpec,
+)
 
 # Execution engines
 from .executor import Executor, LocalExecutor, RayExecutor, get_default_executor
@@ -96,6 +103,11 @@ __all__ = [
     "LocalExecutor",
     "RayExecutor",
     "get_default_executor",
+    "EXECUTION_SERVICES_V1",
+    "ExecutionServiceReceipt",
+    "ExecutionServices",
+    "ExecutionServicesSpec",
+    "ExecutionTaskSpec",
     # Runtime
     "BaseContext",
     "BaseInput",

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -63,6 +63,7 @@ from .input_ref import InputRef
 from .run_handle import RunHandle
 
 if TYPE_CHECKING:
+    from .execution_services import ExecutionServicesSpec
     from .executor import Executor
     from .operator.hooks import RunHooks
 
@@ -672,13 +673,11 @@ def _stamp_deferred_stream_upstream(value: Any, *, parent_kwarg: str) -> Any:
         return replace(value, parent_kwarg=parent_kwarg, ref=None)
     if isinstance(value, tuple):
         return tuple(
-            _stamp_deferred_stream_upstream(item, parent_kwarg=parent_kwarg)
-            for item in value
+            _stamp_deferred_stream_upstream(item, parent_kwarg=parent_kwarg) for item in value
         )
     if isinstance(value, list):
         return [
-            _stamp_deferred_stream_upstream(item, parent_kwarg=parent_kwarg)
-            for item in value
+            _stamp_deferred_stream_upstream(item, parent_kwarg=parent_kwarg) for item in value
         ]
     if isinstance(value, dict):
         return {
@@ -866,9 +865,7 @@ def _runtime_param_names_from_signature(fn: Callable) -> set[str]:
         annotation = type_hints.get(param_name, param.annotation)
         if annotation is inspect.Parameter.empty:
             continue
-        if _safe_issubclass(annotation, BaseContext) or _safe_issubclass(
-            annotation, BaseInput
-        ):
+        if _safe_issubclass(annotation, BaseContext) or _safe_issubclass(annotation, BaseInput):
             names.add(param_name)
     return names
 
@@ -1214,12 +1211,8 @@ def _validate_no_skipped_non_stream_inputs(
         for selector in binding_plan.provider_selectors.values():
             producer = nodes[selector.future_id]
             if (
-                (
-                    selector.tuple_index is not None
-                    or producer.node.num_returns > 1
-                )
-                and selector.future_id not in scheduled_node_ids
-            ):
+                selector.tuple_index is not None or producer.node.num_returns > 1
+            ) and selector.future_id not in scheduled_node_ids:
                 raise ValueError(
                     f"Rerun node {node_id!r} has an indexed or multi-return "
                     "ava.Stream selector "
@@ -1263,8 +1256,7 @@ def _validate_no_skipped_non_stream_inputs(
                 if (
                     parent_id not in scheduled_node_ids
                     and binding.may_expand_single_return
-                    and "python"
-                    in binding_plan.implicit_slot_kinds[binding.slot_index + 1 :]
+                    and "python" in binding_plan.implicit_slot_kinds[binding.slot_index + 1 :]
                 ):
                     raise ValueError(
                         f"Rerun node {node_id!r} has an ambiguous single-return "
@@ -1540,8 +1532,7 @@ def _reattach_lineage(value: Any, lineage_source: Any) -> Any:
         and len(value) == len(lineage_source)
     ):
         return tuple(
-            _reattach_lineage(item, source)
-            for item, source in zip(value, lineage_source)
+            _reattach_lineage(item, source) for item, source in zip(value, lineage_source)
         )
 
     if (
@@ -1549,10 +1540,7 @@ def _reattach_lineage(value: Any, lineage_source: Any) -> Any:
         and isinstance(lineage_source, list)
         and len(value) == len(lineage_source)
     ):
-        return [
-            _reattach_lineage(item, source)
-            for item, source in zip(value, lineage_source)
-        ]
+        return [_reattach_lineage(item, source) for item, source in zip(value, lineage_source)]
 
     lineage = _lineage_from_tree(lineage_source)
     return LineagedResult(value, lineage) if lineage else value
@@ -1650,7 +1638,8 @@ def _with_current_run_context(
     back into ``AppendResult`` here (worker-side) so user code and Stream
     wrappers never see the internal transport type.
     """
-    from .runtime import RunContext, run_with_context
+    from .runtime import RunContext
+    from .runtime.context import _run_with_context
 
     if not isinstance(context, RunContext):
         # Still unwrap parent envelopes so non-context nodes never receive an
@@ -1681,7 +1670,7 @@ def _with_current_run_context(
 
         unwrapped_args = _unwrap_lineaged_tree(args)
         unwrapped_kwargs = _unwrap_lineaged_tree(kwargs)
-        result = run_with_context(context, fn, *unwrapped_args, **unwrapped_kwargs)
+        result = _run_with_context(context, fn, *unwrapped_args, **unwrapped_kwargs)
         return _wrap_lineaged_result(result, context, num_returns=num_returns)
 
     return wrapped
@@ -1694,6 +1683,8 @@ def _inspect_runtime_params(
     run_input: Any,
     run_context: Any,
     system_context: Any,
+    *,
+    defer_input: bool = False,
 ) -> dict[str, Any]:
     import inspect
 
@@ -1738,10 +1729,15 @@ def _inspect_runtime_params(
             elif system_context is not None and isinstance(system_context, annotation):
                 injected[param_name] = system_context
         elif _safe_issubclass(annotation, BaseInput):
-            if run_input is not None and isinstance(run_input, annotation):
+            if defer_input:
+                injected[param_name] = _DEFERRED_EXECUTION_SERVICE_INPUT
+            elif run_input is not None and isinstance(run_input, annotation):
                 injected[param_name] = run_input
 
     return injected
+
+
+_DEFERRED_EXECUTION_SERVICE_INPUT = object()
 
 
 def _data_param_position(
@@ -1802,10 +1798,7 @@ def _fetch_node_result(
 
     # Regular NodeFuture handling
     if fetch_target.future_id not in result_refs:
-        if (
-            scheduled_node_ids is not None
-            and fetch_target.future_id not in scheduled_node_ids
-        ):
+        if scheduled_node_ids is not None and fetch_target.future_id not in scheduled_node_ids:
             return None
         raise ValueError(
             f"Workflow return node {fetch_target.future_id!r} was not scheduled by rerun"
@@ -1877,18 +1870,13 @@ def _implicit_items_from_parent_result(presult: Any) -> list[Any]:
     from .types import LineagedResult
 
     if isinstance(presult, LineagedResult) and isinstance(presult.value, (tuple, list)):
-        return [
-            LineagedResult(item, dict(presult.lineage_vector))
-            for item in presult.value
-        ]
+        return [LineagedResult(item, dict(presult.lineage_vector)) for item in presult.value]
     if isinstance(presult, (tuple, list)):
         return list(presult)
     return [presult]
 
 
-def _indexed_parent_result(
-    presult: Any, tuple_index: int, executor: Any = None
-) -> Any:
+def _indexed_parent_result(presult: Any, tuple_index: int, executor: Any = None) -> Any:
     """Index into a parent result without materializing payloads on the driver.
 
     Preserves any ``LineagedResult`` envelope on the selected element so
@@ -1953,9 +1941,7 @@ def _collect_implicit_parent_results(
             if presult is not None:
                 if incoming.tuple_index is not None:
                     auto_values.append(
-                        _indexed_parent_result(
-                            presult, incoming.tuple_index, executor
-                        )
+                        _indexed_parent_result(presult, incoming.tuple_index, executor)
                     )
                 else:
                     auto_values.extend(_implicit_items_from_parent_result(presult))
@@ -2046,8 +2032,7 @@ def _bind_implicit_parent_results(
 
         if param.kind == inspect.Parameter.VAR_POSITIONAL:
             resolved_args.extend(
-                _implicit_value_from_upstream(item)
-                for item in upstream_values[upstream_index:]
+                _implicit_value_from_upstream(item) for item in upstream_values[upstream_index:]
             )
             upstream_index = len(upstream_values)
             continue
@@ -2157,8 +2142,7 @@ class Workflow:
         if missing:
             known = ", ".join(sorted(slug_to_node_id))
             raise ValueError(
-                f"Unknown rerun start slug(s): {', '.join(missing)}. "
-                f"Known slugs: {known}"
+                f"Unknown rerun start slug(s): {', '.join(missing)}. " f"Known slugs: {known}"
             )
 
         start_node_ids = {slug_to_node_id[slug] for slug in rerun.start}
@@ -2190,6 +2174,7 @@ class Workflow:
         context: Any = None,
         run_id: str | None = None,
         rerun: Any = None,
+        execution_services: "ExecutionServicesSpec | None" = None,
     ) -> RunHandle[Any]:
         """
         Start the workflow and return its process-local lifecycle handle.
@@ -2201,6 +2186,7 @@ class Workflow:
             context: Optional run context payload or BaseContext instance
             run_id: Optional caller-owned run identity
             rerun: Optional Rerun spec for re-executing part of a previous run
+            execution_services: Optional versioned worker lifecycle service request
 
         The handle is returned immediately. Call ``handle.result()`` to block in
         synchronous code or ``await handle`` from asynchronous code.
@@ -2228,6 +2214,8 @@ class Workflow:
                 context=context,
                 run_id=canonical_run_id,
                 rerun=rerun,
+                execution_services=execution_services,
+                receipt_sink=handle._set_execution_receipts,
             )
         )
         return handle
@@ -2241,6 +2229,8 @@ class Workflow:
         context: Any = None,
         run_id: str | None = None,
         rerun: Any = None,
+        execution_services: "ExecutionServicesSpec | None" = None,
+        receipt_sink: Callable[[tuple[Any, ...]], None] | None = None,
     ) -> Any:
         """Execute the blocking workflow driver in the run-handle thread.
 
@@ -2267,7 +2257,20 @@ class Workflow:
         if run_id is None:
             raise ValueError("workflow driver requires a run_id")
         executor_type = "ray" if type(executor).__name__ == "RayExecutor" else "local"
-        run_input = _build_input_value(self.input_type, input)
+        if execution_services is not None:
+            from .execution_services import ExecutionServicesSpec
+
+            if not isinstance(execution_services, ExecutionServicesSpec):
+                raise TypeError("execution_services must be an ExecutionServicesSpec")
+            if not hasattr(executor, "submit_with_services"):
+                raise TypeError(
+                    f"{type(executor).__name__} does not support execution services"
+                )
+        run_input = (
+            None
+            if execution_services is not None
+            else _build_input_value(self.input_type, input)
+        )
         system_context, run_context = _build_context_values(
             self.context_type,
             context,
@@ -2281,6 +2284,9 @@ class Workflow:
         # Ray-only: small per-node status refs from submit_with_status. Fetching
         # a status ref surfaces a task failure without materializing the payload.
         status_refs: dict[str, Any] = {}
+        # Service receipts are a separate control channel. They are never
+        # stored in result_refs or exposed to workflow arguments/context.
+        receipt_refs: dict[str, Any] = {}
 
         # Build reverse dependency map (child -> parents) for execution.
         # Keep the original map so rerun stream providers can still identify
@@ -2307,11 +2313,7 @@ class Workflow:
                 or self.returns is None
                 or (
                     hooks
-                    and (
-                        hooks.on_node_success
-                        or hooks.on_node_failure
-                        or hooks.unwrap_result
-                    )
+                    and (hooks.on_node_success or hooks.on_node_failure or hooks.unwrap_result)
                 )
             )
         )
@@ -2356,7 +2358,18 @@ class Workflow:
                 run_input,
                 node_run_context,
                 node_system_context,
+                defer_input=execution_services is not None,
             )
+            input_param_names = tuple(
+                name
+                for name, value in runtime_params.items()
+                if value is _DEFERRED_EXECUTION_SERVICE_INPUT
+            )
+            runtime_params = {
+                name: value
+                for name, value in runtime_params.items()
+                if value is not _DEFERRED_EXECUTION_SERVICE_INPUT
+            }
             inspected_params = _inspect_providers(node_ref.node.fn, binding_kwargs, PROVIDERS)
             provider_by_param = {}
             position_consuming_params = set()
@@ -2367,8 +2380,10 @@ class Workflow:
                         if getattr(provider, "consumes_upstream", False):
                             position_consuming_params.add(param_name)
                         break
-            skip_param_names = set(runtime_params) | (
-                set(inspected_params) - position_consuming_params
+            skip_param_names = (
+                set(runtime_params)
+                | set(input_param_names)
+                | (set(inspected_params) - position_consuming_params)
             )
 
             injectable_params = {}
@@ -2439,13 +2454,14 @@ class Workflow:
                 # Exclude injectable params from normal resolution
                 if k not in injectable_params and k not in runtime_params
             }
-            resolved_args, resolved_kwargs = _resolve_input_refs(
-                resolved_args,
-                resolved_kwargs,
-                run_input,
-                node_ref.node.fn.__name__,
-                self.name,
-            )
+            if execution_services is None:
+                resolved_args, resolved_kwargs = _resolve_input_refs(
+                    resolved_args,
+                    resolved_kwargs,
+                    run_input,
+                    node_ref.node.fn.__name__,
+                    self.name,
+                )
 
             # Get original function, optionally wrapped by hooks
             actual_fn = node_ref.node.fn
@@ -2556,7 +2572,39 @@ class Workflow:
             )
 
             try:
-                if needs_status and hasattr(executor, "submit_with_status"):
+                if execution_services is not None:
+                    from .execution_services import ExecutionTaskSpec
+
+                    parent_receipts = tuple(
+                        receipt_refs[parent_id]
+                        for parent_id in dependencies_map.get(node_id, [])
+                        if parent_id in receipt_refs
+                    )
+                    result, receipt_ref, status_ref = executor.submit_with_services(
+                        actual_fn,
+                        execution_services,
+                        ExecutionTaskSpec(
+                            run_id=run_id,
+                            workflow_name=self.name,
+                            node_id=node_id,
+                            node_name=node_ref.node.fn.__name__,
+                            node_slug=node_ref.node_slug,
+                            executor_type=executor_type,
+                        ),
+                        self.input_type,
+                        input,
+                        input_param_names,
+                        parent_receipts,
+                        node_ref.node.num_returns,
+                        *resolved_args,
+                        **resolved_kwargs,
+                    )
+                    receipt_refs[node_id] = receipt_ref
+                    if is_ray_executor and status_ref is not None:
+                        # Status is a same-task completion/failure marker. Keep
+                        # receipts worker-side until terminal publication.
+                        status_refs[node_id] = status_ref
+                elif needs_status and hasattr(executor, "submit_with_status"):
                     # Ray: get a small status ref alongside the payload so
                     # completion/failure can be observed without materializing
                     # the payload. The status ref is produced by the same task.
@@ -2580,6 +2628,35 @@ class Workflow:
                 raise
 
             return node_ref, result
+
+        def publish_terminal_receipts() -> None:
+            if receipt_sink is None:
+                return
+            if execution_services is None:
+                receipt_sink(())
+                return
+
+            from .execution_services import ExecutionServiceReceipt
+
+            terminal_node_ids = [
+                node_id
+                for node_id in execution_order
+                if not any(
+                    child_id in scheduled_node_ids for child_id in self.graph.get(node_id, [])
+                )
+            ]
+            refs = [receipt_refs[node_id] for node_id in terminal_node_ids]
+            values = executor.get(refs) if refs else []
+            receipt_sink(
+                tuple(
+                    ExecutionServiceReceipt(
+                        node_id=node_id,
+                        node_slug=self.node_slugs[node_id],
+                        value=value,
+                    )
+                    for node_id, value in zip(terminal_node_ids, values)
+                )
+            )
 
         def resolve_submitted_result(node_ref: NodeFuture, result: Any) -> Any:
             if node_ref.node.num_returns > 1 and isinstance(result, tuple):
@@ -2628,9 +2705,7 @@ class Workflow:
                         resolved_val = resolve_submitted_result(node_ref, result)
                         user_val = _unwrap_lineaged_tree(resolved_val)
                         replacement = hooks.unwrap_result(node_id, user_val)
-                        result_refs[node_id] = _reattach_lineage(
-                            replacement, resolved_val
-                        )
+                        result_refs[node_id] = _reattach_lineage(replacement, resolved_val)
                     elif node_id in status_refs:
                         # Progress-only: fetch just the tiny status ref to
                         # surface a task failure. Never materialize the payload;
@@ -2772,25 +2847,21 @@ class Workflow:
         if self.returns is None:
             already_observed = bool(
                 hooks
-                and (
-                    hooks.on_node_success
-                    or hooks.on_node_failure
-                    or hooks.unwrap_result
-                )
+                and (hooks.on_node_success or hooks.on_node_failure or hooks.unwrap_result)
             )
             if already_observed:
                 # Per-node completion/failure was already observed above (hooks).
+                publish_terminal_receipts()
                 return None
             if is_ray_executor and status_refs:
                 # Fetch only the tiny status refs: this surfaces any task
                 # failure without materializing node payloads on the driver.
                 pending_status = [
-                    status_refs[fid]
-                    for fid in execution_order
-                    if fid in status_refs
+                    status_refs[fid] for fid in execution_order if fid in status_refs
                 ]
                 if pending_status:
                     executor.get(pending_status)
+                publish_terminal_receipts()
                 return None
             # Local / non-status fallback: values are already materialized for
             # LocalExecutor; resolving them just surfaces awaitables/exceptions.
@@ -2805,10 +2876,12 @@ class Workflow:
                     all_refs.append(ref)
             if all_refs:
                 executor.get(all_refs)  # Wait for completion
+            publish_terminal_receipts()
             return None
 
         # Fetch only what the workflow explicitly returns
         # Handle different return types
+        publish_terminal_receipts()
         if isinstance(self.returns, NodeFuture):
             # Single NodeFuture returned
             return _fetch_node_result(

--- a/src/avalanche/execution_services.py
+++ b/src/avalanche/execution_services.py
@@ -1,0 +1,275 @@
+"""Provider-neutral worker lifecycle services for workflow execution."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from .input_ref import InputRef
+
+EXECUTION_SERVICES_V1 = "avalanche.execution-services/v1"
+_SERVICE_METHOD_NAMES = (
+    "probe",
+    "negotiate",
+    "open",
+    "materialize_input",
+    "finalize",
+    "abort",
+    "teardown",
+)
+
+
+@dataclass(frozen=True)
+class ExecutionTaskSpec:
+    """Immutable identity for one workflow task submitted to an executor."""
+
+    run_id: str
+    workflow_name: str
+    node_id: str
+    node_name: str
+    node_slug: str
+    executor_type: str
+
+
+@runtime_checkable
+class ExecutionServices(Protocol):
+    """Worker-side lifecycle implemented by an execution-services provider.
+
+    Implementations must be serializable and must acquire credentials and other
+    worker-local capabilities inside these methods. ``request`` is an opaque,
+    immutable provider descriptor owned by the executor; it must not contain
+    credentials, user-facing storage URIs, absolute local paths, open handles,
+    actors, or scheduler-affinity tokens.
+    """
+
+    def probe(self, *, request: Any, task: ExecutionTaskSpec) -> Any:
+        """Inspect worker capabilities without allocating task resources."""
+        ...
+
+    def negotiate(self, *, request: Any, task: ExecutionTaskSpec, probe: Any) -> Any:
+        """Select a supported service mode before resources are opened."""
+        ...
+
+    def open(
+        self,
+        *,
+        request: Any,
+        task: ExecutionTaskSpec,
+        negotiation: Any,
+        upstream_receipts: tuple[Any, ...],
+    ) -> Any:
+        """Open the task-scoped service session after negotiation succeeds."""
+        ...
+
+    def materialize_input(
+        self,
+        *,
+        session: Any,
+        input_type: type | None,
+        input: Any,
+    ) -> Any:
+        """Materialize the worker-visible run input for the consuming task.
+
+        Materialization may be eager or lazy. The returned input must expose
+        every value and path required by the task, while backing bytes may be
+        fetched on first access by a provider-owned filesystem.
+        """
+        ...
+
+    def finalize(self, *, session: Any) -> Any:
+        """Commit the successful task session and return a small receipt."""
+        ...
+
+    def abort(self, *, session: Any, error: BaseException) -> None:
+        """Abort an opened session after task or finalization failure."""
+        ...
+
+    def teardown(self, *, session: Any) -> None:
+        """Release an opened session exactly once."""
+        ...
+
+
+@dataclass(frozen=True)
+class ExecutionServicesSpec:
+    """Versioned executor-owned service request for a workflow run."""
+
+    service: ExecutionServices
+    request: Any
+    version: str = EXECUTION_SERVICES_V1
+
+    def __post_init__(self) -> None:
+        if self.version != EXECUTION_SERVICES_V1:
+            raise ValueError(
+                f"Unsupported execution services version {self.version!r}; "
+                f"expected {EXECUTION_SERVICES_V1!r}"
+            )
+        if not isinstance(self.service, ExecutionServices):
+            raise TypeError("service must implement the ExecutionServices protocol")
+        async_methods = [
+            name
+            for name in _SERVICE_METHOD_NAMES
+            if inspect.iscoroutinefunction(getattr(self.service, name))
+        ]
+        if async_methods:
+            raise TypeError(
+                "ExecutionServices lifecycle methods must be synchronous; "
+                f"async methods: {', '.join(async_methods)}"
+            )
+
+
+@dataclass(frozen=True)
+class ExecutionServiceReceipt:
+    """A terminal task receipt made available through ``RunHandle``."""
+
+    node_id: str
+    node_slug: str
+    value: Any
+
+
+def _resolve_input_ref(value: Any, run_input: Any, task: ExecutionTaskSpec) -> Any:
+    if not isinstance(value, InputRef):
+        return value
+    if run_input is None:
+        raise ValueError(
+            f"Node {task.node_name!r} references {value!r} in workflow "
+            f"{task.workflow_name!r}, but the execution service returned no run input"
+        )
+
+    current = run_input
+    for attr in value.path:
+        try:
+            current = getattr(current, attr)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"Node {task.node_name!r} references {value!r} in workflow "
+                f"{task.workflow_name!r}, but attribute {attr!r} is missing on "
+                f"{type(current).__name__}."
+            ) from exc
+    return current
+
+
+def _coerce_materialized_input(input_type: type | None, value: Any) -> Any:
+    if input_type is None or isinstance(value, input_type):
+        return value
+    from .runtime import BaseInput
+
+    if not isinstance(input_type, type) or not issubclass(input_type, BaseInput):
+        raise TypeError("workflow input type must inherit from ava.BaseInput")
+    return input_type.model_validate(value)
+
+
+def _call_service_method(method: Callable[..., Any], /, **kwargs: Any) -> Any:
+    """Call one synchronous provider method and reject hidden awaitables."""
+    value = method(**kwargs)
+    if not inspect.isawaitable(value):
+        return value
+    if inspect.iscoroutine(value):
+        value.close()
+    else:
+        cancel = getattr(value, "cancel", None)
+        if callable(cancel):
+            cancel()
+    raise TypeError(
+        "ExecutionServices lifecycle methods must be synchronous; "
+        f"{getattr(method, '__name__', type(method).__name__)} returned an awaitable"
+    )
+
+
+def _add_cleanup_note(error: BaseException, phase: str, cleanup_error: BaseException) -> None:
+    error.add_note(
+        f"Execution services {phase} failed while preserving the primary error: "
+        f"{cleanup_error!r}"
+    )
+
+
+def _run_with_execution_services(
+    fn: Any,
+    spec: ExecutionServicesSpec,
+    task: ExecutionTaskSpec,
+    input_type: type | None,
+    raw_input: Any,
+    input_param_names: tuple[str, ...],
+    upstream_receipts: tuple[Any, ...],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    num_returns: int,
+    normalize_result: Callable[[Any], Any] | None = None,
+) -> tuple[Any, Any]:
+    """Run the service lifecycle around one actual user task invocation."""
+    from runtime._async import call_sync_or_async
+
+    service = spec.service
+    probe = _call_service_method(service.probe, request=spec.request, task=task)
+    negotiation = _call_service_method(
+        service.negotiate,
+        request=spec.request,
+        task=task,
+        probe=probe,
+    )
+    session = _call_service_method(
+        service.open,
+        request=spec.request,
+        task=task,
+        negotiation=negotiation,
+        upstream_receipts=upstream_receipts,
+    )
+
+    finalized = False
+    primary_error: BaseException | None = None
+    try:
+        materialized_input = _call_service_method(
+            service.materialize_input,
+            session=session,
+            input_type=input_type,
+            input=raw_input,
+        )
+        materialized_input = _coerce_materialized_input(input_type, materialized_input)
+        resolved_args = tuple(
+            _resolve_input_ref(value, materialized_input, task) for value in args
+        )
+        resolved_kwargs = {
+            name: _resolve_input_ref(value, materialized_input, task)
+            for name, value in kwargs.items()
+        }
+        for name in input_param_names:
+            resolved_kwargs[name] = materialized_input
+
+        result = call_sync_or_async(fn, *resolved_args, **resolved_kwargs)
+        if normalize_result is not None:
+            result = normalize_result(result)
+        if num_returns > 1 and (
+            not isinstance(result, (tuple, list)) or len(result) != num_returns
+        ):
+            raise ValueError(
+                f"Function {fn.__name__} expected to return {num_returns} values, "
+                f"but returned: {result}"
+            )
+        receipt = _call_service_method(service.finalize, session=session)
+        finalized = True
+        return result, receipt
+    except BaseException as error:
+        primary_error = error
+        if not finalized:
+            try:
+                _call_service_method(service.abort, session=session, error=error)
+            except BaseException as abort_error:
+                _add_cleanup_note(error, "abort", abort_error)
+        raise
+    finally:
+        try:
+            _call_service_method(service.teardown, session=session)
+        except BaseException as teardown_error:
+            if primary_error is None:
+                raise
+            _add_cleanup_note(primary_error, "teardown", teardown_error)
+
+
+__all__ = [
+    "EXECUTION_SERVICES_V1",
+    "ExecutionServiceReceipt",
+    "ExecutionServices",
+    "ExecutionServicesSpec",
+    "ExecutionTaskSpec",
+]

--- a/src/avalanche/input_ref.py
+++ b/src/avalanche/input_ref.py
@@ -12,6 +12,10 @@ class InputRef:
             raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
         return InputRef(self.path + (name,))
 
+    def __reduce__(self):
+        """Reconstruct immutable selectors across executor serialization."""
+        return type(self), (self.path,)
+
     def __repr__(self) -> str:
         return "ava.input" + "".join(f".{part}" for part in self.path)
 

--- a/src/avalanche/run_handle.py
+++ b/src/avalanche/run_handle.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from concurrent.futures import CancelledError, Future
-from typing import Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar
 
 T = TypeVar("T")
 
@@ -16,6 +16,7 @@ class RunHandle(Generic[T]):
     def __init__(self, run_id: str):
         self.run_id = run_id
         self._future: Future[T] = Future()
+        self._execution_receipts: Future[tuple[Any, ...]] = Future()
         self._cancel_event = threading.Event()
         self._state_lock = threading.Lock()
         self._started = False
@@ -56,6 +57,18 @@ class RunHandle(Generic[T]):
     def exception(self, timeout: float | None = None) -> BaseException | None:
         """Return the cached failure, waiting up to ``timeout`` seconds."""
         return self._future.exception(timeout=timeout)
+
+    def execution_receipts(self, timeout: float | None = None) -> tuple[Any, ...]:
+        """Return deterministic terminal execution-service receipts.
+
+        The tuple is empty when the workflow did not use execution services.
+        Receipt failures and cancellation mirror the run's terminal outcome.
+        """
+        return self._execution_receipts.result(timeout=timeout)
+
+    def _set_execution_receipts(self, receipts: tuple[Any, ...]) -> None:
+        if not self._execution_receipts.done():
+            self._execution_receipts.set_result(receipts)
 
     def __await__(self):
         return self._wait().__await__()
@@ -100,12 +113,17 @@ class RunHandle(Generic[T]):
             except CancelledError:
                 with self._state_lock:
                     self._future.cancel()
+                    self._execution_receipts.cancel()
             except BaseException as exc:
                 with self._state_lock:
                     self._future.set_exception(exc)
+                    if not self._execution_receipts.done():
+                        self._execution_receipts.set_exception(exc)
             else:
                 with self._state_lock:
                     self._future.set_result(result)
+                    if not self._execution_receipts.done():
+                        self._execution_receipts.set_result(())
 
         with self._state_lock:
             if self._started:

--- a/src/avalanche/runtime/context.py
+++ b/src/avalanche/runtime/context.py
@@ -96,7 +96,7 @@ def get_current_run_context() -> RunContext | None:
     return _current_run_context.get()
 
 
-def run_with_context(context: RunContext, fn: Any, *args: Any, **kwargs: Any) -> Any:
+def _run_with_context(context: RunContext, fn: Any, /, *args: Any, **kwargs: Any) -> Any:
     """Execute a function with a RunContext available to framework helpers."""
     from runtime._async import resolve_awaitable
 
@@ -105,6 +105,11 @@ def run_with_context(context: RunContext, fn: Any, *args: Any, **kwargs: Any) ->
         return resolve_awaitable(fn(*args, **kwargs))
     finally:
         _current_run_context.reset(token)
+
+
+def run_with_context(context: RunContext, fn: Any, *args: Any, **kwargs: Any) -> Any:
+    """Execute a function with a RunContext available to framework helpers."""
+    return _run_with_context(context, fn, *args, **kwargs)
 
 
 class File(BaseModel):

--- a/src/runtime/_async.py
+++ b/src/runtime/_async.py
@@ -46,6 +46,6 @@ def resolve_awaitable(value: Any) -> Any:
     return _run_awaitable_in_thread(value)
 
 
-def call_sync_or_async(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+def call_sync_or_async(fn: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
     """Call a function and synchronously resolve async results."""
     return resolve_awaitable(fn(*args, **kwargs))

--- a/src/runtime/executor.py
+++ b/src/runtime/executor.py
@@ -92,6 +92,42 @@ def _project_index(value: Any, index: int) -> Any:
     return value[index]
 
 
+def _distributed_execution_services_task(
+    fn: Callable,
+    execution_services: Any,
+    task: Any,
+    input_type: type | None,
+    run_input: Any,
+    input_param_names: tuple[str, ...],
+    dependency_count: int,
+    user_num_returns: int,
+    /,
+    *dependency_and_user_args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Ray entry point with service dependencies exposed as top-level args."""
+    from avalanche.execution_services import _run_with_execution_services
+
+    upstream_receipts = tuple(dependency_and_user_args[:dependency_count])
+    args = tuple(dependency_and_user_args[dependency_count:])
+    result, receipt = _run_with_execution_services(
+        fn,
+        execution_services,
+        task,
+        input_type,
+        run_input,
+        input_param_names,
+        upstream_receipts,
+        args,
+        kwargs,
+        num_returns=user_num_returns,
+        normalize_result=_normalize_distributed_result,
+    )
+    if user_num_returns > 1:
+        return (*result, receipt, None)
+    return result, receipt, None
+
+
 class Executor(Protocol):
     """
     Abstract interface for workflow execution engines.
@@ -145,6 +181,23 @@ class Executor(Protocol):
         only the status ref lets a caller observe completion/failure without
         materializing the payload on the driver (or in a separate worker).
         """
+        ...
+
+    def submit_with_services(
+        self,
+        fn: Callable,
+        execution_services: Any,
+        task: Any,
+        input_type: type | None,
+        run_input: Any,
+        input_param_names: tuple[str, ...],
+        receipt_dependencies: tuple[Any, ...],
+        num_returns: int,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[Any, Any, Any | None]:
+        """Return separate payload, receipt, and optional status channels."""
         ...
 
     def wait(self, futures: list[Any]) -> None:
@@ -226,6 +279,37 @@ class LocalExecutor:
         """
         result = self.submit(fn, *args, num_returns=num_returns, **kwargs)
         return result, None
+
+    def submit_with_services(
+        self,
+        fn: Callable,
+        execution_services: Any,
+        task: Any,
+        input_type: type | None,
+        run_input: Any,
+        input_param_names: tuple[str, ...],
+        receipt_dependencies: tuple[Any, ...],
+        num_returns: int,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[Any, Any, Any | None]:
+        """Execute a service-managed task synchronously."""
+        from avalanche.execution_services import _run_with_execution_services
+
+        result, receipt = _run_with_execution_services(
+            fn,
+            execution_services,
+            task,
+            input_type,
+            run_input,
+            input_param_names,
+            receipt_dependencies,
+            args,
+            kwargs,
+            num_returns=num_returns,
+        )
+        return result, receipt, None
 
     def wait(self, futures: list[Any]) -> None:
         """Local values are already computed; just resolve any awaitables."""
@@ -324,9 +408,7 @@ class RayExecutor:
         # before Ray tries to serialize the task result.
         remote_fn = fn
         if not hasattr(remote_fn, "remote"):
-            remote_fn = self.ray.remote(num_returns=num_returns)(
-                _wrap_sync_or_async(remote_fn)
-            )
+            remote_fn = self.ray.remote(num_returns=num_returns)(_wrap_sync_or_async(remote_fn))
 
         return getattr(remote_fn, "remote")(*args, **kwargs)
 
@@ -361,6 +443,50 @@ class RayExecutor:
         if num_returns == 1:
             return payload_refs[0], status_ref
         return tuple(payload_refs), status_ref
+
+    def submit_with_services(
+        self,
+        fn: Callable,
+        execution_services: Any,
+        task: Any,
+        input_type: type | None,
+        run_input: Any,
+        input_param_names: tuple[str, ...],
+        receipt_dependencies: tuple[Any, ...],
+        num_returns: int,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[Any, Any, Any]:
+        """Submit a task with distinct payload, receipt, and status refs."""
+        if hasattr(fn, "remote"):
+            raise TypeError(
+                "submit_with_services expects a plain function, not a pre-decorated "
+                "Ray remote; it controls payload, receipt, and status return slots"
+            )
+        remote_fn = self.ray.remote(num_returns=num_returns + 2)(
+            _distributed_execution_services_task
+        )
+        refs = getattr(remote_fn, "remote")(
+            fn,
+            execution_services,
+            task,
+            input_type,
+            run_input,
+            input_param_names,
+            len(receipt_dependencies),
+            num_returns,
+            *receipt_dependencies,
+            *args,
+            **kwargs,
+        )
+        refs = list(refs)
+        receipt_ref = refs[-2]
+        status_ref = refs[-1]
+        payload_refs = refs[:-2]
+        if num_returns == 1:
+            return payload_refs[0], receipt_ref, status_ref
+        return tuple(payload_refs), receipt_ref, status_ref
 
     def wait(self, futures: list[Any]) -> None:
         """Block until refs are ready, without observing task exceptions."""

--- a/test/execution_services_test.py
+++ b/test/execution_services_test.py
@@ -1,0 +1,844 @@
+from __future__ import annotations
+
+import os
+from concurrent.futures import CancelledError
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import avalanche as ava
+from avalanche.operator.hooks import RunHooks
+
+
+@dataclass(frozen=True)
+class ManagedValue:
+    value: str
+
+
+@dataclass(frozen=True)
+class ServiceRequest:
+    run_key: str
+    driver_pid: int = 0
+
+
+class ManagedInput(ava.BaseInput):
+    scalar: str
+    values: list[str]
+    optional: str | None
+    empty: list[str]
+    worker_pid: int
+
+
+class RecordingServices:
+    def __init__(self, events: list[tuple[Any, ...]] | None = None):
+        self.events = events if events is not None else []
+
+    def probe(self, *, request, task):
+        self.events.append((task.node_id, "probe"))
+        return f"probe:{request.run_key}"
+
+    def negotiate(self, *, request, task, probe):
+        self.events.append((task.node_id, "negotiate", probe))
+        return f"negotiated:{request.run_key}"
+
+    def open(self, *, request, task, negotiation, upstream_receipts):
+        self.events.append((task.node_id, "open", negotiation, tuple(upstream_receipts)))
+        return {"request": request, "task": task}
+
+    def materialize_input(self, *, session, input_type, input):
+        task = session["task"]
+        self.events.append((task.node_id, "materialize"))
+        return {
+            "scalar": input["scalar"].value,
+            "values": [item.value for item in input["values"]],
+            "optional": (None if input["optional"] is None else input["optional"].value),
+            "empty": [item.value for item in input["empty"]],
+            "worker_pid": os.getpid(),
+        }
+
+    def finalize(self, *, session):
+        task = session["task"]
+        self.events.append((task.node_id, "finalize"))
+        return {"node": task.node_id, "pid": os.getpid()}
+
+    def abort(self, *, session, error):
+        task = session["task"]
+        self.events.append((task.node_id, "abort", type(error).__name__))
+
+    def teardown(self, *, session):
+        task = session["task"]
+        self.events.append((task.node_id, "teardown"))
+
+
+class MetadataCollisionRayServices:
+    def probe(self, *, request, task):
+        return request.run_key
+
+    def negotiate(self, *, request, task, probe):
+        return probe
+
+    def open(self, *, request, task, negotiation, upstream_receipts):
+        return task
+
+    def materialize_input(self, *, session, input_type, input):
+        return input
+
+    def finalize(self, *, session):
+        return {"receipt-node": session.node_id}
+
+    def abort(self, *, session, error):
+        return None
+
+    def teardown(self, *, session):
+        return None
+
+
+def capture_kwargs(**kwargs):
+    return kwargs
+
+
+ALL_INTERNAL_METADATA_KWARGS = {
+    name: f"user-{name.replace('_', '-')}"
+    for name in (
+        "fn",
+        "execution_services",
+        "task",
+        "input_type",
+        "run_input",
+        "input_param_names",
+        "receipt_dependencies",
+        "num_returns",
+        "dependency_count",
+        "user_num_returns",
+        "dependency_and_user_args",
+        "spec",
+        "raw_input",
+        "upstream_receipts",
+        "args",
+        "kwargs",
+        "normalize_result",
+        "context",
+        "request",
+        "probe",
+        "negotiation",
+        "session",
+        "input",
+        "error",
+        "receipt",
+        "internal_metadata",
+    )
+}
+
+
+class RayLifecycleEventRecorder:
+    def __init__(self):
+        self.events = []
+
+    def append(self, event):
+        self.events.append(event)
+
+    def read(self):
+        return self.events
+
+
+class MalformedReturnRayServices:
+    def __init__(self, recorder):
+        self.recorder = recorder
+
+    def record(self, event):
+        import ray
+
+        ray.get(self.recorder.append.remote(event))
+
+    def probe(self, *, request, task):
+        self.record("probe")
+        return request.run_key
+
+    def negotiate(self, *, request, task, probe):
+        self.record("negotiate")
+        return probe
+
+    def open(self, *, request, task, negotiation, upstream_receipts):
+        self.record("open")
+        return task
+
+    def materialize_input(self, *, session, input_type, input):
+        self.record("materialize")
+        return input
+
+    def finalize(self, *, session):
+        self.record("finalize")
+        return session.node_id
+
+    def abort(self, *, session, error):
+        self.record("abort")
+
+    def teardown(self, *, session):
+        self.record("teardown")
+
+
+def return_value(value):
+    return value
+
+
+def _spec(service: Any) -> ava.ExecutionServicesSpec:
+    return ava.ExecutionServicesSpec(
+        service=service,
+        request=ServiceRequest(run_key="run-descriptor"),
+    )
+
+
+def _raw_input() -> dict[str, Any]:
+    # These descriptors are deliberately invalid ManagedInput field values.
+    # Driver-side model construction would fail before the service can materialize them.
+    return {
+        "scalar": ManagedValue("scalar"),
+        "values": [ManagedValue("first"), ManagedValue("second"), ManagedValue("first")],
+        "optional": None,
+        "empty": [],
+    }
+
+
+def test_local_service_input_lifecycle_receipts_and_fan_in():
+    events: list[tuple[Any, ...]] = []
+    services = RecordingServices(events)
+
+    @ava.source
+    def typed(payload: ManagedInput, ctx: ava.RunContext):
+        assert "execution_services" not in ctx.model_dump()
+        return payload.scalar, payload.values, payload.optional, payload.empty
+
+    @ava.source
+    def selected(scalar: str, values: list[str], optional: str | None):
+        return scalar, values, optional
+
+    @ava.step
+    def join(left, right):
+        return left, right
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        left = typed()
+        right = selected(ava.input.scalar, ava.input.values, ava.input.optional)
+        return join(left, right)
+
+    handle = flow().run(
+        executor=ava.LocalExecutor(),
+        input=_raw_input(),
+        execution_services=_spec(services),
+    )
+
+    expected = ("scalar", ["first", "second", "first"], None, [])
+    assert handle.result(timeout=5) == (expected, expected[:3])
+    receipts = handle.execution_receipts(timeout=5)
+    assert [(receipt.node_id, receipt.node_slug) for receipt in receipts] == [
+        ("join_1", "join")
+    ]
+    assert receipts[0].value["node"] == "join_1"
+
+    opens = [event for event in events if event[1] == "open"]
+    assert [event[0] for event in opens] == ["typed_1", "selected_1", "join_1"]
+    assert opens[0][3] == ()
+    assert opens[1][3] == ()
+    assert [receipt["node"] for receipt in opens[2][3]] == ["typed_1", "selected_1"]
+    for node_id in ("typed_1", "selected_1", "join_1"):
+        assert [event[1] for event in events if event[0] == node_id] == [
+            "probe",
+            "negotiate",
+            "open",
+            "materialize",
+            "finalize",
+            "teardown",
+        ]
+
+
+@pytest.mark.parametrize("failure_stage", ["materialize", "user", "finalize"])
+def test_opened_failure_aborts_and_tears_down_once(failure_stage):
+    events: list[tuple[Any, ...]] = []
+
+    class FailingServices(RecordingServices):
+        def materialize_input(self, **kwargs):
+            if failure_stage == "materialize":
+                self.events.append((kwargs["session"]["task"].node_id, "materialize"))
+                raise RuntimeError("materialize failed")
+            return super().materialize_input(**kwargs)
+
+        def finalize(self, **kwargs):
+            if failure_stage == "finalize":
+                self.events.append((kwargs["session"]["task"].node_id, "finalize"))
+                raise RuntimeError("finalize failed")
+            return super().finalize(**kwargs)
+
+    called = []
+
+    @ava.source
+    def task(payload: ManagedInput):
+        called.append(payload.scalar)
+        if failure_stage == "user":
+            raise RuntimeError("user failed")
+        return payload.scalar
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        return task()
+
+    handle = flow().run(
+        executor=ava.LocalExecutor(),
+        input=_raw_input(),
+        execution_services=_spec(FailingServices(events)),
+    )
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        handle.result(timeout=5)
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        handle.execution_receipts(timeout=5)
+    assert sum(event[1] == "abort" for event in events) == 1
+    assert sum(event[1] == "teardown" for event in events) == 1
+    assert called == ([] if failure_stage == "materialize" else ["scalar"])
+
+
+def test_open_failure_has_no_fallback_or_opened_session_cleanup():
+    events: list[tuple[Any, ...]] = []
+
+    class OpenFailure(RecordingServices):
+        def open(self, **kwargs):
+            self.events.append((kwargs["task"].node_id, "open"))
+            raise RuntimeError("open failed")
+
+    called = []
+
+    @ava.source
+    def task(value: str):
+        called.append(value)
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        return task(ava.input.scalar)
+
+    handle = flow().run(
+        executor=ava.LocalExecutor(),
+        input=_raw_input(),
+        execution_services=_spec(OpenFailure(events)),
+    )
+    with pytest.raises(RuntimeError, match="open failed"):
+        handle.result(timeout=5)
+    assert called == []
+    assert [event[1] for event in events] == ["probe", "negotiate", "open"]
+
+
+def test_result_normalization_failure_aborts_before_finalize_and_tears_down_once():
+    from avalanche.execution_services import _run_with_execution_services
+
+    events: list[tuple[Any, ...]] = []
+    task_spec = ava.ExecutionTaskSpec(
+        run_id="run",
+        workflow_name="flow",
+        node_id="task_1",
+        node_name="task",
+        node_slug="task",
+        executor_type="local",
+    )
+
+    def task(payload: ManagedInput):
+        return payload.scalar
+
+    def fail_normalization(_result):
+        raise RuntimeError("normalize failed")
+
+    with pytest.raises(RuntimeError, match="normalize failed"):
+        _run_with_execution_services(
+            task,
+            _spec(RecordingServices(events)),
+            task_spec,
+            ManagedInput,
+            _raw_input(),
+            ("payload",),
+            (),
+            (),
+            {},
+            num_returns=1,
+            normalize_result=fail_normalization,
+        )
+
+    assert [event[1] for event in events] == [
+        "probe",
+        "negotiate",
+        "open",
+        "materialize",
+        "abort",
+        "teardown",
+    ]
+
+
+@pytest.mark.parametrize(
+    "malformed_result",
+    [(), ("only",), ("one", "two", "three")],
+    ids=["zero-values", "one-value", "wrong-multi-value-count"],
+)
+def test_local_malformed_multi_return_aborts_before_finalize_and_tears_down_once(
+    malformed_result,
+):
+    events: list[tuple[Any, ...]] = []
+
+    @ava.source(num_returns=2)
+    def task(payload: ManagedInput):
+        return malformed_result
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        return task()
+
+    handle = flow().run(
+        executor=ava.LocalExecutor(),
+        input=_raw_input(),
+        execution_services=_spec(RecordingServices(events)),
+    )
+    with pytest.raises(ValueError, match="expected to return 2 values"):
+        handle.result(timeout=5)
+    with pytest.raises(ValueError, match="expected to return 2 values"):
+        handle.execution_receipts(timeout=5)
+    assert [event[1] for event in events] == [
+        "probe",
+        "negotiate",
+        "open",
+        "materialize",
+        "abort",
+        "teardown",
+    ]
+
+
+def test_retry_restarts_the_complete_worker_lifecycle():
+    events: list[tuple[Any, ...]] = []
+
+    class RetryingExecutor(ava.LocalExecutor):
+        def submit_with_services(self, fn, *args, **kwargs):
+            try:
+                return super().submit_with_services(fn, *args, **kwargs)
+            except RuntimeError as error:
+                if str(error) != "retry me":
+                    raise
+                return super().submit_with_services(fn, *args, **kwargs)
+
+    attempts = 0
+
+    @ava.source
+    def task(payload: ManagedInput):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("retry me")
+        return payload.scalar
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        return task()
+
+    handle = flow().run(
+        executor=RetryingExecutor(),
+        input=_raw_input(),
+        execution_services=_spec(RecordingServices(events)),
+    )
+    assert handle.result(timeout=5) == "scalar"
+    assert [event[1] for event in events].count("open") == 2
+    assert [event[1] for event in events].count("abort") == 1
+    assert [event[1] for event in events].count("finalize") == 1
+    assert [event[1] for event in events].count("teardown") == 2
+
+
+def test_malformed_return_retry_restarts_the_complete_guarded_lifecycle():
+    events: list[tuple[Any, ...]] = []
+
+    class RetryingExecutor(ava.LocalExecutor):
+        def submit_with_services(self, fn, *args, **kwargs):
+            try:
+                return super().submit_with_services(fn, *args, **kwargs)
+            except ValueError as error:
+                if "expected to return 2 values" not in str(error):
+                    raise
+                return super().submit_with_services(fn, *args, **kwargs)
+
+    attempts = 0
+
+    @ava.source(num_returns=2)
+    def task(payload: ManagedInput):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return (payload.scalar,)
+        return payload.scalar, "ok"
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        return task()
+
+    handle = flow().run(
+        executor=RetryingExecutor(),
+        input=_raw_input(),
+        execution_services=_spec(RecordingServices(events)),
+    )
+    assert handle.result(timeout=5) == ("scalar", "ok")
+    assert [event[1] for event in events] == [
+        "probe",
+        "negotiate",
+        "open",
+        "materialize",
+        "abort",
+        "teardown",
+        "probe",
+        "negotiate",
+        "open",
+        "materialize",
+        "finalize",
+        "teardown",
+    ]
+
+
+def test_cancellation_preserves_completed_service_lifecycle_and_skips_downstream():
+    events: list[tuple[Any, ...]] = []
+    starts: list[str] = []
+
+    @ava.source
+    def first(payload: ManagedInput):
+        return payload.scalar
+
+    @ava.step
+    def second(value: str):
+        return value
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        return first() >> second()
+
+    handle = flow().run(
+        executor=ava.LocalExecutor(),
+        hooks=RunHooks(
+            on_node_start=starts.append,
+            cancel_requested=lambda: len(starts) >= 1,
+        ),
+        input=_raw_input(),
+        execution_services=_spec(RecordingServices(events)),
+    )
+    with pytest.raises(CancelledError):
+        handle.result(timeout=5)
+    assert starts == ["first_1"]
+    assert [event[0] for event in events if event[1] == "open"] == ["first_1"]
+    assert [event[1] for event in events if event[0] == "first_1"][-2:] == [
+        "finalize",
+        "teardown",
+    ]
+
+
+def test_version_and_protocol_validation_and_unchanged_empty_receipts():
+    with pytest.raises(ValueError, match="Unsupported execution services version"):
+        ava.ExecutionServicesSpec(
+            service=RecordingServices(),
+            request=ServiceRequest("run"),
+            version="future",
+        )
+    with pytest.raises(TypeError, match="ExecutionServices protocol"):
+        ava.ExecutionServicesSpec(service=object(), request=ServiceRequest("run"))
+
+    @ava.workflow
+    def unchanged():
+        return "ordinary"
+
+    handle = unchanged().run(executor=ava.LocalExecutor())
+    assert handle.result(timeout=5) == "ordinary"
+    assert handle.execution_receipts(timeout=5) == ()
+
+
+def test_async_provider_methods_are_rejected_at_spec_construction():
+    class AsyncServices(RecordingServices):
+        async def materialize_input(self, **kwargs):  # type: ignore[override]
+            return super().materialize_input(**kwargs)
+
+    with pytest.raises(
+        TypeError,
+        match=r"lifecycle methods must be synchronous; async methods: materialize_input",
+    ):
+        _spec(AsyncServices())
+
+
+def test_hidden_provider_awaitable_is_rejected_without_coroutine_leak():
+    from avalanche.execution_services import _run_with_execution_services
+
+    class HiddenAsyncServices(RecordingServices):
+        def materialize_input(self, **kwargs):  # type: ignore[override]
+            async def materialize():
+                return super().materialize_input(**kwargs)
+
+            return materialize()
+
+    task_spec = ava.ExecutionTaskSpec(
+        run_id="run",
+        workflow_name="flow",
+        node_id="task_1",
+        node_name="task",
+        node_slug="task",
+        executor_type="local",
+    )
+    with pytest.raises(TypeError, match="materialize_input returned an awaitable"):
+        _run_with_execution_services(
+            lambda payload: payload.scalar,
+            _spec(HiddenAsyncServices()),
+            task_spec,
+            ManagedInput,
+            _raw_input(),
+            ("payload",),
+            (),
+            (),
+            {},
+            num_returns=1,
+        )
+
+
+def test_cleanup_failures_do_not_mask_primary_task_failure():
+    from avalanche.execution_services import _run_with_execution_services
+
+    class CleanupFailureServices(RecordingServices):
+        def abort(self, *, session, error):
+            raise RuntimeError("abort cleanup failed")
+
+        def teardown(self, *, session):
+            raise RuntimeError("teardown cleanup failed")
+
+    def fail(payload: ManagedInput):
+        raise ValueError("primary task failed")
+
+    task_spec = ava.ExecutionTaskSpec(
+        run_id="run",
+        workflow_name="flow",
+        node_id="fail_1",
+        node_name="fail",
+        node_slug="fail",
+        executor_type="local",
+    )
+    with pytest.raises(ValueError, match="primary task failed") as error:
+        _run_with_execution_services(
+            fail,
+            _spec(CleanupFailureServices()),
+            task_spec,
+            ManagedInput,
+            _raw_input(),
+            ("payload",),
+            (),
+            (),
+            {},
+            num_returns=1,
+        )
+    notes = getattr(error.value, "__notes__", ())
+    assert any("abort cleanup failed" in note for note in notes)
+    assert any("teardown cleanup failed" in note for note in notes)
+
+
+def test_executor_owned_metadata_does_not_claim_user_keyword_names():
+    task = ava.source(capture_kwargs)
+
+    @ava.workflow(input=ManagedInput)
+    def flow():
+        return task(**ALL_INTERNAL_METADATA_KWARGS)
+
+    handle = flow().run(
+        executor=ava.LocalExecutor(),
+        input=_raw_input(),
+        execution_services=_spec(RecordingServices()),
+    )
+    assert handle.result(timeout=5) == ALL_INTERNAL_METADATA_KWARGS
+    assert handle.execution_receipts(timeout=5)[0].value["node"] == "capture_kwargs_1"
+
+
+@pytest.mark.ray
+def test_real_ray_materializes_on_worker_and_returns_deterministic_hidden_receipts():
+    ray = pytest.importorskip("ray")
+    if ray.is_initialized():
+        ray.shutdown()
+    ray.init(
+        num_cpus=2,
+        ignore_reinit_error=True,
+        include_dashboard=False,
+        runtime_env={"working_dir": None},
+    )
+    try:
+        driver_pid = os.getpid()
+
+        class RayInput(ava.BaseInput):
+            scalar: str
+            values: list[str]
+            worker_pid: int
+
+        @dataclass(frozen=True)
+        class RayRequest:
+            run_key: str
+
+        class RayServices:
+            def probe(self, *, request, task):
+                return request.run_key
+
+            def negotiate(self, *, request, task, probe):
+                return probe
+
+            def open(self, *, request, task, negotiation, upstream_receipts):
+                return task, tuple(upstream_receipts)
+
+            def materialize_input(self, *, session, input_type, input):
+                return {
+                    "scalar": input["scalar"]["value"],
+                    "values": [item["value"] for item in input["values"]],
+                    "worker_pid": os.getpid(),
+                }
+
+            def finalize(self, *, session):
+                task, _upstream_receipts = session
+                return {"node": task.node_id, "pid": os.getpid()}
+
+            def abort(self, *, session, error):
+                return None
+
+            def teardown(self, *, session):
+                return None
+
+        def left_fn(payload):
+            assert payload.worker_pid != driver_pid
+            return [payload.scalar, *payload.values]
+
+        left_fn.__annotations__["payload"] = RayInput
+        left = ava.source(left_fn)
+
+        @ava.source
+        def right(value: str):
+            return value
+
+        @ava.step
+        def join(left_value, right_value):
+            return {"left": left_value, "right": right_value, "pid": os.getpid()}
+
+        @ava.workflow(input=RayInput)
+        def flow():
+            return join(left(), right(ava.input.scalar))
+
+        spec = ava.ExecutionServicesSpec(
+            service=RayServices(),
+            request=RayRequest("ray-run"),
+        )
+        handle = flow().run(
+            executor=ava.RayExecutor(),
+            input={
+                "scalar": {"value": "scalar"},
+                "values": [
+                    {"value": "first"},
+                    {"value": "second"},
+                    {"value": "first"},
+                ],
+            },
+            execution_services=spec,
+        )
+        result = handle.result(timeout=30)
+        receipts = handle.execution_receipts(timeout=30)
+
+        assert result["left"] == ["scalar", "first", "second", "first"]
+        assert result["right"] == "scalar"
+        assert result["pid"] != driver_pid
+        assert [(receipt.node_id, receipt.node_slug) for receipt in receipts] == [
+            ("join_1", "join")
+        ]
+        assert receipts[0].value["node"] == "join_1"
+        assert receipts[0].value["pid"] != driver_pid
+    finally:
+        ray.shutdown()
+
+
+@pytest.mark.ray
+def test_real_ray_executor_owned_metadata_is_strictly_positional_only():
+    ray = pytest.importorskip("ray")
+    if ray.is_initialized():
+        ray.shutdown()
+    ray.init(
+        num_cpus=2,
+        ignore_reinit_error=True,
+        include_dashboard=False,
+        runtime_env={
+            "working_dir": None,
+            "env_vars": {"PYTHONPATH": os.path.dirname(__file__)},
+        },
+    )
+    try:
+        task = ava.source(capture_kwargs)
+
+        @ava.workflow
+        def flow():
+            return task(**ALL_INTERNAL_METADATA_KWARGS)
+
+        handle = flow().run(
+            executor=ava.RayExecutor(),
+            execution_services=ava.ExecutionServicesSpec(
+                service=MetadataCollisionRayServices(),
+                request=ServiceRequest("ray-collision"),
+            ),
+        )
+
+        assert handle.result(timeout=30) == ALL_INTERNAL_METADATA_KWARGS
+        receipts = handle.execution_receipts(timeout=30)
+        assert len(receipts) == 1
+        assert receipts[0].node_id == "capture_kwargs_1"
+        assert receipts[0].value == {"receipt-node": "capture_kwargs_1"}
+    finally:
+        ray.shutdown()
+
+
+@pytest.mark.ray
+def test_real_ray_malformed_multi_returns_abort_before_finalize_and_teardown_once():
+    ray = pytest.importorskip("ray")
+    if ray.is_initialized():
+        ray.shutdown()
+    ray.init(
+        num_cpus=2,
+        ignore_reinit_error=True,
+        include_dashboard=False,
+        runtime_env={
+            "working_dir": None,
+            "env_vars": {"PYTHONPATH": os.path.dirname(__file__)},
+        },
+    )
+    try:
+        event_recorder = ray.remote(num_cpus=0)(RayLifecycleEventRecorder)
+        executor = ava.RayExecutor()
+        task_spec = ava.ExecutionTaskSpec(
+            run_id="run",
+            workflow_name="flow",
+            node_id="task_1",
+            node_name="task",
+            node_slug="task",
+            executor_type="ray",
+        )
+        malformed_results = [(), ("only",), ("one", "two", "three")]
+        for malformed_result in malformed_results:
+            recorder = event_recorder.remote()
+            payload_refs, _receipt_ref, status_ref = executor.submit_with_services(
+                return_value,
+                ava.ExecutionServicesSpec(
+                    service=MalformedReturnRayServices(recorder),
+                    request=ServiceRequest("ray-malformed-return"),
+                ),
+                task_spec,
+                None,
+                None,
+                (),
+                (),
+                2,
+                malformed_result,
+            )
+
+            assert len(payload_refs) == 2
+            with pytest.raises(ray.exceptions.RayTaskError) as error:
+                ray.get(status_ref)
+            assert "expected to return 2 values" in str(error.value)
+            assert ray.get(recorder.read.remote()) == [
+                "probe",
+                "negotiate",
+                "open",
+                "materialize",
+                "abort",
+                "teardown",
+            ]
+    finally:
+        ray.shutdown()

--- a/test/ray_materialization_contract_test.py
+++ b/test/ray_materialization_contract_test.py
@@ -52,6 +52,7 @@ class FakeObjectRef:
     task: "FakeTask | None" = None
     index: int | None = None  # which return slot of the task
     is_status: bool = False
+    is_receipt: bool = False
     stored_label: str | None = None
     stored_value: Any = None
     is_stored: bool = False
@@ -93,15 +94,14 @@ class RayExecutor:
         self.driver_payload_gets: list[str] = []
         self.worker_payload_gets: list[str] = []
         self.status_gets: list[str] = []
+        self.receipt_gets: list[str] = []
         self.payload_resolutions: list[tuple[str, str]] = []  # (context, task)
         self._context: str = "__driver__"
 
     # -- submission -------------------------------------------------------
 
     def submit(self, fn, *args, num_returns=1, **kwargs):
-        self.submissions.append(
-            (fn.__name__, {k: type(v).__name__ for k, v in kwargs.items()})
-        )
+        self.submissions.append((fn.__name__, {k: type(v).__name__ for k, v in kwargs.items()}))
         task = FakeTask(fn=fn, args=args, kwargs=kwargs, num_returns=num_returns)
         if num_returns > 1:
             return tuple(FakeObjectRef(task=task, index=i) for i in range(num_returns))
@@ -109,17 +109,53 @@ class RayExecutor:
 
     def submit_with_status(self, fn, *args, num_returns=1, **kwargs):
         """Return (payload_ref_or_tuple, status_ref) from the same task."""
-        self.submissions.append(
-            (fn.__name__, {k: type(v).__name__ for k, v in kwargs.items()})
-        )
+        self.submissions.append((fn.__name__, {k: type(v).__name__ for k, v in kwargs.items()}))
         task = FakeTask(fn=fn, args=args, kwargs=kwargs, num_returns=num_returns)
-        payload_refs = tuple(
-            FakeObjectRef(task=task, index=i) for i in range(num_returns)
-        )
+        payload_refs = tuple(FakeObjectRef(task=task, index=i) for i in range(num_returns))
         status_ref = FakeObjectRef(task=task, index=num_returns, is_status=True)
         if num_returns == 1:
             return payload_refs[0], status_ref
         return payload_refs, status_ref
+
+    def submit_with_services(
+        self,
+        fn,
+        execution_services,
+        task,
+        input_type,
+        run_input,
+        input_param_names,
+        receipt_dependencies,
+        num_returns,
+        /,
+        *args,
+        **kwargs,
+    ):
+        from runtime.executor import _distributed_execution_services_task
+
+        refs = self.submit(
+            _distributed_execution_services_task,
+            fn,
+            execution_services,
+            task,
+            input_type,
+            run_input,
+            input_param_names,
+            len(receipt_dependencies),
+            num_returns,
+            *receipt_dependencies,
+            *args,
+            num_returns=num_returns + 2,
+            **kwargs,
+        )
+        refs = tuple(refs)
+        receipt_ref = refs[-2]
+        receipt_ref.is_receipt = True
+        status_ref = refs[-1]
+        status_ref.is_status = True
+        if num_returns == 1:
+            return refs[0], receipt_ref, status_ref
+        return refs[:-2], receipt_ref, status_ref
 
     # -- object store -----------------------------------------------------
 
@@ -199,6 +235,9 @@ class RayExecutor:
             if isinstance(ref, FakeObjectRef) and ref.is_status:
                 self.status_gets.append(self._task_label(ref))
                 out.append(value)
+            elif isinstance(ref, FakeObjectRef) and ref.is_receipt:
+                self.receipt_gets.append(self._task_label(ref))
+                out.append(value)
             else:
                 if isinstance(ref, FakeObjectRef):
                     self.driver_payload_gets.append(self._task_label(ref))
@@ -250,7 +289,12 @@ class RayExecutor:
     def _task_label(self, ref: FakeObjectRef) -> str:
         if ref.task is not None and ref.task.fn is not None:
             name = ref.task.fn.__name__
-            if ref.task.num_returns > 1 and ref.index is not None and not ref.is_status:
+            if (
+                ref.task.num_returns > 1
+                and ref.index is not None
+                and not ref.is_status
+                and not ref.is_receipt
+            ):
                 return f"{name}[{ref.index}]"
             return name
         if ref.is_stored:
@@ -267,9 +311,9 @@ class RayExecutor:
 
 
 def _assert_no_driver_payload(executor: RayExecutor):
-    assert executor.driver_payload_gets == [], (
-        f"driver materialized payloads: {executor.driver_payload_gets}"
-    )
+    assert (
+        executor.driver_payload_gets == []
+    ), f"driver materialized payloads: {executor.driver_payload_gets}"
 
 
 def _assert_no_synthetic_payload_resolution(executor: RayExecutor):
@@ -279,6 +323,52 @@ def _assert_no_synthetic_payload_resolution(executor: RayExecutor):
         if ctx in ("__driver__", "__status__", "__projection__")
     ]
     assert synthetic == [], f"synthetic path resolved payloads: {synthetic}"
+
+
+def test_execution_service_receipts_do_not_materialize_user_payloads_on_driver():
+    from execution_services_test import RecordingServices, _raw_input, _spec
+
+    class Input(ava.BaseInput):
+        scalar: str
+        values: list[str]
+        optional: str | None
+        empty: list[str]
+        worker_pid: int
+
+    @ava.source
+    def load(value: str):
+        return [value] * 100
+
+    @ava.step
+    def left(value):
+        return value + ["left"]
+
+    @ava.step
+    def right(value):
+        return value + ["right"]
+
+    @ava.step
+    def join(left_value, right_value):
+        return len(left_value) + len(right_value)
+
+    @ava.workflow(input=Input)
+    def flow():
+        root = load(ava.input.scalar)
+        return join(left(root), right(root))
+
+    executor = RayExecutor()
+    handle = flow().run(
+        executor=executor,
+        input=_raw_input(),
+        execution_services=_spec(RecordingServices()),
+    )
+
+    assert handle.result() == 202
+    assert [receipt.node_id for receipt in handle.execution_receipts()] == ["join_1"]
+    assert executor.driver_payload_gets == ["_distributed_execution_services_task[0]"]
+    assert len(executor.status_gets) == 4
+    assert len(executor.receipt_gets) == 1
+    assert all(context != "__driver__" for context, _label in executor.payload_resolutions)
 
 
 # ---------------------------------------------------------------------------
@@ -341,9 +431,9 @@ def test_no_return_workflow_does_not_materialize_payloads():
     assert result is None
     _assert_no_driver_payload(executor)
     _assert_no_synthetic_payload_resolution(executor)
-    assert executor.ray.wait_calls or executor.status_gets, (
-        "no-return workflow never observed completion"
-    )
+    assert (
+        executor.ray.wait_calls or executor.status_gets
+    ), "no-return workflow never observed completion"
 
 
 def test_no_return_workflow_surfaces_task_failure():
@@ -411,9 +501,7 @@ def test_success_hook_with_return_fetches_only_final_once():
 
     events: list[str] = []
     executor = RayExecutor()
-    result = wf().run(
-        executor=executor, hooks=RunHooks(on_node_success=events.append)
-    ).result()
+    result = wf().run(executor=executor, hooks=RunHooks(on_node_success=events.append)).result()
 
     assert result == 6
     assert "load" not in executor.driver_payload_gets, executor.driver_payload_gets


### PR DESCRIPTION
## Summary

- add provider-neutral execution services around each worker task
- use `materialize_input` terminology and document eager/lazy materialization
- keep Ray payloads, receipts, and progress statuses on separate channels
- preserve primary task/finalization errors when cleanup also fails
- expose deterministic terminal receipts through `RunHandle`

## Architecture and DX

- add `docs/execution-services.md`
- document provider and workflow-author contracts in `ARCHITECTURE.md`, README, and DAG API docs
- keep credentials and worker-local capabilities behind the provider boundary
- require synchronous lifecycle methods while continuing to support async workflow tasks

## Verification

- `uv run ruff check .`
- `uv run pytest -q`: 811 passed, 2 skipped
- Delta integration against this source: 1278 passed, 15 skipped
- independent Codex review (`gpt-5.6-sol`, high): APPROVE
