### PR TITLE
perf(tui): virtualize log rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### TUI performance
+
+- Virtualized log rendering keeps steady and incremental refresh work bounded by
+  the visible viewport instead of rebuilding complete log history every frame.
+- Added `make tui-bench`, which enforces the 30 FPS refresh budget through
+  10,000 log rows for steady and append scenarios.
+
 ### Worker execution services
 
 - Added the versioned `ava.ExecutionServicesSpec` and worker-side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Virtualized log rendering keeps steady and incremental refresh work bounded by
   the visible viewport instead of rebuilding complete log history every frame.
+- DAG pointer scrolling now accumulates higher-sensitivity horizontal and
+  vertical targets with short animations instead of jumping between cells.
 - Added `make tui-bench`, which enforces the 30 FPS refresh budget through
   10,000 log rows for steady and append scenarios.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-cov test-cov-html lint format precommit-check check smoke-test brand install clean
+.PHONY: test test-cov test-cov-html lint format precommit-check check smoke-test tui-bench brand install clean
 
 # Run tests with every supported executor/storage extra installed.
 test:
@@ -31,6 +31,10 @@ check: precommit-check
 # Run bounded smoke tests for the documented user path
 smoke-test:
 	uv run pytest test/smoke_test.py test/example_smoke_test.py test/operator_example_discovery_test.py -v
+
+# Measure TUI refresh scaling as log history grows
+tui-bench:
+	uv run python scripts/benchmark_tui.py --assert-budget
 
 # Build checked-in brand image artifacts from the Three.js source HTML.
 brand:

