### PR TITLE
Add run-lineaged artifact store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Run-lineaged artifact storage
+
+- Added `ava.ArtifactStore`, `ava.LocalArtifactStore`, durable
+  `ava.ArtifactRef` metadata, and one input/output `ArtifactManifest` per run.
+- Configured workflows stage inline uploads and register remote objects after
+  run-ID assignment but before node execution.
+- Nodes explicitly publish generated files through
+  `RunContext.publish_artifact(...)`; local publication is atomic and rejects
+  duplicate names without overwriting existing objects.
+
 ### Worker execution services
 
 - Added the versioned `ava.ExecutionServicesSpec` and worker-side

--- a/docs/dag-api.md
+++ b/docs/dag-api.md
@@ -267,6 +267,54 @@ contents = payload.remote_document.read_bytes(
 )
 ```
 
+### Durable run artifacts
+
+Configure an artifact store when files must remain usable beyond the submitting
+client, executor, or sandbox:
+
+```python
+class ArtifactInput(ava.BaseInput):
+    document: ava.ArtifactRef
+
+
+@ava.step
+def create_proposal(payload: ArtifactInput, ctx: ava.RunContext):
+    text = payload.document.read_bytes().decode()
+    generated = render_proposal(text)
+    return ctx.publish_artifact(generated, role="proposal")
+
+
+@ava.workflow(
+    input=ArtifactInput,
+    artifact_store=ava.LocalArtifactStore("./artifacts"),
+)
+def proposal_workflow():
+    return create_proposal()
+```
+
+Before nodes execute, configured workflows replace submitted `ava.File` values
+with durable `ava.ArtifactRef` values. The operator assigns the run ID before
+this staging step. Submitted `ava.S3File` and existing `ArtifactRef` values are
+registered in the new run without downloading or copying their objects.
+
+`RunContext.publish_artifact(path, role=..., name=..., media_type=...)` copies a
+generated file into configured storage and records its current run and node.
+Publication is explicit: scratch and temporary files are never inferred.
+`name` defaults to the source filename. Names are unique within each run and
+artifact kind; a duplicate raises `ava.DuplicateArtifactError` and never
+overwrites the first object.
+
+Each `ArtifactRef` records `uri`, SHA-256 `checksum`, byte `size`, `media_type`,
+`kind` (`"input"` or `"output"`), `run_id`, `node_id`, `role`, and `origin`.
+Use `workflow.artifact_manifest(run_id)`, `store.manifest(run_id)`, or
+`ctx.artifact_manifest()` to read the one manifest covering both directions.
+
+`ava.LocalArtifactStore` is the included content-addressed filesystem backend.
+It atomically publishes blobs and stores manifests in SQLite so independent
+worker processes can publish safely. `ava.ArtifactStore` is the backend contract
+for shared filesystems and object-store implementations.
+
+
 ## Execution
 
 Run a workflow by constructing it and calling `.run()` with an executor. The

--- a/src/avalanche/__init__.py
+++ b/src/avalanche/__init__.py
@@ -5,6 +5,14 @@ Provides a DAG-based framework for building data transformation workflows
 with local and distributed execution.
 """
 
+from .artifacts import (
+    ArtifactManifest,
+    ArtifactRef,
+    ArtifactStore,
+    DuplicateArtifactError,
+    LocalArtifactStore,
+)
+
 # DAG primitives
 from .dag import Pipeline, Workflow, dest, pipeline, source, step, transform, workflow
 from .execution_services import (
@@ -95,6 +103,12 @@ __all__ = [
     "workflow",
     "pipeline",
     "input",
+    # Artifacts
+    "ArtifactManifest",
+    "ArtifactRef",
+    "ArtifactStore",
+    "DuplicateArtifactError",
+    "LocalArtifactStore",
     # Workflow
     "Workflow",
     "Pipeline",

--- a/src/avalanche/artifacts.py
+++ b/src/avalanche/artifacts.py
@@ -1,0 +1,527 @@
+"""Durable, run-lineaged artifact storage contracts and local backend."""
+
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+import os
+import sqlite3
+import tempfile
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from contextlib import closing
+from pathlib import Path
+from typing import Any, BinaryIO, Literal
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+ArtifactKind = Literal["input", "output"]
+_CHUNK_SIZE = 1024 * 1024
+
+
+class ArtifactRef(BaseModel):
+    """Durable artifact metadata passed across workflow and executor boundaries."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    uri: str
+    checksum: str | None
+    size: int | None
+    media_type: str | None
+    kind: ArtifactKind
+    run_id: str
+    node_id: str | None
+    role: str
+    origin: str
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        invalid = (
+            not value
+            or value in {".", ".."}
+            or any(char in value for char in ("/", "\\", "\0"))
+        )
+        if invalid:
+            raise ValueError("artifact name must be a non-empty file name")
+        return value
+
+    @field_validator("uri", "run_id", "role", "origin")
+    @classmethod
+    def _validate_non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("artifact metadata values must be non-empty")
+        return value
+
+    @field_validator("checksum")
+    @classmethod
+    def _validate_checksum(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.lower()
+        if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+            raise ValueError("artifact checksum must be a 64-character SHA-256 digest")
+        return normalized
+
+    @field_validator("size")
+    @classmethod
+    def _validate_size(cls, value: int | None) -> int | None:
+        if value is not None and value < 0:
+            raise ValueError("artifact size must be non-negative")
+        return value
+
+    def open(self, mode: str = "rb", **kwargs: Any) -> BinaryIO:
+        """Open the durable object through its URI."""
+        parsed = urlparse(self.uri)
+        if parsed.scheme == "file":
+            path = Path(url2pathname(unquote(parsed.path)))
+            return path.open(mode, **kwargs)
+        try:
+            import fsspec
+        except ModuleNotFoundError as exc:  # pragma: no cover - core dependency today
+            raise ModuleNotFoundError(
+                f"Artifact URI access for {parsed.scheme!r} requires fsspec",
+                name="fsspec",
+            ) from exc
+        return fsspec.open(self.uri, mode=mode, **kwargs).open()
+
+    def read_bytes(self, **kwargs: Any) -> bytes:
+        """Read and validate the complete artifact payload."""
+        with self.open("rb", **kwargs) as file:
+            content = file.read()
+        if self.size is not None and len(content) != self.size:
+            raise ValueError("artifact size does not match metadata")
+        if self.checksum is not None and hashlib.sha256(content).hexdigest() != self.checksum:
+            raise ValueError("artifact checksum does not match content")
+        return content
+
+
+class ArtifactManifest(BaseModel):
+    """The complete input/output artifact lineage for one run."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    run_id: str
+    artifacts: tuple[ArtifactRef, ...] = ()
+
+    @property
+    def inputs(self) -> tuple[ArtifactRef, ...]:
+        return tuple(ref for ref in self.artifacts if ref.kind == "input")
+
+    @property
+    def outputs(self) -> tuple[ArtifactRef, ...]:
+        return tuple(ref for ref in self.artifacts if ref.kind == "output")
+
+
+class DuplicateArtifactError(FileExistsError):
+    """Raised when a run already contains an artifact with the same kind and name."""
+
+
+class ArtifactStore(ABC):
+    """Backend contract for durable staging, registration, and publication."""
+
+    @abstractmethod
+    def stage_input(
+        self,
+        source: Any,
+        *,
+        run_id: str,
+        role: str,
+        name: str | None = None,
+        media_type: str | None = None,
+    ) -> ArtifactRef:
+        """Copy a submitted input into durable storage."""
+
+    @abstractmethod
+    def register(
+        self,
+        uri: str,
+        *,
+        name: str,
+        checksum: str | None,
+        size: int | None,
+        media_type: str | None,
+        kind: ArtifactKind,
+        run_id: str,
+        node_id: str | None,
+        role: str,
+        origin: str | None = None,
+    ) -> ArtifactRef:
+        """Register an existing durable object without copying it."""
+
+    @abstractmethod
+    def publish(
+        self,
+        source: str | Path,
+        *,
+        run_id: str,
+        node_id: str,
+        role: str,
+        name: str | None = None,
+        media_type: str | None = None,
+    ) -> ArtifactRef:
+        """Atomically publish a generated local file."""
+
+    @abstractmethod
+    def manifest(self, run_id: str) -> ArtifactManifest:
+        """Return the single manifest containing a run's inputs and outputs."""
+
+
+class LocalArtifactStore(ArtifactStore):
+    """Content-addressed local filesystem backend with an atomic SQLite manifest.
+
+    Artifact names are unique per ``(run_id, kind)``. Publishing or staging a
+    duplicate raises :class:`DuplicateArtifactError`; existing content and
+    manifest rows are never overwritten.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root).expanduser().resolve()
+
+    def stage_input(
+        self,
+        source: Any,
+        *,
+        run_id: str,
+        role: str,
+        name: str | None = None,
+        media_type: str | None = None,
+    ) -> ArtifactRef:
+        from .runtime import File
+
+        if isinstance(source, File):
+            artifact_name = name or source.name or role.rsplit(".", 1)[-1]
+            resolved_media_type = (
+                media_type or source.content_type or _guess_media_type(artifact_name)
+            )
+            ref = self._store_bytes(
+                source.content,
+                name=artifact_name,
+                run_id=run_id,
+                role=role,
+                media_type=resolved_media_type,
+                kind="input",
+                node_id=None,
+                origin=f"upload://{artifact_name}",
+            )
+            if source.sha256 is not None and ref.checksum != source.sha256:
+                raise ValueError("staged input checksum does not match File metadata")
+            return ref
+
+        path = Path(source)
+        artifact_name = name or path.name
+        return self._store_path(
+            path,
+            name=artifact_name,
+            run_id=run_id,
+            role=role,
+            media_type=media_type or _guess_media_type(artifact_name),
+            kind="input",
+            node_id=None,
+            origin=path.resolve().as_uri(),
+        )
+
+    def register(
+        self,
+        uri: str,
+        *,
+        name: str,
+        checksum: str | None,
+        size: int | None,
+        media_type: str | None,
+        kind: ArtifactKind,
+        run_id: str,
+        node_id: str | None,
+        role: str,
+        origin: str | None = None,
+    ) -> ArtifactRef:
+        parsed = urlparse(uri)
+        if not parsed.scheme:
+            raise ValueError("registered artifact URI must be absolute")
+        if kind == "output" and not node_id:
+            raise ValueError("published output artifacts require a node_id")
+        ref = ArtifactRef(
+            name=name,
+            uri=uri,
+            checksum=checksum,
+            size=size,
+            media_type=media_type or _guess_media_type(name),
+            kind=kind,
+            run_id=run_id,
+            node_id=node_id,
+            role=role,
+            origin=origin or uri,
+        )
+        self._insert_manifest_ref(ref)
+        return ref
+
+    def publish(
+        self,
+        source: str | Path,
+        *,
+        run_id: str,
+        node_id: str,
+        role: str,
+        name: str | None = None,
+        media_type: str | None = None,
+    ) -> ArtifactRef:
+        path = Path(source)
+        artifact_name = name or path.name
+        return self._store_path(
+            path,
+            name=artifact_name,
+            run_id=run_id,
+            role=role,
+            media_type=media_type or _guess_media_type(artifact_name),
+            kind="output",
+            node_id=node_id,
+            origin=path.resolve().as_uri(),
+        )
+
+    def manifest(self, run_id: str) -> ArtifactManifest:
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    name, uri, checksum, size, media_type, kind,
+                    run_id, node_id, role, origin
+                FROM artifacts
+                WHERE run_id = ?
+                ORDER BY CASE kind WHEN 'input' THEN 0 ELSE 1 END, name, COALESCE(node_id, '')
+                """,
+                (run_id,),
+            ).fetchall()
+        return ArtifactManifest(
+            run_id=run_id,
+            artifacts=tuple(
+                ArtifactRef(
+                    name=row[0],
+                    uri=row[1],
+                    checksum=row[2],
+                    size=row[3],
+                    media_type=row[4],
+                    kind=row[5],
+                    run_id=row[6],
+                    node_id=row[7],
+                    role=row[8],
+                    origin=row[9],
+                )
+                for row in rows
+            ),
+        )
+
+    def _store_bytes(
+        self,
+        content: bytes,
+        *,
+        name: str,
+        run_id: str,
+        role: str,
+        media_type: str | None,
+        kind: ArtifactKind,
+        node_id: str | None,
+        origin: str,
+    ) -> ArtifactRef:
+        def write_content(target: BinaryIO) -> tuple[str, int]:
+            digest = hashlib.sha256()
+            view = memoryview(content)
+            for offset in range(0, len(view), _CHUNK_SIZE):
+                chunk = view[offset : offset + _CHUNK_SIZE]
+                target.write(chunk)
+                digest.update(chunk)
+            return digest.hexdigest(), len(content)
+
+        return self._store(write_content, name, run_id, role, media_type, kind, node_id, origin)
+
+    def _store_path(
+        self,
+        path: Path,
+        *,
+        name: str,
+        run_id: str,
+        role: str,
+        media_type: str | None,
+        kind: ArtifactKind,
+        node_id: str | None,
+        origin: str,
+    ) -> ArtifactRef:
+        if not path.is_file():
+            raise FileNotFoundError(f"artifact source is not a file: {path}")
+
+        def copy_content(target: BinaryIO) -> tuple[str, int]:
+            digest = hashlib.sha256()
+            size = 0
+            with path.open("rb") as source:
+                while chunk := source.read(_CHUNK_SIZE):
+                    target.write(chunk)
+                    digest.update(chunk)
+                    size += len(chunk)
+            return digest.hexdigest(), size
+
+        return self._store(copy_content, name, run_id, role, media_type, kind, node_id, origin)
+
+    def _store(
+        self,
+        writer: Any,
+        name: str,
+        run_id: str,
+        role: str,
+        media_type: str | None,
+        kind: ArtifactKind,
+        node_id: str | None,
+        origin: str,
+    ) -> ArtifactRef:
+        root = self._resolved_root()
+        temporary_root = root / ".tmp"
+        temporary_root.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(prefix="artifact-", dir=temporary_root)
+        temporary_path = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "wb") as target:
+                checksum, size = writer(target)
+                target.flush()
+                os.fsync(target.fileno())
+            blob = root / "blobs" / checksum[:2] / checksum
+            blob.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.link(temporary_path, blob)
+            except FileExistsError:
+                pass
+            ref = ArtifactRef(
+                name=name,
+                uri=blob.resolve().as_uri(),
+                checksum=checksum,
+                size=size,
+                media_type=media_type,
+                kind=kind,
+                run_id=run_id,
+                node_id=node_id,
+                role=role,
+                origin=origin,
+            )
+            self._insert_manifest_ref(ref)
+            return ref
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+    def _insert_manifest_ref(self, ref: ArtifactRef) -> None:
+        try:
+            with closing(self._connect()) as connection:
+                with connection:
+                    connection.execute(
+                        """
+                        INSERT INTO artifacts
+                            (
+                                name, uri, checksum, size, media_type,
+                                kind, run_id, node_id, role, origin
+                            )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            ref.name,
+                            ref.uri,
+                            ref.checksum,
+                            ref.size,
+                            ref.media_type,
+                            ref.kind,
+                            ref.run_id,
+                            ref.node_id,
+                            ref.role,
+                            ref.origin,
+                        ),
+                    )
+        except sqlite3.IntegrityError as exc:
+            raise DuplicateArtifactError(
+                f"artifact {ref.name!r} already exists for run {ref.run_id!r} as {ref.kind}"
+            ) from exc
+
+    def _connect(self) -> sqlite3.Connection:
+        root = self._resolved_root()
+        root.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(root / "manifest.sqlite3", timeout=30)
+        connection.execute("PRAGMA busy_timeout = 30000")
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS artifacts (
+                name TEXT NOT NULL,
+                uri TEXT NOT NULL,
+                checksum TEXT,
+                size INTEGER,
+                media_type TEXT,
+                kind TEXT NOT NULL CHECK (kind IN ('input', 'output')),
+                run_id TEXT NOT NULL,
+                node_id TEXT,
+                role TEXT NOT NULL,
+                origin TEXT NOT NULL,
+                PRIMARY KEY (run_id, kind, name)
+            )
+            """
+        )
+        connection.commit()
+        return connection
+
+    def _resolved_root(self) -> Path:
+        return self.root
+
+
+def stage_artifact_inputs(value: Any, store: ArtifactStore, *, run_id: str) -> Any:
+    """Recursively replace submitted file transports with durable input references."""
+    from .runtime import File, S3File
+
+    def stage(item: Any, path: tuple[str, ...]) -> Any:
+        role = ".".join(path) or "input"
+        if isinstance(item, File):
+            return store.stage_input(item, run_id=run_id, role=role)
+        if isinstance(item, Path):
+            return store.stage_input(item, run_id=run_id, role=role)
+        if isinstance(item, S3File):
+            parsed = urlparse(item.uri)
+            name = Path(unquote(parsed.path)).name or (path[-1] if path else "input")
+            return store.register(
+                item.uri,
+                name=name,
+                checksum=item.sha256,
+                size=item.size_bytes,
+                media_type=item.content_type,
+                kind="input",
+                run_id=run_id,
+                node_id=None,
+                role=role,
+                origin=item.uri,
+            )
+        if isinstance(item, ArtifactRef):
+            if item.run_id == run_id and item.kind == "input":
+                return item
+            return store.register(
+                item.uri,
+                name=item.name,
+                checksum=item.checksum,
+                size=item.size,
+                media_type=item.media_type,
+                kind="input",
+                run_id=run_id,
+                node_id=None,
+                role=role,
+                origin=item.uri,
+            )
+        if isinstance(item, BaseModel):
+            return {
+                field_name: stage(getattr(item, field_name), (*path, field_name))
+                for field_name in type(item).model_fields
+            }
+        if isinstance(item, Mapping):
+            return {key: stage(child, (*path, str(key))) for key, child in item.items()}
+        if isinstance(item, list):
+            return [stage(child, (*path, str(index))) for index, child in enumerate(item)]
+        if isinstance(item, tuple):
+            return tuple(stage(child, (*path, str(index))) for index, child in enumerate(item))
+        return item
+
+    return stage(value, ())
+
+
+def _guess_media_type(name: str) -> str | None:
+    return mimetypes.guess_type(name)[0]

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -63,6 +63,7 @@ from .input_ref import InputRef
 from .run_handle import RunHandle
 
 if TYPE_CHECKING:
+    from .artifacts import ArtifactManifest, ArtifactStore
     from .execution_services import ExecutionServicesSpec
     from .executor import Executor
     from .operator.hooks import RunHooks
@@ -1416,6 +1417,7 @@ def _build_context_values(
     workflow_name: str,
     executor_type: str,
     rerun: Any = None,
+    artifact_store: "ArtifactStore | None" = None,
 ) -> tuple[Any, Any]:
     from .runtime import BaseContext, RunContext
 
@@ -1424,6 +1426,7 @@ def _build_context_values(
         workflow_name=workflow_name,
         executor_type=executor_type,
         rerun=rerun,
+        artifact_store=artifact_store,
     )
     target_type = context_type or RunContext
     if not _safe_issubclass(target_type, BaseContext):
@@ -1438,6 +1441,7 @@ def _build_context_values(
         "node_name": None,
         "node_slug": None,
         "lineage_vector": {},
+        "artifact_store": artifact_store,
     }
 
     if raw_context is not None and isinstance(raw_context, target_type):
@@ -2072,6 +2076,7 @@ class Workflow:
         cron: str | None = None,
         input_type: type | None = None,
         context_type: type | None = None,
+        artifact_store: "ArtifactStore | None" = None,
         agent_defaults: dict[str, Any] | None = None,
     ):
         """
@@ -2095,6 +2100,7 @@ class Workflow:
         _validate_workflow_types(input_type, context_type)
         self.input_type = input_type
         self.context_type = context_type
+        self.artifact_store = artifact_store
         self.agent_defaults = dict(agent_defaults or {})
 
         # Validate: detect cycles via Kahn's algorithm (incomplete sort = cycle)
@@ -2165,6 +2171,20 @@ class Workflow:
             original_dependencies_map,
         )
         return [node_id for node_id in execution_order if node_id in scheduled_node_ids]
+
+    def stage_input(self, input: Any, *, run_id: str) -> Any:
+        """Stage submitted files and register remote objects before node execution."""
+        if self.artifact_store is None or input is None:
+            return input
+        from .artifacts import stage_artifact_inputs
+
+        return stage_artifact_inputs(input, self.artifact_store, run_id=run_id)
+
+    def artifact_manifest(self, run_id: str) -> "ArtifactManifest":
+        """Return the configured store's complete artifact manifest for a run."""
+        if self.artifact_store is None:
+            raise RuntimeError("workflow has no artifact_store configured")
+        return self.artifact_store.manifest(run_id)
 
     def run(
         self,
@@ -2266,6 +2286,7 @@ class Workflow:
                 raise TypeError(
                     f"{type(executor).__name__} does not support execution services"
                 )
+        input = self.stage_input(input, run_id=run_id)
         run_input = (
             None
             if execution_services is not None
@@ -2278,6 +2299,7 @@ class Workflow:
             workflow_name=self.name,
             executor_type=executor_type,
             rerun=rerun_spec,
+            artifact_store=self.artifact_store,
         )
 
         result_refs: dict[str, Any] = {}
@@ -2925,6 +2947,7 @@ def workflow(
     input: type | None = None,
     context: type | None = None,
     ctx: type | None = None,
+    artifact_store: "ArtifactStore | None" = None,
     agent_defaults: dict[str, Any] | None = None,
 ) -> Callable[[], Workflow] | Callable[[Callable[[], None]], Callable[[], Workflow]]:
     """
@@ -2951,6 +2974,7 @@ def workflow(
         input: Optional BaseInput subclass validated at run start.
         context: Optional BaseContext subclass validated at run start.
         ctx: Alias for context.
+        artifact_store: Optional durable input/output artifact store.
 
     Returns:
         Function that returns a Workflow object when called
@@ -2984,6 +3008,7 @@ def workflow(
                     cron=cron,
                     input_type=input,
                     context_type=context_type,
+                    artifact_store=artifact_store,
                     agent_defaults=agent_defaults,
                 )
             finally:

--- a/src/avalanche/runtime/context.py
+++ b/src/avalanche/runtime/context.py
@@ -8,6 +8,8 @@ from typing import Any, BinaryIO, Literal, TextIO, overload
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from ..artifacts import ArtifactManifest, ArtifactRef, ArtifactStore
+
 MAX_INLINE_FILE_BYTES = 3 * 1024 * 1024
 MAX_INLINE_REQUEST_BYTES = MAX_INLINE_FILE_BYTES
 
@@ -73,6 +75,7 @@ class RunContext(BaseContext):
     node_slug: str | None = None
     lineage_vector: dict[str, str] = Field(default_factory=dict, exclude=True)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    artifact_store: ArtifactStore | None = Field(default=None, exclude=True, repr=False)
 
     def for_node(self, *, node_id: str, node_name: str, node_slug: str) -> "RunContext":
         return self.model_copy(
@@ -83,6 +86,34 @@ class RunContext(BaseContext):
                 "lineage_vector": dict(self.lineage_vector),
             }
         )
+
+    def publish_artifact(
+        self,
+        source: str | Path,
+        *,
+        role: str,
+        name: str | None = None,
+        media_type: str | None = None,
+    ) -> ArtifactRef:
+        """Atomically publish a generated file with this run and node's lineage."""
+        if self.artifact_store is None:
+            raise RuntimeError("workflow has no artifact_store configured")
+        if self.node_id is None:
+            raise RuntimeError("artifacts can only be published from a workflow node")
+        return self.artifact_store.publish(
+            source,
+            run_id=self.run_id,
+            node_id=self.node_id,
+            role=role,
+            name=name,
+            media_type=media_type,
+        )
+
+    def artifact_manifest(self) -> ArtifactManifest:
+        """Return the current run's input/output artifact manifest."""
+        if self.artifact_store is None:
+            raise RuntimeError("workflow has no artifact_store configured")
+        return self.artifact_store.manifest(self.run_id)
 
 
 _current_run_context: ContextVar[RunContext | None] = ContextVar(

--- a/src/runtime/operator/run_worker.py
+++ b/src/runtime/operator/run_worker.py
@@ -67,6 +67,7 @@ def run_worker(
         workflow = builder()
         if not isinstance(workflow, Workflow):
             raise TypeError("Marked builder did not return a Workflow")
+        input_value = workflow.stage_input(input_value, run_id=run_id)
         event_queue.put({"type": "prepared", **_workflow_metadata(workflow)})
     except BaseException as exc:
         event_queue.put(

--- a/test/artifact_store_test.py
+++ b/test/artifact_store_test.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import hashlib
+import socket
+import time
+
+import pytest
+
+import avalanche as ava
+from avalanche.operator import Operator
+from avalanche.operator.client import GrpcStateProvider
+from avalanche.operator.models import RunStatus
+from avalanche.operator.server import serve
+
+
+class ArtifactInput(ava.BaseInput):
+    document: ava.ArtifactRef
+    remote_document: ava.ArtifactRef
+
+
+def _unused_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("localhost", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_terminal_run(client: GrpcStateProvider, run_id: str):
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        run = client.get_run(run_id)
+        if run is not None and run.status in {
+            RunStatus.SUCCESS,
+            RunStatus.FAILED,
+            RunStatus.CANCELLED,
+        }:
+            return run
+        time.sleep(0.05)
+    return client.get_run(run_id)
+
+
+def test_workflow_stages_inputs_registers_remote_objects_and_publishes_outputs(tmp_path):
+    store = ava.LocalArtifactStore(tmp_path / "artifacts")
+    scratch = tmp_path / "executor-scratch" / "proposal.txt"
+
+    @ava.source(slug="build-proposal")
+    def build(payload: ArtifactInput, ctx: ava.RunContext):
+        assert isinstance(payload.document, ava.ArtifactRef)
+        assert payload.document.read_bytes() == b"submitted document"
+        assert payload.remote_document.uri == "s3://existing-bucket/reference.pdf"
+        scratch.parent.mkdir()
+        scratch.write_bytes(b"generated proposal")
+        published = ctx.publish_artifact(scratch, role="proposal")
+        return published, ctx.artifact_manifest()
+
+    @ava.workflow(input=ArtifactInput, artifact_store=store)
+    def artifact_workflow():
+        return build()
+
+    run_id = "run-artifact-lineage"
+    output, manifest_during_run = (
+        artifact_workflow()
+        .run(
+            executor=ava.LocalExecutor(),
+            run_id=run_id,
+            input={
+                "document": ava.File(
+                    name="brief.txt",
+                    content=b"submitted document",
+                    content_type="text/plain",
+                ),
+                "remote_document": ava.S3File(
+                    uri="s3://existing-bucket/reference.pdf",
+                    size_bytes=421,
+                    content_type="application/pdf",
+                    sha256="a" * 64,
+                ),
+            },
+        )
+        .result()
+    )
+
+    scratch.unlink()
+    manifest = artifact_workflow().artifact_manifest(run_id)
+
+    assert manifest == manifest_during_run
+    assert manifest.run_id == run_id
+    assert [ref.name for ref in manifest.inputs] == ["brief.txt", "reference.pdf"]
+    assert [ref.name for ref in manifest.outputs] == ["proposal.txt"]
+
+    staged = manifest.inputs[0]
+    assert staged.uri.startswith("file://")
+    assert staged.checksum == hashlib.sha256(b"submitted document").hexdigest()
+    assert staged.size == len(b"submitted document")
+    assert staged.media_type == "text/plain"
+    assert staged.kind == "input"
+    assert staged.run_id == run_id
+    assert staged.node_id is None
+    assert staged.role == "document"
+    assert staged.origin == "upload://brief.txt"
+    assert staged.read_bytes() == b"submitted document"
+
+    registered = manifest.inputs[1]
+    assert registered.uri == "s3://existing-bucket/reference.pdf"
+    assert registered.checksum == "a" * 64
+    assert registered.size == 421
+    assert registered.media_type == "application/pdf"
+    assert registered.kind == "input"
+    assert registered.run_id == run_id
+    assert registered.node_id is None
+    assert registered.role == "remote_document"
+    assert registered.origin == registered.uri
+
+    assert output == manifest.outputs[0]
+    assert output.read_bytes() == b"generated proposal"
+    assert output.checksum == hashlib.sha256(b"generated proposal").hexdigest()
+    assert output.size == len(b"generated proposal")
+    assert output.media_type == "text/plain"
+    assert output.kind == "output"
+    assert output.run_id == run_id
+    assert output.node_id == "build_1"
+    assert output.role == "proposal"
+    assert output.origin == scratch.resolve().as_uri()
+
+
+def test_publication_is_atomic_and_rejects_duplicate_run_kind_names(tmp_path):
+    store = ava.LocalArtifactStore(tmp_path / "artifacts")
+    source = tmp_path / "result.txt"
+    source.write_bytes(b"first")
+
+    first = store.publish(
+        source,
+        run_id="run-duplicate",
+        node_id="first_1",
+        role="result",
+    )
+    source.write_bytes(b"second")
+
+    with pytest.raises(ava.DuplicateArtifactError, match="already exists"):
+        store.publish(
+            source,
+            run_id="run-duplicate",
+            node_id="second_1",
+            role="result",
+        )
+
+    assert first.read_bytes() == b"first"
+    assert store.manifest("run-duplicate").artifacts == (first,)
+
+
+def test_run_context_requires_configured_store_to_publish(tmp_path):
+    context = ava.RunContext(
+        run_id="run-no-store",
+        workflow_name="missing_store",
+        node_id="node_1",
+    )
+    source = tmp_path / "output.txt"
+    source.write_text("output")
+
+    with pytest.raises(RuntimeError, match="no artifact_store configured"):
+        context.publish_artifact(source, role="result")
+
+
+def test_operator_stages_cli_upload_before_nodes_and_keeps_manifest_after_teardown(tmp_path):
+    artifact_root = tmp_path / "operator-artifacts"
+    workflow_path = tmp_path / "artifact_workflow.py"
+    workflow_path.write_text(
+        f"""\
+from pathlib import Path
+import avalanche as ava
+
+store = ava.LocalArtifactStore({str(artifact_root)!r})
+
+class Input(ava.BaseInput):
+    document: ava.ArtifactRef
+
+@ava.source
+
+def publish(payload: Input, ctx: ava.RunContext):
+    assert payload.document.kind == "input"
+    assert payload.document.run_id == ctx.run_id
+    assert payload.document.read_bytes() == b"operator upload"
+    generated = Path({str(tmp_path / "operator-scratch.txt")!r})
+    generated.write_bytes(payload.document.read_bytes().upper())
+    return ctx.publish_artifact(generated, role="normalized")
+
+@ava.workflow(input=Input, artifact_store=store)
+def operator_artifact_workflow():
+    return publish()
+"""
+    )
+    operator = Operator(workflow_paths=[str(workflow_path)], schedule=False, watch=False)
+    port = _unused_port()
+    server = serve(operator, port=port, block=False)
+    client = GrpcStateProvider(f"localhost:{port}")
+    run_id = "run-operator-artifacts"
+    try:
+        assert (
+            client.start_run(
+                "operator_artifact_workflow",
+                run_id=run_id,
+                files={"document": ava.File(name="upload.txt", content=b"operator upload")},
+            )
+            == run_id
+        )
+        run = _wait_for_terminal_run(client, run_id)
+        assert run is not None
+        assert run.status == RunStatus.SUCCESS
+    finally:
+        client.close()
+        server.stop(grace=1)
+        operator.close()
+
+    manifest = ava.LocalArtifactStore(artifact_root).manifest(run_id)
+    assert [ref.kind for ref in manifest.artifacts] == ["input", "output"]
+    assert manifest.inputs[0].read_bytes() == b"operator upload"
+    assert manifest.outputs[0].read_bytes() == b"OPERATOR UPLOAD"
+    assert manifest.outputs[0].node_id == "publish_1"


### PR DESCRIPTION
## Summary
- add a backend-neutral artifact store contract, durable artifact references, and per-run manifests
- stage inline/local inputs and register remote inputs before workflow nodes execute
- publish generated outputs atomically through `RunContext` with run/node lineage and defined duplicate handling
- include a content-addressed local filesystem backend plus operator, CLI-path, durability, and metadata coverage

## Verification
- `uv run pytest test/artifact_store_test.py test/run_context_test.py test/input_ref_test.py test/operator_tests/test_grpc.py test/cli_test.py -q` — 72 passed
- `uv run ruff check src/avalanche/artifacts.py src/avalanche/runtime/context.py src/avalanche/dag.py src/avalanche/__init__.py src/runtime/operator/run_worker.py test/artifact_store_test.py` — OK
- durable workflow smoke path — `SMOKE OK: run=smoke-run inputs=1 outputs=1 durable_output=SMOKE`

Closes #10