### PR TITLE
Add typed cardinality-aware model streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
   and read back as validated models via `read_models()`.
 - `ava.AppendResult` is generic over the row model and adds `to_models()`,
   `one()` (asserts exactly-one-row cardinality), and `one_or_none()`.
+- `ava.ModelStream.one()`, `one_or_none()`, and `all()` inject validated row
+  models at workflow stream boundaries with explicit cardinality contracts and
+  contextual errors, while preserving passthrough, table-backed, Ray, and rerun
+  behavior.
 - New `ava.input.<field>` build-time placeholder for feeding validated run
   input into any node's arguments.
 - Fix: futures passed explicitly as keyword arguments are no longer re-bound

--- a/docs/data-model-api.md
+++ b/docs/data-model-api.md
@@ -97,6 +97,41 @@ model accessors to the frame accessors:
 Row provenance columns (`_ava_*`) behave identically to DataFramely-schema'd
 tables, and DataFramely remains fully supported for dataframe-native pipelines.
 
+Use `ava.ModelStream` at workflow boundaries to inject row models instead of a
+Polars DataFrame:
+
+```python
+@ava.step
+def greet(person: Person = ava.ModelStream.one(ns.people)) -> str:
+    return f"Hello, {person.name}"
+
+
+@ava.step
+def maybe_greet(
+    person: Person | None = ava.ModelStream.one_or_none(ns.people),
+) -> str | None:
+    return None if person is None else f"Hello, {person.name}"
+
+
+@ava.step
+def greet_everyone(
+    people: list[Person] = ava.ModelStream.all(ns.people),
+) -> list[str]:
+    return [f"Hello, {person.name}" for person in people]
+```
+
+`one()` requires exactly one row. `one_or_none()` returns `None` for zero rows
+and rejects multiple rows. `all()` returns validated models in stable row order,
+including an empty list for zero rows. These providers require a table declared
+with a Pydantic model schema. Framework-owned `_ava_*` provenance columns are
+removed from the model boundary internally. Cardinality and validation errors
+include the table, workflow run, and upstream source node when available.
+
+`ModelStream` supports the same durable options as `Stream`, for example
+`ava.ModelStream.all(table, key="people_to_greet", mode="append_scan")`.
+Passthrough, table-backed, local, distributed, and rerun execution preserve the
+same read and progress semantics described below.
+
 ## Iceberg namespace
 
 An Iceberg namespace groups declared tables under one catalog namespace and base

