### PR TITLE
Add declared namespace lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Declared namespace lifecycle
+
+- `@ava.workflow(namespaces=[...])` records required table namespaces without
+  provisioning during import, DAG construction, or operator discovery.
+- Direct and operator-triggered runs provision declarations before node
+  submission. Failures stop the run before nodes start, and concurrent starts
+  serialize provisioning for each namespace resource.
+- Iceberg namespace and table creation now handles concurrent create conflicts
+  without duplicating catalog resources. Workflows without declarations retain
+  explicit `push()` behavior.
+
+
 ### Worker execution services
 
 - Added the versioned `ava.ExecutionServicesSpec` and worker-side

--- a/docs/dag-api.md
+++ b/docs/dag-api.md
@@ -19,6 +19,29 @@ The body of a `@ava.workflow` function should stay declarative. It runs when the
 workflow is built, not once per row or once per input item. Put business logic in
 source, step, and destination functions.
 
+## Declared namespace lifecycle
+
+Declare table namespaces on the workflow instead of calling `push()` while the
+workflow module is imported:
+
+```python
+@ava.workflow(namespaces=[analytics])
+def document_flow():
+    return load_documents() >> publish_chunks()
+```
+
+Building or discovering this workflow records `analytics` without provisioning
+it. Every direct or operator-triggered run provisions declared namespaces before
+submitting any node, so Local and Ray workers receive bound table references.
+Provisioning failures fail the run before node execution. Concurrent starts are
+serialized per namespace resource in each process, and backend `push()` operations
+remain idempotent; Iceberg handles concurrent create conflicts by loading the
+winning catalog resource.
+
+Existing workflows may continue to call `namespace.push()` explicitly and omit
+`namespaces=`.
+
+
 ## Minimal workflow
 
 ```python

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -49,6 +49,7 @@ When a workflow runs:
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable
 from concurrent.futures import CancelledError
 from contextvars import ContextVar
 from copy import copy
@@ -61,6 +62,7 @@ from ulid import ULID
 
 from .input_ref import InputRef
 from .run_handle import RunHandle
+from .storage import Namespace
 
 if TYPE_CHECKING:
     from .execution_services import ExecutionServicesSpec
@@ -2073,6 +2075,7 @@ class Workflow:
         input_type: type | None = None,
         context_type: type | None = None,
         agent_defaults: dict[str, Any] | None = None,
+        namespaces: tuple[Namespace, ...] = (),
     ):
         """
         Initialize workflow.
@@ -2083,6 +2086,7 @@ class Workflow:
             name: Workflow name
             returns: Value(s) returned by workflow function (NodeFuture, tuple, or None)
             cron: Optional cron expression for scheduled execution
+            namespaces: Namespace resources provisioned before node execution
         """
         self.graph = graph
         self.nodes = nodes
@@ -2096,6 +2100,7 @@ class Workflow:
         self.input_type = input_type
         self.context_type = context_type
         self.agent_defaults = dict(agent_defaults or {})
+        self.namespaces = tuple(namespaces)
 
         # Validate: detect cycles via Kahn's algorithm (incomplete sort = cycle)
         order = self._topological_sort()
@@ -2165,6 +2170,16 @@ class Workflow:
             original_dependencies_map,
         )
         return [node_id for node_id in execution_order if node_id in scheduled_node_ids]
+
+    def _provision_namespaces(self) -> None:
+        for namespace in self.namespaces:
+            try:
+                namespace._provision()
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Failed to provision namespace {namespace.name!r} "
+                    f"for workflow {self.name!r}: {exc}"
+                ) from exc
 
     def run(
         self,
@@ -2242,6 +2257,8 @@ class Workflow:
         Note:
             Intermediate results stay as refs (zero-copy).
         """
+        self._provision_namespaces()
+
         if executor is None:
             from .executor import get_default_executor
 
@@ -2926,6 +2943,7 @@ def workflow(
     context: type | None = None,
     ctx: type | None = None,
     agent_defaults: dict[str, Any] | None = None,
+    namespaces: Iterable[Namespace] | None = None,
 ) -> Callable[[], Workflow] | Callable[[Callable[[], None]], Callable[[], Workflow]]:
     """
     Decorator for workflow definitions.
@@ -2946,11 +2964,16 @@ def workflow(
         def parameterized_workflow():
             process()
 
+        @ava.workflow(namespaces=[analytics])
+        def provisioned_workflow():
+            process()
+
     Args:
         cron: Optional cron expression for scheduled execution.
         input: Optional BaseInput subclass validated at run start.
         context: Optional BaseContext subclass validated at run start.
         ctx: Alias for context.
+        namespaces: Namespace resources provisioned immediately before execution.
 
     Returns:
         Function that returns a Workflow object when called
@@ -2965,6 +2988,17 @@ def workflow(
         agent_defaults = validate_runtime_kwargs(
             agent_defaults, owner="ava.workflow(agent_defaults=...)"
         )
+
+    declared_namespaces: list[Namespace] = []
+    for namespace in namespaces or ():
+        if not isinstance(namespace, Namespace):
+            raise TypeError(
+                "workflow namespaces must contain Namespace instances; "
+                f"got {type(namespace).__name__}"
+            )
+        if all(namespace is not existing for existing in declared_namespaces):
+            declared_namespaces.append(namespace)
+    namespace_declarations = tuple(declared_namespaces)
 
     def decorator(fn: Callable[[], None]) -> Callable[[], Workflow]:
         @wraps(fn)
@@ -2985,6 +3019,7 @@ def workflow(
                     input_type=input,
                     context_type=context_type,
                     agent_defaults=agent_defaults,
+                    namespaces=namespace_declarations,
                 )
             finally:
                 _workflow_context.reset(token)

--- a/src/avalanche/iceberg/namespace.py
+++ b/src/avalanche/iceberg/namespace.py
@@ -9,7 +9,12 @@ import logging
 from typing import Iterable, Optional, Tuple, Union
 
 from pyiceberg.catalog import Catalog, load_catalog
-from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchTableError
+from pyiceberg.exceptions import (
+    NamespaceAlreadyExistsError,
+    NoSuchNamespaceError,
+    NoSuchTableError,
+    TableAlreadyExistsError,
+)
 from pyiceberg.table import (
     ALWAYS_TRUE,
     EMPTY_DICT,
@@ -296,36 +301,32 @@ class IcebergNamespace(Namespace):
         return super()._get_all_tables()
 
     def push(self) -> None:
-        """
-        Create/update namespace and tables in catalog.
-
-        This is like 'prisma db push' - synchronizes declared schema with actual state.
-        """
+        """Idempotently create the namespace and bind every declared table."""
         if (self.name,) not in self.catalog.list_namespaces():
-            self.catalog.create_namespace(self.name)
+            try:
+                self.catalog.create_namespace(self.name)
+            except NamespaceAlreadyExistsError:
+                pass
 
-        for name, table in self._get_all_tables():
+        for _, table in self._get_all_tables():
             self._push_table(table)
 
     def _push_table(self, table: IcebergTable) -> None:
-        """Push a single table to the catalog."""
-        existing_tables = self.catalog.list_tables(self.name)
-        logger.info(f"Existing tables: {existing_tables}")
+        """Idempotently create or load one table and bind it to this instance."""
+        identifier = (self.name, table._table_name)
+        if identifier in self.catalog.list_tables(self.name):
+            table._table = self.catalog.load_table(identifier)
+            return
 
-        if (self.name, table._table_name) not in existing_tables:
-            # Compute location
-            location = urljoin(self.location, table._table_name)
-            logger.warning(f"Creating table {table.identifier} at {location}")
-
-            # Create table
+        location = urljoin(self.location, table._table_name)
+        try:
             table._table = self.catalog.create_table(
-                identifier=table.identifier,
+                identifier=identifier,
                 schema=table.schema,
                 location=location,
             )
-        else:
-            logger.debug(f"Table {table.identifier} already exists. Loading it.")
-            table._table = self.catalog.load_table(table.identifier)
+        except TableAlreadyExistsError:
+            table._table = self.catalog.load_table(identifier)
 
     def drop(self, *, drop_tables: bool = False) -> None:
         """

--- a/src/avalanche/storage.py
+++ b/src/avalanche/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Any
@@ -189,6 +190,10 @@ class TableGroup:
         return [(name, table) for name, table in self._tables.items()]
 
 
+_provision_locks: dict[tuple[type["Namespace"], str, str], threading.Lock] = {}
+_provision_locks_guard = threading.Lock()
+
+
 class Namespace(ABC):
     """Backend-neutral namespace/catalog contract."""
 
@@ -213,6 +218,14 @@ class Namespace(ABC):
     def location(self) -> str:
         """Namespace storage location."""
         return urljoin(str(self.base_location), self.name)
+
+    def _provision(self) -> None:
+        """Provision this namespace once at a time within the current process."""
+        key = (type(self), str(self.base_location), self.name)
+        with _provision_locks_guard:
+            lock = _provision_locks.setdefault(key, threading.Lock())
+        with lock:
+            self.push()
 
     def _get_all_tables(self) -> list[tuple[str, Table]]:
         tables: list[tuple[str, Table]] = []

--- a/test/iceberg/namespace_test.py
+++ b/test/iceberg/namespace_test.py
@@ -104,6 +104,11 @@ class TestIcebergNamespace:
         print_directory_tree(tmpdir, level=1)
 
         assert os.path.exists(f"{tmpdir}/test-namespace/test_table")
+        metadata_dir = f"{tmpdir}/test-namespace/test_table/metadata"
+        assert (
+            len([name for name in os.listdir(metadata_dir) if name.endswith(".metadata.json")])
+            == 1
+        )
 
     def test_in_memory_single_connection_pool_serializes_connection_leases(
         self, namespace: TestNamespace
@@ -242,9 +247,7 @@ class TestIcebergNamespace:
         def concurrent_flow():
             return list_namespaces_concurrently()
 
-        handles = [
-            concurrent_flow().run(executor=ava.LocalExecutor()) for _ in range(7)
-        ]
+        handles = [concurrent_flow().run(executor=ava.LocalExecutor()) for _ in range(7)]
         barrier.wait(timeout=10)
         for handle in handles:
             assert (ns.name,) in handle.result(timeout=10)

--- a/test/namespace_lifecycle_test.py
+++ b/test/namespace_lifecycle_test.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import avalanche as ava
+from avalanche.operator import Operator
+from avalanche.operator.models import RunStatus
+from avalanche.storage import Namespace, NamespaceConfig, ScanResult, Table
+
+
+class RecordingTable(Table):
+    schema: Any = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bound = False
+
+    @property
+    def current_version_id(self) -> int | None:
+        return None
+
+    def append(self, df: Any) -> Any:
+        raise NotImplementedError
+
+    def scan(self, *args: Any, **kwargs: Any) -> ScanResult:
+        raise NotImplementedError
+
+
+def make_namespace(
+    tmp_path: Path,
+    events: list[str],
+    *,
+    failure: Exception | None = None,
+    provision_delay: float = 0.0,
+) -> Namespace:
+    state_lock = threading.Lock()
+
+    class RecordingNamespace(Namespace):
+        ns_config = NamespaceConfig(
+            name="managed",
+            base_location=str(tmp_path),
+        )
+        records = RecordingTable()
+
+        def __init__(self) -> None:
+            self.active_pushes = 0
+            self.max_active_pushes = 0
+            self.push_count = 0
+            super().__init__()
+
+        def push(self) -> None:
+            with state_lock:
+                self.active_pushes += 1
+                self.max_active_pushes = max(
+                    self.max_active_pushes,
+                    self.active_pushes,
+                )
+                self.push_count += 1
+            try:
+                events.append("push")
+                if provision_delay:
+                    time.sleep(provision_delay)
+                if failure is not None:
+                    raise failure
+                Path(self.location).mkdir(parents=True, exist_ok=True)
+                self.records.bound = True
+            finally:
+                with state_lock:
+                    self.active_pushes -= 1
+
+        def drop(self, *, drop_tables: bool = False) -> None:
+            return None
+
+    return RecordingNamespace()
+
+
+def test_declaration_records_without_mutation_and_provisions_before_table_binding(
+    tmp_path: Path,
+):
+    events: list[str] = []
+    namespace = make_namespace(tmp_path, events)
+
+    @ava.source
+    def read_bound_table(records=namespace.records):
+        events.append("node")
+        return records.bound, records._ns is namespace, Path(records.location).parent.is_dir()
+
+    @ava.workflow(namespaces=[namespace, namespace])
+    def flow():
+        return read_bound_table()
+
+    assert events == []
+    built = flow()
+    assert built.namespaces == (namespace,)
+    assert events == []
+    assert not Path(namespace.location).exists()
+
+    assert built.run(executor=ava.LocalExecutor()).result(timeout=5) == (
+        True,
+        True,
+        True,
+    )
+    assert events == ["push", "node"]
+
+
+def test_provisioning_failure_fails_run_before_nodes_start(tmp_path: Path):
+    events: list[str] = []
+    namespace = make_namespace(
+        tmp_path,
+        events,
+        failure=ValueError("catalog unavailable"),
+    )
+
+    @ava.source
+    def unreachable():
+        events.append("node")
+
+    @ava.workflow(namespaces=[namespace])
+    def flow():
+        return unreachable()
+
+    handle = flow().run(executor=ava.LocalExecutor())
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Failed to provision namespace 'managed' for workflow 'flow': "
+            "catalog unavailable"
+        ),
+    ) as raised:
+        handle.result(timeout=5)
+
+    assert isinstance(raised.value.__cause__, ValueError)
+    assert events == ["push"]
+
+
+def test_concurrent_starts_serialize_idempotent_provisioning(tmp_path: Path):
+    events: list[str] = []
+    namespace = make_namespace(tmp_path, events, provision_delay=0.02)
+
+    @ava.source
+    def observe_resource():
+        return Path(namespace.location).is_dir()
+
+    @ava.workflow(namespaces=[namespace])
+    def flow():
+        return observe_resource()
+
+    handles = [flow().run(executor=ava.LocalExecutor()) for _ in range(8)]
+
+    assert [handle.result(timeout=5) for handle in handles] == [True] * 8
+    assert namespace.push_count == 8
+    assert namespace.max_active_pushes == 1
+    assert Path(namespace.location).is_dir()
+
+
+def test_workflow_without_declarations_preserves_explicit_push(tmp_path: Path):
+    events: list[str] = []
+    namespace = make_namespace(tmp_path, events)
+    namespace.push()
+
+    @ava.source
+    def observe_resource():
+        events.append("node")
+        return Path(namespace.location).is_dir()
+
+    @ava.workflow
+    def flow():
+        return observe_resource()
+
+    built = flow()
+    assert built.namespaces == ()
+    assert built.run(executor=ava.LocalExecutor()).result(timeout=5) is True
+    assert events == ["push", "node"]
+    assert namespace.push_count == 1
+
+
+def test_operator_discovery_is_read_only_and_triggered_run_provisions(tmp_path: Path):
+    base_location = tmp_path / "catalog"
+    namespace_location = base_location / "operator-managed"
+    workflow_file = tmp_path / "managed_workflow.py"
+    workflow_file.write_text(
+        "from pathlib import Path\n"
+        "import avalanche as ava\n"
+        "from avalanche.storage import Namespace, NamespaceConfig\n"
+        "class ManagedNamespace(Namespace):\n"
+        "    ns_config = NamespaceConfig(\n"
+        "        name='operator-managed',\n"
+        f"        base_location={str(base_location)!r},\n"
+        "    )\n"
+        "    def push(self):\n"
+        "        Path(self.location).mkdir(parents=True, exist_ok=True)\n"
+        "    def drop(self, *, drop_tables=False):\n"
+        "        return None\n"
+        "ns = ManagedNamespace()\n"
+        "@ava.source\n"
+        "def verify():\n"
+        "    assert Path(ns.location).is_dir()\n"
+        "    return True\n"
+        "@ava.workflow(namespaces=[ns])\n"
+        "def managed_workflow():\n"
+        "    return verify()\n"
+    )
+
+    operator = Operator(
+        workflow_paths=[str(workflow_file)],
+        schedule=False,
+        watch=False,
+    )
+    try:
+        assert [item.name for item in operator.list_workflows()] == ["managed_workflow"]
+        assert not namespace_location.exists()
+
+        run_id = operator.start_run("managed_workflow")
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            run = operator.get_run(run_id)
+            if run is not None and run.status in (RunStatus.SUCCESS, RunStatus.FAILED):
+                break
+            time.sleep(0.05)
+
+        run = operator.get_run(run_id)
+        assert run is not None
+        assert run.status == RunStatus.SUCCESS, [entry.message for entry in run.logs]
+        assert namespace_location.is_dir()
+    finally:
+        operator.close()


### PR DESCRIPTION
## Summary
- add `@ava.workflow(namespaces=[...])` declarations without import/discovery provisioning
- provision namespaces before Local or Ray node submission, with clear pre-node run failures
- serialize concurrent in-process provisioning and make Iceberg create races conflict-safe
- preserve explicit `namespace.push()` workflows

## Verification
- `uv run pytest test/dag_test.py test/run_handle_test.py test/iceberg/namespace_test.py test/operator_tests/test_operator.py test/namespace_lifecycle_test.py -q` — 101 passed, 2 warnings
- declared Lance namespace smoke path — absent before run, bound table visible in node, present after run
- `uv run ruff check src/avalanche/dag.py src/avalanche/storage.py src/avalanche/iceberg/namespace.py test/namespace_lifecycle_test.py test/iceberg/namespace_test.py` — OK

Closes #12