--- a/scripts/benchmark_tui.py
+++ b/scripts/benchmark_tui.py
@@ -1,0 +1,179 @@
+"""Measure Avalanche TUI refresh latency as log history grows."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import gc
+import json
+import math
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+
+from avalanche.tui.app import AvalancheApp
+from avalanche.tui.models import LogEntry, LogLevel
+
+
+@dataclass(frozen=True)
+class Result:
+    scenario: str
+    rows: int
+    characters: int
+    p50_ms: float
+    p95_ms: float
+    maximum_ms: float
+    frame_budget_ms: float
+
+    @property
+    def within_budget(self) -> bool:
+        return self.p95_ms <= self.frame_budget_ms
+
+
+def percentile(samples: list[float], percentile_value: float) -> float:
+    ordered = sorted(samples)
+    rank = max(0, math.ceil(percentile_value * len(ordered)) - 1)
+    return ordered[rank]
+
+
+def build_log(message_length: int, node_id: str) -> LogEntry:
+    return LogEntry(
+        timestamp=datetime(2026, 1, 1),
+        level=LogLevel.INFO,
+        node_id=node_id,
+        message="x" * message_length,
+    )
+
+
+def build_logs(count: int, message_length: int, node_id: str) -> list[LogEntry]:
+    return [build_log(message_length, node_id) for _ in range(count)]
+
+
+async def measure(
+    rows: int,
+    *,
+    scenario: str,
+    message_length: int,
+    samples: int,
+    width: int,
+    height: int,
+    frame_budget_ms: float,
+) -> Result:
+    app = AvalancheApp()
+    async with app.run_test(size=(width, height)) as pilot:
+        await pilot.pause()
+        if app._timer is not None:
+            app._timer.pause()
+
+        run = app.store.current_run
+        if run is None:
+            raise RuntimeError("mock TUI did not initialize a current run")
+
+        app.store.run_pinned = True
+        node_id = app.store.all_nodes[0].name
+        run.logs = build_logs(rows, message_length, node_id)
+
+        # Warm the widget and compositor caches before collecting samples.
+        app._tick()
+        await app.wait_for_refresh()
+        gc.collect()
+
+        durations: list[float] = []
+        for _ in range(samples):
+            if scenario == "append":
+                run.logs.append(build_log(message_length, node_id))
+            started = time.perf_counter()
+            app._tick()
+            await app.wait_for_refresh()
+            durations.append((time.perf_counter() - started) * 1000)
+
+        characters = sum(
+            len(entry.node_id) + len(entry.level.value) + len(entry.message) + 25
+            for entry in run.logs
+        )
+        return Result(
+            scenario=scenario,
+            rows=rows,
+            characters=characters,
+            p50_ms=statistics.median(durations),
+            p95_ms=percentile(durations, 0.95),
+            maximum_ms=max(durations),
+            frame_budget_ms=frame_budget_ms,
+        )
+
+
+async def run_benchmark(args: argparse.Namespace) -> list[Result]:
+    frame_budget_ms = 1000 / args.fps
+    results = []
+    for rows in args.rows:
+        for scenario in args.scenarios:
+            results.append(
+                await measure(
+                    rows,
+                    scenario=scenario,
+                    message_length=args.message_length,
+                    samples=args.samples,
+                    width=args.width,
+                    height=args.height,
+                    frame_budget_ms=frame_budget_ms,
+                )
+            )
+    return results
+
+
+def print_results(results: list[Result]) -> None:
+    print("scenario    rows       chars      p50 ms      p95 ms      max ms    budget")
+    for result in results:
+        status = "PASS" if result.within_budget else "FAIL"
+        print(
+            f"{result.scenario:<8}  {result.rows:>7,}  {result.characters:>10,}  "
+            f"{result.p50_ms:>10.2f}  {result.p95_ms:>10.2f}  "
+            f"{result.maximum_ms:>10.2f}  {status:>8}"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, nargs="+", default=[100, 1_000, 5_000, 10_000])
+    parser.add_argument("--message-length", type=int, default=80)
+    parser.add_argument("--samples", type=int, default=30)
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        choices=("steady", "append"),
+        default=["steady", "append"],
+    )
+    parser.add_argument("--width", type=int, default=120)
+    parser.add_argument("--height", type=int, default=40)
+    parser.add_argument("--fps", type=float, default=30)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--assert-budget", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    results = asyncio.run(run_benchmark(args))
+    print_results(results)
+
+    if args.json is not None:
+        args.json.write_text(
+            json.dumps(
+                [
+                    asdict(result) | {"within_budget": result.within_budget}
+                    for result in results
+                ],
+                indent=2,
+            )
+            + "\n"
+        )
+
+    if args.assert_budget and not all(result.within_budget for result in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_tui.py
+++ b/scripts/benchmark_tui.py
@@ -9,7 +9,7 @@ import json
 import math
 import statistics
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from pathlib import Path
 
@@ -67,35 +67,57 @@ async def measure(
         if app._timer is not None:
             app._timer.pause()
 
+        # Apply startup updates before replacing the snapshot under test.
+        app._tick()
+        await app.wait_for_refresh()
+
         run = app.store.current_run
         if run is None:
             raise RuntimeError("mock TUI did not initialize a current run")
 
         app.store.run_pinned = True
         node_id = app.store.all_nodes[0].name
-        run.logs = build_logs(rows, message_length, node_id)
+        app.store.current_run = replace(
+            run,
+            logs=build_logs(rows, message_length, node_id),
+        )
 
-        # Warm the widget and compositor caches before collecting samples.
-        app._tick()
+        # Isolate the visible-widget refresh path from mock-provider polling,
+        # which would replace the synthetic snapshot with its backing run.
+        app._refresh_widgets()
         await app.wait_for_refresh()
         gc.collect()
 
         durations: list[float] = []
         for _ in range(samples):
-            if scenario == "append":
-                run.logs.append(build_log(message_length, node_id))
+            current_run = app.store.current_run
+            if current_run is None:
+                raise RuntimeError("current run disappeared during benchmark")
+            if scenario == "steady":
+                app.store.current_run = replace(
+                    current_run,
+                    logs=list(current_run.logs),
+                )
+            else:
+                app.store.current_run = replace(
+                    current_run,
+                    logs=[*current_run.logs, build_log(message_length, node_id)],
+                )
             started = time.perf_counter()
-            app._tick()
+            app._refresh_widgets()
             await app.wait_for_refresh()
             durations.append((time.perf_counter() - started) * 1000)
 
+        current_run = app.store.current_run
+        if current_run is None:
+            raise RuntimeError("current run disappeared during benchmark")
         characters = sum(
             len(entry.node_id) + len(entry.level.value) + len(entry.message) + 25
-            for entry in run.logs
+            for entry in current_run.logs
         )
         return Result(
             scenario=scenario,
-            rows=rows,
+            rows=len(current_run.logs),
             characters=characters,
             p50_ms=statistics.median(durations),
             p95_ms=percentile(durations, 0.95),

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -430,8 +430,10 @@ class AvalancheApp(App):
             self._refresh_widgets()
             self._scroll_run_history_to_selected()
         elif pane == "log":
+            self._log_autoscroll = False
             try:
-                self._screen.query_one("#log-panel").scroll_up()
+                log_view = self._screen.query_one("#log-content", LogWidget)
+                log_view.scroll_up(animate=False)
             except Exception:
                 pass
 
@@ -448,7 +450,9 @@ class AvalancheApp(App):
             self._scroll_run_history_to_selected()
         elif pane == "log":
             try:
-                self._screen.query_one("#log-panel").scroll_down()
+                log_view = self._screen.query_one("#log-content", LogWidget)
+                log_view.scroll_down(animate=False)
+                self._log_autoscroll = log_view.scroll_y >= log_view.max_scroll_y - 1
             except Exception:
                 pass
 

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -139,12 +139,6 @@ class AvalancheApp(App):
         self._poll_counter += 1
         if self._poll_counter % 30 == 0:
             self._poll_current_run()
-        # Read back match count from previous LogWidget render
-        try:
-            log_w = self._screen.query_one("#log-content", LogWidget)
-            self.store.set_match_count(len(log_w._match_lines))
-        except Exception:
-            pass
         self.store.auto_follow_latest_run()
         self._refresh_widgets()
         self._autoscroll_logs()
@@ -181,12 +175,11 @@ class AvalancheApp(App):
                 self._screen.query_one(f"#{widget_id}").refresh()
             except Exception:
                 pass
-        # Refresh scrollable content with layout=True so height recalculates
-        for widget_id in ("log-content", "run-history-content"):
-            try:
-                self._screen.query_one(f"#{widget_id}").refresh(layout=True)
-            except Exception:
-                pass
+        # Run history still sizes itself to its complete table.
+        try:
+            self._screen.query_one("#run-history-content").refresh(layout=True)
+        except Exception:
+            pass
         # Update sticky headers
         try:
             from .widgets.run_history import RunHistoryWidget
@@ -274,6 +267,7 @@ class AvalancheApp(App):
             log_w = self._screen.query_one("#log-content", LogWidget)
             # Subtract 2: 1 for the scrollbar gutter + 1 for breathing room
             log_w.wrap_width = (lp.content_size.width - 2) if self._log_wrap else 0
+            log_w.sync_from_store()
         except Exception:
             pass
 
@@ -291,19 +285,15 @@ class AvalancheApp(App):
     # ── Log autoscroll ────────────────────────────────────────────────
 
     def _autoscroll_logs(self) -> None:
-        """Scroll log panel to bottom when autoscroll is active.
-
-        Sets scroll_y directly so both content and scrollbar update in
-        the same frame — no 1-frame lag from call_after_refresh.
-        """
+        """Scroll the virtualized log view to its last row."""
         if not self._log_autoscroll:
             return
         try:
-            container = self._screen.query_one("#log-panel")
-            target = container.max_scroll_y
-            if target > 0 and container.scroll_y != target:
-                container.scroll_target_y = target
-                container.scroll_y = target
+            log_view = self._screen.query_one("#log-content", LogWidget)
+            target = log_view.max_scroll_y
+            if target > 0 and log_view.scroll_y != target:
+                log_view.scroll_target_y = target
+                log_view.scroll_y = target
         except Exception:
             pass
 
@@ -582,17 +572,17 @@ class AvalancheApp(App):
         """Page Up: scroll log panel up, disable autoscroll."""
         self._log_autoscroll = False
         try:
-            container = self._screen.query_one("#log-panel")
-            container.scroll_page_up(animate=False)
+            log_view = self._screen.query_one("#log-content", LogWidget)
+            log_view.scroll_page_up(animate=False)
         except Exception:
             pass
 
     def action_log_page_down(self) -> None:
         """Page Down: scroll log panel down; re-enable autoscroll at bottom."""
         try:
-            container = self._screen.query_one("#log-panel")
-            container.scroll_page_down(animate=False)
-            self._log_autoscroll = container.scroll_y >= container.max_scroll_y - 1
+            log_view = self._screen.query_one("#log-content", LogWidget)
+            log_view.scroll_page_down(animate=False)
+            self._log_autoscroll = log_view.scroll_y >= log_view.max_scroll_y - 1
         except Exception:
             pass
 

--- a/src/tui/screens/workflow_detail.py
+++ b/src/tui/screens/workflow_detail.py
@@ -122,35 +122,6 @@ class _TableScrollContainer(_ThinScrollContainer):
         except Exception:
             pass
 
-    def _update_log_autoscroll(self) -> None:
-        """Disable autoscroll on user input; re-enable if at bottom."""
-        if self.id != "log-panel":
-            return
-        try:
-            app = self.app
-            app._log_autoscroll = self.scroll_y >= self.max_scroll_y - 1
-        except Exception:
-            pass
-
-    def _on_mouse_scroll_up(self, event) -> None:
-        super()._on_mouse_scroll_up(event)
-        self._update_log_autoscroll()
-
-    def _on_mouse_scroll_down(self, event) -> None:
-        super()._on_mouse_scroll_down(event)
-        self._update_log_autoscroll()
-
-    def _on_scroll_up(self, event) -> None:
-        super()._on_scroll_up(event)
-        self._update_log_autoscroll()
-
-    def _on_scroll_down(self, event) -> None:
-        super()._on_scroll_down(event)
-        self._update_log_autoscroll()
-
-    def _on_scroll_to(self, message) -> None:
-        super()._on_scroll_to(message)
-        self._update_log_autoscroll()
 
 
 
@@ -255,9 +226,13 @@ class WorkflowDetailScreen(Screen):
     }
 
     /* ── Scrollable content ── */
-    #run-history-content, #log-content {
+    #run-history-content {
         height: auto;
         width: auto;
+    }
+    #log-content {
+        height: 1fr;
+        width: 1fr;
     }
 
     /* ── Status bar ── */
@@ -303,7 +278,7 @@ class WorkflowDetailScreen(Screen):
                     dag_container.styles.height = "2fr"
                     yield DagWidget(id="dag-panel")
                     yield _DagCenterBtn(" ⊡ center ", id="dag-center-btn")
-                with _TableScrollContainer(id="log-panel") as lp:
+                with Vertical(id="log-panel") as lp:
                     lp.border_title = "Logs"
                     lp.styles.height = "2fr"
                     yield Static(id="log-header", classes="pane-header")

--- a/src/tui/screens/workflow_detail.py
+++ b/src/tui/screens/workflow_detail.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from rich.color import Color
 from rich.segment import Segments
+from textual import events
 from textual.app import ComposeResult
 from textual.containers import Horizontal, ScrollableContainer, Vertical
 from textual.screen import Screen
@@ -110,6 +111,64 @@ class _ThinScrollContainer(ScrollableContainer):
         sb = super().horizontal_scrollbar
         sb.renderer = _HalfHeightScrollBarRender
         return sb
+
+class _DagScrollContainer(_ThinScrollContainer):
+    """DAG viewport with cumulative, animated pointer scrolling."""
+
+    HORIZONTAL_SCROLL_STEP = 8
+    VERTICAL_SCROLL_STEP = 3
+    SCROLL_DURATION = 0.08
+
+    def _on_mouse_scroll_left(self, event: events.MouseScrollLeft) -> None:
+        self._scroll_horizontal(event, -1)
+
+    def _on_mouse_scroll_right(self, event: events.MouseScrollRight) -> None:
+        self._scroll_horizontal(event, 1)
+
+    def _on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        if event.ctrl or event.shift:
+            self._scroll_horizontal(event, -1)
+        else:
+            self._scroll_vertical(event, -1)
+
+    def _on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        if event.ctrl or event.shift:
+            self._scroll_horizontal(event, 1)
+        else:
+            self._scroll_vertical(event, 1)
+
+    def _scroll_horizontal(
+        self,
+        event: events.MouseEvent,
+        direction: int,
+    ) -> None:
+        if not self.allow_horizontal_scroll:
+            return
+        changed = self._scroll_to(
+            x=self.scroll_target_x + direction * self.HORIZONTAL_SCROLL_STEP,
+            animate=True,
+            duration=self.SCROLL_DURATION,
+            easing="out_cubic",
+        )
+        if changed:
+            event.stop()
+
+    def _scroll_vertical(
+        self,
+        event: events.MouseEvent,
+        direction: int,
+    ) -> None:
+        if not self.allow_vertical_scroll:
+            return
+        changed = self._scroll_to(
+            y=self.scroll_target_y + direction * self.VERTICAL_SCROLL_STEP,
+            animate=True,
+            duration=self.SCROLL_DURATION,
+            easing="out_cubic",
+        )
+        if changed:
+            event.stop()
+
 
 
 class _TableScrollContainer(_ThinScrollContainer):
@@ -273,7 +332,7 @@ class WorkflowDetailScreen(Screen):
                     rh.border_title = "Runs"
                     yield Static(id="run-history-header", classes="pane-header")
                     yield RunHistoryWidget(id="run-history-content")
-                with _ThinScrollContainer(id="dag-container") as dag_container:
+                with _DagScrollContainer(id="dag-container") as dag_container:
                     dag_container.border_title = "DAG"
                     dag_container.styles.height = "2fr"
                     yield DagWidget(id="dag-panel")

--- a/src/tui/widgets/log_panel.py
+++ b/src/tui/widgets/log_panel.py
@@ -63,6 +63,7 @@ class LogWidget(RichLog):
         self._test_store = None
         self._wrap_width = 0
         self._projection_key: tuple | None = None
+        self._logs_ref = None
         self._seen_log_count = 0
         self._visible_count = 0
         self._has_placeholder = False
@@ -95,29 +96,45 @@ class LogWidget(RichLog):
         """Append new entries or rebuild when the visible projection changes."""
         store = self._test_store or self.app.store
         selected_node = store.selected_node
+        node_statuses = store.node_statuses
         selected_status = (
-            store.node_statuses.get(selected_node.name, NodeStatus.PENDING)
-            if selected_node
-            else None
+            node_statuses.get(selected_node.name, NodeStatus.PENDING) if selected_node else None
+        )
+        status_projection = (
+            selected_status if selected_node else frozenset(node_statuses.items())
         )
         query = store.search_query
         projection_key = (
             store.current_run.run_id if store.current_run else None,
             selected_node.name if selected_node else None,
-            selected_status,
+            status_projection,
             query,
             store.search_index if query else -1,
             self._wrap_width,
         )
         logs = store.logs
+        snapshot_replaced = store.current_run is not None and logs is not self._logs_ref
+        replacement_changed = (
+            snapshot_replaced
+            and len(logs) == self._seen_log_count
+            and logs != self._logs_ref
+        )
 
-        if projection_key != self._projection_key or len(logs) < self._seen_log_count:
+        if (
+            projection_key != self._projection_key
+            or len(logs) < self._seen_log_count
+            or replacement_changed
+        ):
             self._projection_key = projection_key
             self._rebuild(store)
             return
 
+        if snapshot_replaced and len(logs) == self._seen_log_count:
+            self._logs_ref = logs
+
         if len(logs) > self._seen_log_count:
             new_entries = logs[self._seen_log_count :]
+            self._logs_ref = logs if store.current_run is not None else None
             self._seen_log_count = len(logs)
             if self._has_placeholder and any(
                 self._entry_visible(entry, selected_node) for entry in new_entries
@@ -133,6 +150,7 @@ class LogWidget(RichLog):
         self._match_lines.clear()
         self._visible_count = 0
         self._has_placeholder = False
+        self._logs_ref = store.logs if store.current_run is not None else None
         self._seen_log_count = len(store.logs)
 
         selected_node = store.selected_node
@@ -186,6 +204,7 @@ class LogWidget(RichLog):
             self._visible_count += 1
 
         if text:
+            text.remove_suffix("\n")
             self.write(text, shrink=False, scroll_end=False)
 
     @staticmethod
@@ -263,7 +282,7 @@ class LogWidget(RichLog):
 
     def _write_placeholder(self, message: str, style: Style) -> None:
         self._has_placeholder = True
-        self.write(Text(message + "\n", style=style), shrink=False, scroll_end=False)
+        self.write(Text(message, style=style), shrink=False, scroll_end=False)
 
     def scroll_to_match(self) -> None:
         """Scroll the current search match to the center of the viewport."""

--- a/src/tui/widgets/log_panel.py
+++ b/src/tui/widgets/log_panel.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from rich.style import Style
 from rich.text import Text
-from textual.widgets import Static
+from textual.widgets import RichLog
 
 from ..models import LogLevel, NodeStatus
 from ..theme import (
     DIM_STYLE,
-    ICE_BRIGHT,
     ICE_FROST,
     ICE_STEEL,
     ICE_WARN,
@@ -35,14 +34,38 @@ def _wrap_message(msg: str, wrap_width: int) -> list[str]:
     return [msg[i : i + avail] for i in range(0, len(msg), avail)]
 
 
-class LogWidget(Static):
-    """Renders logs — all logs with selected node's entries highlighted."""
+class LogWidget(RichLog):
+    """Virtualized log view that renders only visible terminal rows."""
+
+    DEFAULT_CSS = """
+    LogWidget {
+        width: 1fr;
+        height: 1fr;
+        min-width: 0;
+        scrollbar-size-vertical: 1;
+        scrollbar-size-horizontal: 1;
+        overflow-x: auto;
+        overflow-y: auto;
+        background: transparent;
+    }
+    """
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(
+            min_width=0,
+            wrap=False,
+            highlight=False,
+            markup=False,
+            auto_scroll=False,
+            **kwargs,
+        )
         self._match_lines: list[int] = []
         self._test_store = None