--- a/src/avalanche/__init__.py
+++ b/src/avalanche/__init__.py
@@ -50,6 +50,7 @@ from .runtime import (  # noqa: F401
     Cursor,
     File,
     Logger,
+    ModelStream,
     Rerun,
     RunContext,
     S3File,
@@ -120,6 +121,7 @@ __all__ = [
     "RunHandle",
     "S3File",
     "Stream",
+    "ModelStream",
     "Logger",
     "consume_stream",
     # Progress

--- a/src/avalanche/_testing/model_stream_helpers.py
+++ b/src/avalanche/_testing/model_stream_helpers.py
@@ -1,0 +1,36 @@
+"""Importable functions and models for distributed ModelStream tests."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelStreamRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    name: str
+
+
+def append_passthrough_people(*, people):
+    return people.append(
+        [ModelStreamRow(id=2, name="second"), ModelStreamRow(id=1, name="first")]
+    )
+
+
+def append_rerun_people(*, people):
+    return people.append(
+        [ModelStreamRow(id=3, name="third"), ModelStreamRow(id=4, name="fourth")]
+    )
+
+
+def collect_model_pairs(people: list[ModelStreamRow]) -> list[tuple[int, str]]:
+    return [(person.id, person.name) for person in people]
+
+
+def collect_model_names(people: list[ModelStreamRow]) -> list[str]:
+    return [person.name for person in people]
+
+
+def return_model(person: ModelStreamRow) -> ModelStreamRow:
+    return person

--- a/src/avalanche/runtime/__init__.py
+++ b/src/avalanche/runtime/__init__.py
@@ -17,7 +17,7 @@ from .context import (
     run_with_context,
 )
 from .cursor import Cursor
-from .providers import Logger, LoggerInstance, Stream, consume_stream
+from .providers import Logger, LoggerInstance, ModelStream, Stream, consume_stream
 
 __all__ = [
     "BaseContext",
@@ -32,6 +32,7 @@ __all__ = [
     "get_current_run_context",
     "run_with_context",
     "Stream",
+    "ModelStream",
     "consume_stream",
     "Logger",
     "LoggerInstance",

--- a/src/avalanche/runtime/providers/__init__.py
+++ b/src/avalanche/runtime/providers/__init__.py
@@ -6,10 +6,11 @@ protocol. Providers can be registered in the DAG for automatic resolution.
 """
 
 from .logger import Logger, LoggerInstance
-from .stream import Stream, consume_stream
+from .stream import ModelStream, Stream, consume_stream
 
 __all__ = [
     "Stream",
+    "ModelStream",
     "consume_stream",
     "Logger",
     "LoggerInstance",
@@ -18,6 +19,7 @@ __all__ = [
 # Provider registry for DAG execution
 # Add new providers here as they're implemented
 PROVIDERS = [
+    ModelStream,
     Stream,
     Logger,
 ]

--- a/src/avalanche/runtime/providers/stream.py
+++ b/src/avalanche/runtime/providers/stream.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Generator, Generic, Literal, TypeVar
 
 import polars as pl
+from pydantic import BaseModel
 from pyiceberg.exceptions import CommitFailedException
 
 from avalanche.types import ParamContext, ParameterProvider
@@ -24,13 +25,25 @@ if TYPE_CHECKING:
     from avalanche.types import AppendResult
 
 T = TypeVar("T")
+ModelT = TypeVar("ModelT", bound=BaseModel)
 
 StreamMode = Literal["run_scoped", "append_scan"]
+ModelStreamCardinality = Literal["one", "one_or_none", "all"]
 
 
 def _table_identity(table: Any) -> str | None:
     """Best-effort stable identity for a storage table (Iceberg id / location)."""
     return getattr(table, "identifier", None) or getattr(table, "location", None) or None
+
+def _table_label(table: Any) -> str:
+    """Human-readable table identity for model-stream errors."""
+    identity = _table_identity(table)
+    if identity:
+        return str(identity)
+    table_name = getattr(table, "_table_name", None)
+    if table_name:
+        return str(table_name)
+    return type(table).__name__
 
 
 def _is_executor_ref(value: Any, executor: Any) -> bool:
@@ -235,6 +248,12 @@ class Stream(ParameterProvider, Generic[T]):
     def __repr__(self) -> str:
         return f"Stream(table={self.table}, key={self.key!r}, mode={self.mode!r})"
 
+    def _materialize(
+        self, df: pl.DataFrame, source_node_slugs: tuple[str, ...]
+    ) -> pl.DataFrame:
+        """Project the consumed frame into the value injected into user code."""
+        return df
+
     # ParameterProvider protocol implementation (class methods for registry use)
     @classmethod
     def can_resolve(cls, param_value: Any) -> bool:
@@ -333,16 +352,18 @@ class Stream(ParameterProvider, Generic[T]):
                     upstream_data=upstream_data,
                     source_node_slugs=source_node_slugs,
                 )
-                context_managers.append((param_name, cm))
+                context_managers.append((param_name, stream, source_node_slugs, cm))
 
             # Enter contexts and collect DataFrames
             entered_contexts = []
             try:
                 resolved_streams = {}
-                for param_name, cm in context_managers:
+                for param_name, stream, source_node_slugs, cm in context_managers:
                     df = cm.__enter__()
                     entered_contexts.append(cm)
-                    resolved_streams[param_name] = df
+                    resolved_streams[param_name] = stream._materialize(
+                        df, source_node_slugs
+                    )
 
                 # Update kwargs with resolved streams
                 kwargs.update(resolved_streams)
@@ -380,6 +401,118 @@ class Stream(ParameterProvider, Generic[T]):
                 return result
 
         return stream_wrapper
+
+class ModelStream(Stream[ModelT], Generic[ModelT]):
+    """Stream provider that injects validated pydantic row models."""
+
+    cardinality: ModelStreamCardinality
+
+    def __init__(
+        self,
+        table: "IcebergTable | Table",
+        *,
+        cardinality: ModelStreamCardinality,
+        key: str | None = None,
+        mode: StreamMode = "run_scoped",
+    ):
+        if getattr(table, "row_model", None) is None:
+            raise TypeError(
+                "ModelStream requires a table declared with a pydantic model schema; "
+                f"table={_table_label(table)!r}."
+            )
+        super().__init__(table, key=key, mode=mode)
+        self.cardinality = cardinality
+
+    @classmethod
+    def one(
+        cls,
+        table: "IcebergTable | Table",
+        *,
+        key: str | None = None,
+        mode: StreamMode = "run_scoped",
+    ) -> "ModelStream[ModelT]":
+        """Inject exactly one validated row model."""
+        return cls(table, cardinality="one", key=key, mode=mode)
+
+    @classmethod
+    def one_or_none(
+        cls,
+        table: "IcebergTable | Table",
+        *,
+        key: str | None = None,
+        mode: StreamMode = "run_scoped",
+    ) -> "ModelStream[ModelT]":
+        """Inject one validated row model, or None when no rows exist."""
+        return cls(table, cardinality="one_or_none", key=key, mode=mode)
+
+    @classmethod
+    def all(
+        cls,
+        table: "IcebergTable | Table",
+        *,
+        key: str | None = None,
+        mode: StreamMode = "run_scoped",
+    ) -> "ModelStream[ModelT]":
+        """Inject all validated row models in stable table order."""
+        return cls(table, cardinality="all", key=key, mode=mode)
+
+    def __repr__(self) -> str:
+        return (
+            f"ModelStream.{self.cardinality}(table={self.table}, key={self.key!r}, "
+            f"mode={self.mode!r})"
+        )
+
+    @classmethod
+    def can_resolve(cls, param_value: Any) -> bool:
+        """Resolve only model streams; Stream handles dataframe streams."""
+        return isinstance(param_value, cls)
+
+    def _materialize(
+        self, df: pl.DataFrame, source_node_slugs: tuple[str, ...]
+    ) -> ModelT | None | list[ModelT]:
+        from avalanche.model_frame import arrow_to_models
+        from avalanche.runtime import get_current_run_context
+
+        context = get_current_run_context()
+        details = [f"table={_table_label(self.table)!r}"]
+        if context is not None:
+            details.extend(
+                (
+                    f"workflow={context.workflow_name!r}",
+                    f"run_id={context.run_id!r}",
+                )
+            )
+        if len(source_node_slugs) == 1:
+            details.append(f"source_node={source_node_slugs[0]!r}")
+        elif source_node_slugs:
+            details.append(f"source_nodes={source_node_slugs!r}")
+        error_context = ", ".join(details)
+
+        row_count = df.height
+        if self.cardinality == "one" and row_count != 1:
+            raise ValueError(
+                "ModelStream.one expected exactly one row; "
+                f"got {row_count} rows ({error_context})."
+            )
+        if self.cardinality == "one_or_none":
+            if row_count == 0:
+                return None
+            if row_count > 1:
+                raise ValueError(
+                    "ModelStream.one_or_none expected at most one row; "
+                    f"got {row_count} rows ({error_context})."
+                )
+
+        try:
+            models = arrow_to_models(df, self.table.row_model)
+        except Exception as exc:
+            raise ValueError(
+                f"ModelStream failed to validate rows ({error_context}): {exc}"
+            ) from exc
+
+        if self.cardinality == "all":
+            return models
+        return models[0]
 
 
 @contextmanager

--- a/test/model_stream_test.py
+++ b/test/model_stream_test.py
@@ -1,0 +1,248 @@
+"""Typed, cardinality-aware ModelStream provider contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import polars as pl
+import pytest
+
+import avalanche as ava
+from avalanche._testing.model_stream_helpers import (
+    ModelStreamRow as ModelRow,
+)
+from avalanche._testing.model_stream_helpers import (
+    append_passthrough_people,
+    append_rerun_people,
+    collect_model_names,
+    collect_model_pairs,
+    return_model,
+)
+from avalanche.iceberg import IcebergNs, IcebergNsConfig, IcebergTable
+from avalanche.runtime import run_with_context
+from avalanche.runtime.providers import PROVIDERS
+
+
+class _ModelTable:
+    row_model = ModelRow
+    identifier = "models.people"
+
+
+@pytest.mark.parametrize(
+    ("factory", "rows", "expected"),
+    [
+        (ava.ModelStream.one, [(1, "one")], ModelRow(id=1, name="one")),
+        (ava.ModelStream.one_or_none, [], None),
+        (ava.ModelStream.one_or_none, [(1, "one")], ModelRow(id=1, name="one")),
+        (ava.ModelStream.all, [], []),
+        (ava.ModelStream.all, [(2, "second")], [ModelRow(id=2, name="second")]),
+        (
+            ava.ModelStream.all,
+            [(2, "second"), (1, "first")],
+            [ModelRow(id=2, name="second"), ModelRow(id=1, name="first")],
+        ),
+    ],
+)
+def test_model_stream_materializes_each_cardinality_in_stable_order(factory, rows, expected):
+    frame = pl.DataFrame(
+        {
+            "id": [row[0] for row in rows],
+            "name": [row[1] for row in rows],
+            "_ava_run_id": ["source-run"] * len(rows),
+            "_ava_node_slug": ["load-people"] * len(rows),
+        },
+        schema={
+            "id": pl.Int64,
+            "name": pl.String,
+            "_ava_run_id": pl.String,
+            "_ava_node_slug": pl.String,
+        },
+    )
+
+    stream = factory(_ModelTable())
+
+    assert stream._materialize(frame, ("load-people",)) == expected
+
+
+@pytest.mark.parametrize(
+    ("factory", "row_count", "expectation"),
+    [
+        (ava.ModelStream.one, 0, "expected exactly one row; got 0 rows"),
+        (ava.ModelStream.one, 2, "expected exactly one row; got 2 rows"),
+        (ava.ModelStream.one_or_none, 2, "expected at most one row; got 2 rows"),
+    ],
+)
+def test_model_stream_cardinality_errors_include_available_context(
+    factory, row_count, expectation
+):
+    frame = pl.DataFrame(
+        {"id": list(range(row_count)), "name": ["person"] * row_count},
+        schema={"id": pl.Int64, "name": pl.String},
+    )
+    stream = factory(_ModelTable())
+    context = ava.RunContext(run_id="run-42", workflow_name="people-workflow")
+
+    with pytest.raises(ValueError) as exc_info:
+        run_with_context(
+            context,
+            stream._materialize,
+            frame,
+            ("load-people",),
+        )
+
+    message = str(exc_info.value)
+    assert expectation in message
+    assert "table='models.people'" in message
+    assert "workflow='people-workflow'" in message
+    assert "run_id='run-42'" in message
+    assert "source_node='load-people'" in message
+
+
+def test_model_stream_validation_errors_include_available_context():
+    stream = ava.ModelStream.all(_ModelTable())
+    context = ava.RunContext(run_id="run-invalid", workflow_name="people-workflow")
+
+    with pytest.raises(ValueError) as exc_info:
+        run_with_context(
+            context,
+            stream._materialize,
+            pl.DataFrame({"id": ["not-an-int"], "name": ["invalid"]}),
+            ("load-people",),
+        )
+
+    message = str(exc_info.value)
+    assert "ModelStream failed to validate rows" in message
+    assert "table='models.people'" in message
+    assert "workflow='people-workflow'" in message
+    assert "run_id='run-invalid'" in message
+    assert "source_node='load-people'" in message
+
+
+def test_model_stream_requires_a_model_declared_table_and_has_own_provider():
+    class UntypedTable:
+        row_model = None
+        identifier = "models.untyped"
+
+    with pytest.raises(TypeError, match="pydantic model schema.*models.untyped"):
+        ava.ModelStream.all(UntypedTable())
+
+    marker = ava.ModelStream.all(_ModelTable())
+    provider = next(provider for provider in PROVIDERS if provider.can_resolve(marker))
+
+    assert provider is ava.ModelStream
+    assert repr(marker).startswith("ModelStream.all(")
+
+
+@pytest.fixture(params=["local", pytest.param("ray", marks=pytest.mark.ray)])
+def model_executor(request: pytest.FixtureRequest) -> Iterator[ava.Executor]:
+    if request.param == "local":
+        yield ava.LocalExecutor()
+        return
+
+    pytest.importorskip("ray")
+    import ray
+
+    if ray.is_initialized():
+        ray.shutdown()
+    ray.init(
+        num_cpus=2,
+        ignore_reinit_error=True,
+        include_dashboard=False,
+        runtime_env={"working_dir": None},
+    )
+    try:
+        yield ava.RayExecutor()
+    finally:
+        ray.shutdown()
+
+
+@pytest.fixture
+def model_namespace(tmp_path):
+    class ModelNamespace(IcebergNs):
+        ns_config = IcebergNsConfig(
+            name="model-stream-contract",
+            base_location=str(tmp_path / "warehouse"),
+        )
+        people = IcebergTable(schema=ModelRow)
+
+    namespace = ModelNamespace(
+        catalog="model-stream-catalog",
+        load_catalog_props={
+            "type": "sql",
+            "uri": f"sqlite:///{tmp_path / 'catalog.db'}",
+        },
+    )
+    namespace.push()
+    return namespace
+
+
+def test_model_stream_passthrough_is_consistent_across_executors(
+    model_namespace, model_executor
+):
+    namespace = model_namespace
+
+    load_people = ava.source(slug="load-people")(append_passthrough_people)
+    consume_people = ava.step(slug="consume-people")(collect_model_pairs)
+
+    @ava.workflow
+    def workflow():
+        return load_people(people=namespace.people) >> consume_people(
+            people=ava.ModelStream.all(namespace.people)
+        )
+
+    assert workflow().run(
+        executor=model_executor,
+        run_id="passthrough-run",
+    ).result() == [(2, "second"), (1, "first")]
+
+
+def test_model_stream_table_backed_is_consistent_across_executors(
+    model_namespace, model_executor
+):
+    namespace = model_namespace
+    appended = namespace.people.append(ModelRow(id=7, name="table-backed"))
+
+    consume_person = ava.step(slug="consume-person")(return_model)
+
+    @ava.workflow
+    def workflow():
+        return consume_person(
+            person=ava.ModelStream.one(
+                namespace.people,
+                key="model_table_backed",
+                mode="append_scan",
+            )
+        )
+
+    assert workflow().run(executor=model_executor).result() == ModelRow(
+        id=7, name="table-backed"
+    )
+    assert (
+        ava.ProgressStore(namespace.people, key="model_table_backed").get_cursor()
+        == appended.snapshot_id
+    )
+
+
+def test_model_stream_rerun_is_consistent_across_executors(
+    model_namespace, model_executor
+):
+    namespace = model_namespace
+
+    load_people = ava.source(slug="load-people")(append_rerun_people)
+    consume_people = ava.step(slug="consume-people")(collect_model_names)
+
+    @ava.workflow
+    def workflow():
+        return load_people(people=namespace.people) >> consume_people(
+            people=ava.ModelStream.all(namespace.people)
+        )
+
+    assert workflow().run(
+        executor=model_executor,
+        run_id="source-run",
+    ).result() == ["third", "fourth"]
+    assert workflow().run(
+        executor=model_executor,
+        run_id="rerun-run",
+        rerun=ava.Rerun(run_id="source-run", start=["consume-people"], mode="lazy"),
+    ).result() == ["third", "fourth"]


### PR DESCRIPTION
## Summary
- add public `ava.ModelStream.one`, `one_or_none`, and `all` providers for Pydantic-backed tables
- preserve Stream passthrough, table-backed, progress, Ray, and rerun behavior while converting provenance-bearing frames into validated models
- add contextual cardinality/validation errors, public docs, changelog entry, and provider/integration coverage

## Verification
- `uv run pytest test/model_stream_test.py -m ray` — 3 passed, 14 deselected
- `uv run pytest test/model_stream_test.py test/streaming_test.py test/storage/test_stream_contracts.py test/executor_storage_matrix_test.py test/rerun_test.py test/stream_serialization_test.py test/model_tables_test.py test/model_frame_test.py test/append_result_test.py -m 'not ray'` — 144 passed, 31 deselected
- focused Ruff check — OK
- public LocalExecutor smoke workflow — returned `Person(id=11, name='Ada')` with stored provenance excluded from model fields

Closes #11