-        self.wrap_width: int = 0  # 0 = no wrap; >0 = wrap messages to this width
+        self._wrap_width = 0
+        self._projection_key: tuple | None = None
+        self._seen_log_count = 0
+        self._visible_count = 0
+        self._has_placeholder = False
 
     @staticmethod
     def render_header() -> Text:
@@ -53,125 +76,220 @@ class LogWidget(Static):
         text.append(f"{'Node':<19}", _HEADER_STYLE)
         text.append(f"{'Level':<7}", _HEADER_STYLE)
         text.append("Message", _HEADER_STYLE)
-        # 2 + 21 + 19 + 7 + 7 = 56 columns of header
         text.append("\n")
         text.append("  " + "─" * 54, DIM_STYLE)
         return text
 
-    def render(self) -> Text:
+    @property
+    def wrap_width(self) -> int:
+        return self._wrap_width
+
+    @wrap_width.setter
+    def wrap_width(self, value: int) -> None:
+        value = max(0, value)
+        if value != self._wrap_width:
+            self._wrap_width = value
+            self._projection_key = None
+
+    def sync_from_store(self) -> None:
+        """Append new entries or rebuild when the visible projection changes."""
         store = self._test_store or self.app.store
-        text = Text()
-
         selected_node = store.selected_node
-        node_statuses = store.node_statuses
+        selected_status = (
+            store.node_statuses.get(selected_node.name, NodeStatus.PENDING)
+            if selected_node
+            else None
+        )
+        query = store.search_query
+        projection_key = (
+            store.current_run.run_id if store.current_run else None,
+            selected_node.name if selected_node else None,
+            selected_status,
+            query,
+            store.search_index if query else -1,
+            self._wrap_width,
+        )
         logs = store.logs
-        search_query = store.search_query
-        search_current = store.search_index
-        frame = store.frame
 
-        # Status messages for specific node states
-        if selected_node:
-            status = node_statuses.get(selected_node.name, NodeStatus.PENDING)
-            if status == NodeStatus.PENDING:
-                text.append("  Waiting for dependencies…\n", DIM_STYLE)
-                return text
-            if status == NodeStatus.SKIPPED:
-                text.append("  Skipped — upstream dependency failed.\n", Style(color=ICE_WARN))
-                return text
+        if projection_key != self._projection_key or len(logs) < self._seen_log_count:
+            self._projection_key = projection_key
+            self._rebuild(store)
+            return
 
-        # Filter entries for selected node
-        visible = logs
-        if selected_node:
-            visible = [
-                e for e in logs
-                if e.node_id in (selected_node.name, selected_node.display_name)
-            ]
+        if len(logs) > self._seen_log_count:
+            new_entries = logs[self._seen_log_count :]
+            self._seen_log_count = len(logs)
+            if self._has_placeholder and any(
+                self._entry_visible(entry, selected_node) for entry in new_entries
+            ):
+                self._rebuild(store)
+                return
+            self._append_entries(new_entries, store)
 
-        if not visible and selected_node:
-            status = node_statuses.get(selected_node.name, NodeStatus.PENDING)
-            if status == NodeStatus.RUNNING:
-                text.append("  Starting…\n", DIM_STYLE)
-                return text
-
-        if not visible:
-            text.append("  No logs yet.\n", DIM_STYLE)
-            return text
-
-        # Render entries with search highlighting
-        self._match_lines.clear()
-        query = search_query.lower()
-
-        for line_idx, entry in enumerate(visible):
-            ts = entry.timestamp.strftime("%Y-%m-%d %H:%M:%S")
-            level_str = entry.level.value
-            node_status = node_statuses.get(entry.node_id, NodeStatus.PENDING)
-            ls = LOG_LEVEL_STYLES.get(entry.level, Style())
-            ns = STATUS_STYLES[node_status]
-            msg_style = ls if entry.level != LogLevel.INFO else Style(color=ICE_FROST)
-
-            full_line = f"{ts} {entry.node_id} {level_str} {entry.message}"
-            is_match = query and query in full_line.lower()
-            if is_match:
-                self._match_lines.append(line_idx)
-
-            is_current = is_match and search_current == len(self._match_lines) - 1
-
-            text.append("  ")
-            node_padded = f"{entry.node_id:<17}"
-            level_padded = f"{level_str:<5}"
-
-            msg_chunks = _wrap_message(entry.message, self.wrap_width)
-
-            if is_match:
-                self._append_highlighted(text, f"{ts}  ", query, DIM_STYLE, is_current)
-                self._append_highlighted(text, node_padded, query, ns, is_current)
-                text.append("  ")
-                self._append_highlighted(text, level_padded, query, ls, is_current)
-                text.append("  ")
-                self._append_highlighted(text, msg_chunks[0], query, msg_style, is_current)
-                text.append("\n")
-                for chunk in msg_chunks[1:]:
-                    text.append(" " * _MSG_PREFIX_WIDTH)
-                    self._append_highlighted(text, chunk, query, msg_style, is_current)
-                    text.append("\n")
-            else:
-                text.append(f"{ts}  ", DIM_STYLE)
-                text.append(node_padded, ns)
-                text.append(f"  {level_padded}  ", ls)
-                text.append(f"{msg_chunks[0]}\n", msg_style)
-                for chunk in msg_chunks[1:]:
-                    text.append(" " * _MSG_PREFIX_WIDTH)
-                    text.append(f"{chunk}\n", msg_style)
-
-        # Blinking cursor if selected node is running
-        if selected_node and not query:
-            status = node_statuses.get(selected_node.name, NodeStatus.PENDING)
-            if status == NodeStatus.RUNNING:
-                if int(frame / 5) % 2 == 0:
-                    text.append("  █\n", Style(color=ICE_BRIGHT))
-
-        # Write back match count for StatusBar
         store.set_match_count(len(self._match_lines))
 
-        return text
+    def _rebuild(self, store) -> None:
+        self.clear()
+        self._match_lines.clear()
+        self._visible_count = 0
+        self._has_placeholder = False
+        self._seen_log_count = len(store.logs)
 
-    def on_click(self, event) -> None:
-        store = self._test_store or self.app.store
-        store.focused_pane = "log"
+        selected_node = store.selected_node
+        if selected_node:
+            status = store.node_statuses.get(selected_node.name, NodeStatus.PENDING)
+            if status == NodeStatus.PENDING:
+                self._write_placeholder("  Waiting for dependencies…", DIM_STYLE)
+                store.set_match_count(0)
+                return
+            if status == NodeStatus.SKIPPED:
+                self._write_placeholder(
+                    "  Skipped — upstream dependency failed.",
+                    Style(color=ICE_WARN),
+                )
+                store.set_match_count(0)
+                return
 
-    _HEADER_LINES = 0  # headers now in separate widget
+        self._append_entries(store.logs, store)
+        if self._visible_count == 0:
+            status = (
+                store.node_statuses.get(selected_node.name, NodeStatus.PENDING)
+                if selected_node
+                else None
+            )
+            if status == NodeStatus.RUNNING:
+                self._write_placeholder("  Starting…", DIM_STYLE)
+            elif selected_node is None:
+                self._write_placeholder("  No logs yet.", DIM_STYLE)
+
+        store.set_match_count(len(self._match_lines))
+
+    def _append_entries(self, entries, store) -> None:
+        selected_node = store.selected_node
+        query = store.search_query.lower()
+        node_statuses = store.node_statuses
+        text = Text()
+        line_count = 0
+        first_line = len(self.lines)
+
+        for entry in entries:
+            if not self._entry_visible(entry, selected_node):
+                continue
+            line_count += self._append_entry(
+                text,
+                entry,
+                query,
+                store.search_index,
+                node_statuses,
+                first_line + line_count,
+            )
+            self._visible_count += 1
+
+        if text:
+            self.write(text, shrink=False, scroll_end=False)
+
+    @staticmethod
+    def _entry_visible(entry, selected_node) -> bool:
+        return selected_node is None or entry.node_id in (
+            selected_node.name,
+            selected_node.display_name,
+        )
+
+    def _append_entry(
+        self,
+        text: Text,
+        entry,
+        query: str,
+        search_index: int,
+        node_statuses,
+        first_line: int,
+    ) -> int:
+        ts = entry.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+        level_str = entry.level.value
+        node_status = node_statuses.get(entry.node_id, NodeStatus.PENDING)
+        level_style = LOG_LEVEL_STYLES.get(entry.level, Style())
+        node_style = STATUS_STYLES[node_status]
+        message_style = level_style if entry.level != LogLevel.INFO else Style(color=ICE_FROST)
+        full_line = f"{ts} {entry.node_id} {level_str} {entry.message}"
+        is_match = bool(query and query in full_line.lower())
+        match_index = len(self._match_lines)
+        is_current = is_match and search_index == match_index
+
+        if is_match:
+            self._match_lines.append(first_line)
+
+        chunks = _wrap_message(entry.message, self._wrap_width)
+        self._append_field(text, "  ", query, None, is_current)
+        self._append_field(text, f"{ts}  ", query, DIM_STYLE, is_current)
+        self._append_field(
+            text,
+            f"{entry.node_id:<17}",
+            query,
+            node_style,
+            is_current,
+        )
+        self._append_field(text, "  ", query, None, is_current)
+        self._append_field(
+            text,
+            f"{level_str:<5}",
+            query,
+            level_style,
+            is_current,
+        )
+        self._append_field(text, "  ", query, None, is_current)
+        self._append_field(text, chunks[0], query, message_style, is_current)
+        text.append("\n")
+
+        for chunk in chunks[1:]:
+            text.append(" " * _MSG_PREFIX_WIDTH)
+            self._append_field(text, chunk, query, message_style, is_current)
+            text.append("\n")
+
+        return len(chunks)
+
+    @classmethod
+    def _append_field(
+        cls,
+        text: Text,
+        value: str,
+        query: str,
+        style: Style | None,
+        is_current: bool,
+    ) -> None:
+        if query and query in value.lower():
+            cls._append_highlighted(text, value, query, style or Style(), is_current)
+        else:
+            text.append(value, style)
+
+    def _write_placeholder(self, message: str, style: Style) -> None:
+        self._has_placeholder = True
+        self.write(Text(message + "\n", style=style), shrink=False, scroll_end=False)
 
     def scroll_to_match(self) -> None:
-        """Scroll the parent container so the current search match is centered."""
+        """Scroll the current search match to the center of the viewport."""
         store = self._test_store or self.app.store
         if store.search_index < 0 or store.search_index >= len(self._match_lines):
             return
         line = self._match_lines[store.search_index]
-        y = self._HEADER_LINES + line
-        container = self.parent
-        if container is not None:
-            half = container.content_size.height // 2
-            container.scroll_to(y=max(0, y - half), animate=False)
+        self.scroll_to(y=max(0, line - self.size.height // 2), animate=False)
+
+    def watch_scroll_x(self, old_value: float, new_value: float) -> None:
+        super().watch_scroll_x(old_value, new_value)
+        try:
+            self.screen.query_one("#log-header").styles.offset = (-new_value, 0)
+        except Exception:
+            pass
+
+    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        super().watch_scroll_y(old_value, new_value)
+        try:
+            self.app._log_autoscroll = new_value >= self.max_scroll_y - 1
+        except Exception:
+            pass
+
+    def on_click(self, event) -> None:
+        store = self._test_store or self.app.store
+        store.focused_pane = "log"
 
     @staticmethod
     def _append_highlighted(
@@ -182,15 +300,15 @@ class LogWidget(Static):
         is_current: bool,
     ) -> None:
         """Append msg with search matches highlighted."""
-        hl = SEARCH_CURRENT if is_current else SEARCH_HIGHLIGHT
+        highlight = SEARCH_CURRENT if is_current else SEARCH_HIGHLIGHT
         lower = msg.lower()
-        pos = 0
-        while pos < len(msg):
-            idx = lower.find(query, pos)
-            if idx == -1:
-                text.append(msg[pos:], base_style)
+        position = 0
+        while position < len(msg):
+            index = lower.find(query, position)
+            if index == -1:
+                text.append(msg[position:], base_style)
                 break
-            if idx > pos:
-                text.append(msg[pos:idx], base_style)
-            text.append(msg[idx:idx + len(query)], hl)
-            pos = idx + len(query)
+            if index > position:
+                text.append(msg[position:index], base_style)
+            text.append(msg[index : index + len(query)], highlight)
+            position = index + len(query)

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -1709,6 +1709,163 @@ class TestLogTimestamps:
             assert "2026-03-27 14:35:01" in rendered
 
 
+class TestVirtualizedLogs:
+    @staticmethod
+    def _entry(node_id: str, message: str) -> LogEntry:
+        return LogEntry(
+            timestamp=datetime(2026, 3, 27, 14, 35, 1),
+            level=LogLevel.INFO,
+            node_id=node_id,
+            message=message,
+        )
+
+    @pytest.mark.asyncio
+    async def test_equal_cardinality_snapshot_replacement_is_rendered(self):
+        from avalanche.tui.app import AvalancheApp
+        from avalanche.tui.widgets.log_panel import LogWidget
+
+        app = AvalancheApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app._timer.pause()
+            node_id = next(iter(app.store.current_run.nodes))
+            app.store.current_run = replace(
+                app.store.current_run,
+                logs=[
+                    self._entry(node_id, "old first"),
+                    self._entry(node_id, "old second"),
+                ],
+            )
+            app._refresh_widgets()
+
+            app.store.current_run = replace(
+                app.store.current_run,
+                logs=[
+                    self._entry(node_id, "new first"),
+                    self._entry(node_id, "new second"),
+                ],
+            )
+            app._refresh_widgets()
+            log_view = app._screen.query_one("#log-content", LogWidget)
+            rendered = "\n".join(line.text for line in log_view.lines)
+
+            assert "new first" in rendered
+            assert "new second" in rendered
+            assert "old first" not in rendered
+            assert "old second" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_existing_rows_restyle_when_node_status_changes(self):
+        from avalanche.tui.app import AvalancheApp
+        from avalanche.tui.theme import STATUS_STYLES
+        from avalanche.tui.widgets.log_panel import LogWidget
+
+        app = AvalancheApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app._timer.pause()
+            node_id = next(iter(app.store.current_run.nodes))
+            logs = [self._entry(node_id, "status-sensitive")]
+            nodes = dict(app.store.current_run.nodes)
+            nodes[node_id] = replace(nodes[node_id], status=NodeStatus.RUNNING)
+            app.store.current_run = replace(app.store.current_run, logs=logs, nodes=nodes)
+            app._refresh_widgets()
+
+            nodes = dict(app.store.current_run.nodes)
+            nodes[node_id] = replace(nodes[node_id], status=NodeStatus.SUCCESS)
+            app.store.current_run = replace(app.store.current_run, nodes=nodes)
+            app._refresh_widgets()
+            log_view = app._screen.query_one("#log-content", LogWidget)
+            node_segment = next(
+                segment
+                for line in log_view.lines
+                for segment in line._segments
+                if node_id in segment.text
+            )
+
+            assert node_segment.style == STATUS_STYLES[NodeStatus.SUCCESS]
+
+    @pytest.mark.asyncio
+    async def test_incremental_append_adds_exactly_one_row(self):
+        from avalanche.tui.app import AvalancheApp
+        from avalanche.tui.widgets.log_panel import LogWidget
+
+        app = AvalancheApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app._timer.pause()
+            node_id = next(iter(app.store.current_run.nodes))
+            logs = [self._entry(node_id, "first")]
+            app.store.current_run = replace(app.store.current_run, logs=logs)
+            app._refresh_widgets()
+            log_view = app._screen.query_one("#log-content", LogWidget)
+            initial_rows = len(log_view.lines)
+
+            logs.append(self._entry(node_id, "second"))
+            app._refresh_widgets()
+
+            assert initial_rows == 1
+            assert len(log_view.lines) == initial_rows + 1
+            assert [line.text.endswith(("first", "second")) for line in log_view.lines] == [
+                True,
+                True,
+            ]
+
+    @pytest.mark.asyncio
+    async def test_equivalent_snapshot_and_append_retain_prefix_without_rebuild(self):
+        from avalanche.tui.app import AvalancheApp
+        from avalanche.tui.widgets.log_panel import LogWidget
+
+        app = AvalancheApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app._timer.pause()
+            node_id = next(iter(app.store.current_run.nodes))
+            initial_logs = [self._entry(node_id, "first")]
+            app.store.current_run = replace(app.store.current_run, logs=initial_logs)
+            app._refresh_widgets()
+            log_view = app._screen.query_one("#log-content", LogWidget)
+            initial_prefix = list(log_view.lines)
+            rebuilds = 0
+            original_rebuild = log_view._rebuild
+
+            def count_rebuilds(store):
+                nonlocal rebuilds
+                rebuilds += 1
+                original_rebuild(store)
+
+            log_view._rebuild = count_rebuilds
+            app.store.current_run = replace(
+                app.store.current_run,
+                logs=list(initial_logs),
+            )
+            app._refresh_widgets()
+
+            assert rebuilds == 0
+            assert all(
+                rendered is initial
+                for rendered, initial in zip(
+                    log_view.lines, initial_prefix, strict=True
+                )
+            )
+
+            app.store.current_run = replace(
+                app.store.current_run,
+                logs=[*initial_logs, self._entry(node_id, "second")],
+            )
+            app._refresh_widgets()
+
+            assert rebuilds == 0
+            assert len(log_view.lines) == len(initial_prefix) + 1
+            assert all(
+                rendered is initial
+                for rendered, initial in zip(
+                    log_view.lines[: len(initial_prefix)], initial_prefix, strict=True
+                )
+            )
+            assert log_view.lines[-1].text.endswith("second")
+
+
 # ── Headless interaction tests (Textual pilot) ────────────────────────────
 
 
@@ -2198,42 +2355,73 @@ class TestInteractions:
             assert dag_scroll.styles.overflow_y == "auto"
 
     async def test_dag_pointer_scroll_accumulates_smoothly(self):
-        """Rapid pointer events should accumulate into one animated target."""
-        from textual.events import MouseScrollRight
+        """Pointer scroll routes by axis/modifier and stays within boundaries."""
+        from textual.events import (
+            MouseScrollDown,
+            MouseScrollLeft,
+            MouseScrollRight,
+            MouseScrollUp,
+        )
 
         from avalanche.tui.app import AvalancheApp
 
         app = AvalancheApp(workflow="ml_workflow")
-        async with app.run_test(size=(50, 40)) as pilot:
+        async with app.run_test(size=(50, 15)) as pilot:
             await pilot.pause()
             app._timer.pause()
             dag_scroll = app._screen.query_one("#dag-container")
             assert dag_scroll.max_scroll_x > 0
+            assert dag_scroll.max_scroll_y > 0
 
-            def scroll_right() -> None:
-                dag_scroll._on_mouse_scroll_right(
-                    MouseScrollRight(
-                        dag_scroll,
-                        x=10,
-                        y=5,
-                        delta_x=0,
-                        delta_y=1,
-                        button=0,
-                        shift=False,
-                        meta=False,
-                        ctrl=False,
-                    )
+            def pointer_event(event_type, *, shift=False, ctrl=False):
+                return event_type(
+                    dag_scroll,
+                    x=10,
+                    y=5,
+                    delta_x=0,
+                    delta_y=1,
+                    button=0,
+                    shift=shift,
+                    meta=False,
+                    ctrl=ctrl,
                 )
 
-            scroll_right()
+            dag_scroll._on_mouse_scroll_right(pointer_event(MouseScrollRight))
             assert dag_scroll.scroll_target_x == 8
             assert dag_scroll.scroll_x < dag_scroll.scroll_target_x
 
-            scroll_right()
+            dag_scroll._on_mouse_scroll_right(pointer_event(MouseScrollRight))
+            assert dag_scroll.scroll_target_x == 16
+
+            dag_scroll._on_mouse_scroll_left(pointer_event(MouseScrollLeft))
+            assert dag_scroll.scroll_target_x == 8
+
+            await pilot.pause(0.12)
+            assert dag_scroll.scroll_x == pytest.approx(8)
+
+            dag_scroll._on_mouse_scroll_down(pointer_event(MouseScrollDown))
+            assert dag_scroll.scroll_target_y == 3
+
+            await pilot.pause(0.12)
+            assert dag_scroll.scroll_y == pytest.approx(3)
+
+            dag_scroll._on_mouse_scroll_down(pointer_event(MouseScrollDown, shift=True))
             assert dag_scroll.scroll_target_x == 16
 
             await pilot.pause(0.12)
             assert dag_scroll.scroll_x == pytest.approx(16)
+
+            dag_scroll._on_mouse_scroll_up(pointer_event(MouseScrollUp, ctrl=True))
+            assert dag_scroll.scroll_target_x == 8
+
+            await pilot.pause(0.12)
+            assert dag_scroll.scroll_x == pytest.approx(8)
+
+            dag_scroll._scroll_to(x=0, y=0, animate=False)
+            dag_scroll._on_mouse_scroll_left(pointer_event(MouseScrollLeft))
+            dag_scroll._on_mouse_scroll_up(pointer_event(MouseScrollUp))
+            assert dag_scroll.scroll_target_x == 0
+            assert dag_scroll.scroll_target_y == 0
 
     async def test_dag_center_button_exists(self):
         """DAG pane should have a center button."""
@@ -2375,6 +2563,46 @@ class TestInteractions:
                 assert w.scroll_x == 0, (
                     f"{pane}: left/right arrows should not scroll horizontally"
                 )
+
+    async def test_focused_log_up_down_scrolls_log_content(self):
+        """Up/down in the log pane should scroll the actual RichLog."""
+        from avalanche.tui.app import AvalancheApp
+        from avalanche.tui.widgets.log_panel import LogWidget
+
+        app = AvalancheApp()
+        async with app.run_test(size=(80, 20)) as pilot:
+            await pilot.pause()
+            app._timer.pause()
+            node_id = next(iter(app.store.current_run.nodes))
+            app.store.current_run = replace(
+                app.store.current_run,
+                logs=[
+                    LogEntry(
+                        timestamp=datetime(2026, 3, 27, 14, 35, index),
+                        level=LogLevel.INFO,
+                        node_id=node_id,
+                        message=f"line {index}",
+                    )
+                    for index in range(30)
+                ],
+            )
+            app.store.focused_pane = "log"
+            app._log_autoscroll = False
+            app._refresh_widgets()
+            await pilot.pause()
+            log_view = app._screen.query_one("#log-content", LogWidget)
+            log_view.scroll_end(animate=False)
+            await pilot.pause()
+            bottom = log_view.scroll_y
+            assert bottom > 0
+
+            await pilot.press("up")
+            await pilot.pause()
+            assert log_view.scroll_y < bottom
+
+            await pilot.press("down")
+            await pilot.pause()
+            assert log_view.scroll_y == bottom
 
     async def test_left_right_move_dag_nodes_from_any_pane(self):
         """Left/right should drive DAG selection even when another pane is focused."""

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -1683,24 +1683,30 @@ class TestLogTimestamps:
         )
         assert isinstance(entry.timestamp, datetime)
 
-    def test_log_panel_renders_datetime(self):
+    @pytest.mark.asyncio
+    async def test_log_panel_renders_datetime(self):
+        from avalanche.tui.app import AvalancheApp
         from avalanche.tui.widgets.log_panel import LogWidget
-        store = UIStore(MockStateProvider())
-        _apply_async_updates(store)
-        # Add a log entry with known timestamp
-        if store.current_run:
-            store.current_run.logs.append(
+
+        app = AvalancheApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app._timer.pause()
+            app.store.run_pinned = True
+            app.store.current_run.logs.append(
                 LogEntry(
                     timestamp=datetime(2026, 3, 27, 14, 35, 1),
                     level=LogLevel.INFO,
-                    node_id=store.all_nodes[0].name,
+                    node_id=app.store.all_nodes[0].name,
                     message="Starting...",
                 )
             )
-        w = LogWidget()
-        w._test_store = store
-        rendered = w.render().plain
-        assert "2026-03-27 14:35:01" in rendered
+            app._tick()
+            await app.wait_for_refresh()
+
+            log_view = app._screen.query_one("#log-content", LogWidget)
+            rendered = "\n".join(line.text for line in log_view.lines)
+            assert "2026-03-27 14:35:01" in rendered
 
 
 # ── Headless interaction tests (Textual pilot) ────────────────────────────
@@ -2148,7 +2154,7 @@ class TestInteractions:
                 await pilot.pause()
 
             # Verify our CSS is at least being applied
-            for widget_id in ("#run-history", "#dag-container", "#log-panel"):
+            for widget_id in ("#run-history", "#dag-container", "#log-content"):
                 w = app._screen.query_one(widget_id)
                 assert w.styles.scrollbar_size_vertical == 1, (
                     f"{widget_id} scrollbar_size_vertical={w.styles.scrollbar_size_vertical}"
@@ -2170,7 +2176,7 @@ class TestInteractions:
                 app._tick()
                 await pilot.pause()
 
-            lp = app._screen.query_one("#log-panel")
+            lp = app._screen.query_one("#log-content")
 
             # Container must support horizontal scrolling
             assert lp.styles.overflow_x == "auto"

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -2197,6 +2197,44 @@ class TestInteractions:
             assert dag_scroll.styles.overflow_x == "auto"
             assert dag_scroll.styles.overflow_y == "auto"
 
+    async def test_dag_pointer_scroll_accumulates_smoothly(self):
+        """Rapid pointer events should accumulate into one animated target."""
+        from textual.events import MouseScrollRight
+
+        from avalanche.tui.app import AvalancheApp
+
+        app = AvalancheApp(workflow="ml_workflow")
+        async with app.run_test(size=(50, 40)) as pilot:
+            await pilot.pause()
+            app._timer.pause()
+            dag_scroll = app._screen.query_one("#dag-container")
+            assert dag_scroll.max_scroll_x > 0
+
+            def scroll_right() -> None:
+                dag_scroll._on_mouse_scroll_right(
+                    MouseScrollRight(
+                        dag_scroll,
+                        x=10,
+                        y=5,
+                        delta_x=0,
+                        delta_y=1,
+                        button=0,
+                        shift=False,
+                        meta=False,
+                        ctrl=False,
+                    )
+                )
+
+            scroll_right()
+            assert dag_scroll.scroll_target_x == 8
+            assert dag_scroll.scroll_x < dag_scroll.scroll_target_x
+
+            scroll_right()
+            assert dag_scroll.scroll_target_x == 16
+
+            await pilot.pause(0.12)
+            assert dag_scroll.scroll_x == pytest.approx(16)
+
     async def test_dag_center_button_exists(self):
         """DAG pane should have a center button."""
         app = await self._make_app()


### PR DESCRIPTION
## Summary
- virtualize log rendering so refresh cost is bounded by the visible viewport
- append replacement-snapshot log updates incrementally while rebuilding changed, truncated, filtered, or restyled projections
- preserve search, wrapping, autoscroll, horizontal scrolling, and node-status styling
- route focused Up/Down navigation to the actual RichLog scroll owner
- avoid terminal-newline blank rows in incremental and placeholder writes
- make DAG pointer scrolling cumulative and smoothly animated for native horizontal and shift-wheel events
- add an enforcing `make tui-bench` replacement-snapshot benchmark

## Performance
The benchmark replaces the run/log snapshot on every sample and measures the visible-widget refresh path without mock-provider polling overwriting the synthetic snapshot.

At 10,000 log rows with a 33.3 ms frame budget:
- equivalent replacement snapshot p95: 17.50 ms
- replacement append at 10,030 rows p95: 17.71 ms
- previous full refresh p95: approximately 1,164 ms

DAG native horizontal pointer scrolling:
- first-paint p50: 16.62 ms
- first-paint p95: 17.75 ms
- each event accumulates an 8-column target

## Verification
- `make tui-bench` — all 100–10,000-row steady and append scenarios passed
- `uv run pytest test/tui_test.py -q` — 146 passed
- `uv run pytest test/tui_tmux_test.py -q` — 7 passed
- `make lint` — passed
- `git diff --check` — passed
- full local suite — 816 passed, 2 skipped; one unrelated Ray fire-and-forget test failed once and passed twice in isolated reruns
- fresh read-only closure review — APPROVE WITH NITS, no blockers
