### PR TITLE
feat(agent): add native RLM support in TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@
 - The agent inspector now has Trace and Metadata tabs. Metadata is available
   before execution and shows the resolved signature, skills, static
   instructions, tools, and effective redacted runtime configuration.
+- Fix: live agent evidence now remains attached across async node execution, so
+  the Trace tab receives turns and status updates under local and Ray backends.
 - See [docs/agent-steps.md](docs/agent-steps.md).
 
 ## 0.1.0-rc0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@
   configuration and automatic agent-step table/output behavior were removed.
 - `ava.agent.skills`, `ava.agent.Skill`, and `ava.agent.File` lazily re-export
   the corresponding PredictRLM APIs.
+- The agent inspector now has Trace and Metadata tabs. Metadata is available
+  before execution and shows the resolved signature, skills, static
+  instructions, tools, and effective redacted runtime configuration.
 - See [docs/agent-steps.md](docs/agent-steps.md).
 
 ## 0.1.0-rc0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,6 @@ dev = [
     "predict-rlm>=0.7.1",
 ]
 
-[tool.uv.sources]
-predict-rlm = { path = "../predict-rlm", editable = true }
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-rP --testdox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ dev = [
     "predict-rlm>=0.7.1",
 ]
 
+[tool.uv.sources]
+predict-rlm = { path = "../predict-rlm", editable = true }
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-rP --testdox"

--- a/src/avalanche/_agent_evidence.py
+++ b/src/avalanche/_agent_evidence.py
@@ -1,0 +1,34 @@
+"""Context-local bridge for best-effort agent evidence observation."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Callable, Iterator
+
+_AGENT_EVIDENCE_LISTENER: ContextVar[Callable[[dict[str, Any]], None] | None] = ContextVar(
+    "avalanche_agent_evidence_listener", default=None
+)
+
+
+@contextmanager
+def capture_agent_evidence(
+    listener: Callable[[dict[str, Any]], None],
+) -> Iterator[None]:
+    """Capture evidence emitted by agent calls in the current context."""
+    token = _AGENT_EVIDENCE_LISTENER.set(listener)
+    try:
+        yield
+    finally:
+        _AGENT_EVIDENCE_LISTENER.reset(token)
+
+
+def emit_agent_evidence(event: dict[str, Any]) -> None:
+    """Notify the current observer without affecting agent execution."""
+    listener = _AGENT_EVIDENCE_LISTENER.get()
+    if listener is None:
+        return
+    try:
+        listener(event)
+    except BaseException:
+        pass

--- a/src/avalanche/agent/agent_step.py
+++ b/src/avalanche/agent/agent_step.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import inspect
+import json
+import math
+import types
 from contextvars import ContextVar
+from enum import Enum
 from functools import update_wrapper
-from typing import Any, Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence, Union, get_args, get_origin
 
+from .._agent_evidence import emit_agent_evidence
 from ..dag import Node, NodeType
 from .config import UNSET, validate_runtime_kwargs
 from .signature import resolve_signature
@@ -17,12 +23,109 @@ class AgentStepError(RuntimeError):
 
 
 class AgentStepExecutionError(RuntimeError):
-    """A PredictRLM invocation failed inside an agent step."""
+    """An agent invocation failed inside an agent step."""
 
 
 _WORKFLOW_AGENT_DEFAULTS: ContextVar[Mapping[str, Any]] = ContextVar(
     "avalanche_agent_workflow_defaults", default={}
 )
+
+
+class _AvalancheEvidenceSink:
+    """Best-effort projection of agent evidence into Avalanche."""
+
+    strict = False
+
+    async def emit(self, event: Any) -> None:
+        emit_agent_evidence(_project_evidence_event(event))
+
+    async def flush(self, run_id: str) -> None:
+        return None
+
+    async def close(self, run_id: str, terminal_event: Any | None = None) -> None:
+        if terminal_event is not None:
+            emit_agent_evidence(_project_evidence_event(terminal_event))
+
+
+def _project_evidence_event(event: Any) -> dict[str, Any]:
+    kind_value = getattr(getattr(event, "kind", None), "value", None)
+    event_kind = kind_value if isinstance(kind_value, str) else str(getattr(event, "kind", ""))
+    raw_data = getattr(event, "data", {})
+    data = dict(raw_data) if isinstance(raw_data, Mapping) else {}
+    projected: dict[str, Any] = {}
+
+    if event_kind == "run.started":
+        inputs = data.get("inputs")
+        projected["input_fields"] = sorted(inputs) if isinstance(inputs, Mapping) else []
+    elif event_kind == "iteration.recorded":
+        step = data.get("step")
+        step = step if isinstance(step, Mapping) else {}
+        projected = {
+            "iteration": step.get("iteration"),
+            "duration_ms": step.get("duration_ms"),
+            "error": step.get("error"),
+            "tool_count": len(step.get("tool_calls") or []),
+            "predict_count": sum(
+                len(group.get("calls") or [])
+                for group in (step.get("predict_calls") or [])
+                if isinstance(group, Mapping)
+            ),
+        }
+    elif event_kind == "predict.started":
+        projected = {
+            key: data.get(key)
+            for key in ("call_id", "signature", "instructions", "model")
+            if data.get(key) is not None
+        }
+    elif event_kind == "predict.finished":
+        projected = {
+            key: data.get(key) for key in ("call_id", "error") if data.get(key) is not None
+        }
+    elif event_kind in {"tool.started", "tool.finished"}:
+        projected = {
+            key: data.get(key)
+            for key in ("call_id", "name", "error")
+            if data.get(key) is not None
+        }
+    elif event_kind == "code.generated":
+        projected = {
+            key: data.get(key) for key in ("iteration", "code") if data.get(key) is not None
+        }
+    elif event_kind == "code.executed":
+        projected = {
+            key: data.get(key)
+            for key in ("iteration", "output", "error")
+            if data.get(key) is not None
+        }
+    elif event_kind in {"run.failed", "run.cancelled"}:
+        projected = {
+            key: data.get(key) for key in ("error_type", "error") if data.get(key) is not None
+        }
+
+    return {
+        "kind": "evidence",
+        "sequence": int(getattr(event, "sequence", 0)),
+        "event_kind": event_kind,
+        "timestamp_ns": int(getattr(event, "timestamp_ns", 0)),
+        "data": projected,
+    }
+
+
+def _emit_terminal_trace(trace: Any) -> bool:
+    try:
+        exported = trace.to_exportable_json()
+        parsed = json.loads(exported)
+        if not isinstance(parsed, dict):
+            raise TypeError("exported trace is not a JSON object")
+    except BaseException as exc:
+        _emit_trace_unavailable(exc)
+        return False
+    emit_agent_evidence({"kind": "trace_finished", "trace": parsed})
+    return True
+
+
+def _emit_trace_unavailable(error: Any) -> None:
+    emit_agent_evidence({"kind": "trace_unavailable", "error": str(error)})
 
 
 class Agent:
@@ -61,8 +164,19 @@ class Agent:
             )
 
         try:
-            return await self._predictor.acall(**inputs)
+            prediction = await self._predictor.acall(**inputs)
+            trace = getattr(prediction, "trace", None)
+            if trace is None:
+                _emit_trace_unavailable("Agent trace unavailable")
+            else:
+                _emit_terminal_trace(trace)
+            return prediction
         except Exception as exc:
+            trace = getattr(exc, "trace", None)
+            if trace is None:
+                _emit_trace_unavailable(exc)
+            else:
+                _emit_terminal_trace(trace)
             input_types = {name: type(value).__name__ for name, value in inputs.items()}
             raise AgentStepExecutionError(
                 f"agent step {self._step_name!r} failed calling "
@@ -78,9 +192,7 @@ class Agent:
             self._skills = (
                 () if self._skills_override is UNSET else tuple(self._skills_override)
             )
-            self._tools = (
-                () if self._tools_override is UNSET else tuple(self._tools_override)
-            )
+            self._tools = () if self._tools_override is UNSET else tuple(self._tools_override)
         return self._dspy_signature
 
     def _validate_input_names(self, dspy_signature: Any, inputs: Mapping[str, Any]) -> None:
@@ -135,6 +247,44 @@ class _AgentStepSpec:
             tools=self.tools,
         )
 
+    def declaration_metadata(
+        self, workflow_defaults: Mapping[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Serialize static agent declaration state without building a predictor."""
+        signature = resolve_signature(self.signature, name=self.step_name)
+        skills = () if self.skills is UNSET else tuple(self.skills)
+        tools = () if self.tools is UNSET else tuple(self.tools)
+
+        from predict_rlm.rlm_skills import merge_skills
+
+        skill_instructions, packages, modules, skill_tools = merge_skills(list(skills))
+        signature_instructions = str(getattr(signature, "instructions", "") or "")
+        aggregated_instructions = signature_instructions
+        if skill_instructions:
+            aggregated_instructions += (
+                "\n\n" if aggregated_instructions else ""
+            ) + skill_instructions
+
+        return {
+            "signature": {
+                "name": getattr(signature, "__name__", type(signature).__name__),
+                "instructions": signature_instructions,
+                "inputs": _serialize_signature_fields(signature.input_fields),
+                "outputs": _serialize_signature_fields(signature.output_fields),
+            },
+            "runtime": _effective_runtime_metadata(
+                workflow_defaults or {}, self.runtime_kwargs
+            ),
+            "skills": [_serialize_skill(skill) for skill in skills],
+            "aggregated_static_instructions": aggregated_instructions,
+            "packages": packages,
+            "modules": list(modules),
+            "tools": [
+                *_serialize_tools(skill_tools),
+                *_serialize_tools({_callable_name(tool): tool for tool in tools}),
+            ],
+        }
+
     def with_workflow_defaults(
         self, fn: Callable[..., Any], defaults: Mapping[str, Any]
     ) -> Callable[..., Any]:
@@ -148,6 +298,161 @@ class _AgentStepSpec:
         update_wrapper(bound, fn)
         bound.__signature__ = getattr(fn, "__signature__", inspect.signature(fn))  # type: ignore[attr-defined]
         return bound
+
+
+_OMIT_METADATA = object()
+_OMITTED_RUNTIME_KEYS = frozenset(
+    {
+        "events",
+        "on_runtime_hook_event",
+        "output_dir",
+        "runtime_hooks",
+        "submit_confirmation",
+        "telemetry_context",
+        "trace_export_path",
+    }
+)
+_SECRET_KEY_PARTS = ("api_key", "auth", "credential", "password", "secret", "token")
+
+
+def _serialize_signature_fields(fields: Mapping[str, Any]) -> list[dict[str, str]]:
+    serialized = []
+    for name, field in fields.items():
+        extra = getattr(field, "json_schema_extra", None)
+        description = getattr(field, "description", None)
+        if not isinstance(description, str) and isinstance(extra, Mapping):
+            description = extra.get("desc")
+        serialized.append(
+            {
+                "name": name,
+                "annotation": _annotation_name(getattr(field, "annotation", Any)),
+                "description": description if isinstance(description, str) else "",
+            }
+        )
+    return serialized
+
+
+def _annotation_name(annotation: Any) -> str:
+    if annotation is Any:
+        return "Any"
+    if annotation is None or annotation is types.NoneType:
+        return "None"
+    if isinstance(annotation, str):
+        return annotation
+    forward_name = getattr(annotation, "__forward_arg__", None)
+    if isinstance(forward_name, str):
+        return forward_name
+
+    origin = get_origin(annotation)
+    if origin is not None:
+        args = get_args(annotation)
+        if origin in (Union, types.UnionType):
+            return " | ".join(_annotation_name(arg) for arg in args)
+        origin_name = getattr(origin, "__qualname__", getattr(origin, "__name__", "type"))
+        rendered_args = ", ".join(_annotation_name(arg) for arg in args)
+        return f"{origin_name}[{rendered_args}]" if rendered_args else origin_name
+
+    return getattr(
+        annotation,
+        "__qualname__",
+        getattr(annotation, "__name__", type(annotation).__name__),
+    )
+
+
+def _serialize_skill(skill: Any) -> dict[str, Any]:
+    tools = getattr(skill, "tools", {})
+    modules = getattr(skill, "modules", {})
+    return {
+        "name": str(getattr(skill, "name", type(skill).__name__)),
+        "instructions": str(getattr(skill, "instructions", "") or ""),
+        "packages": [
+            package for package in getattr(skill, "packages", ()) if isinstance(package, str)
+        ],
+        "modules": [name for name in modules if isinstance(name, str)],
+        "tools": [name for name in tools if isinstance(name, str)],
+    }
+
+
+def _serialize_tools(tools: Mapping[str, Callable[..., Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "name": name,
+            "description": inspect.getdoc(tool) or "",
+        }
+        for name, tool in tools.items()
+        if isinstance(name, str) and callable(tool)
+    ]
+
+
+def _callable_name(value: Callable[..., Any]) -> str:
+    return str(getattr(value, "__name__", type(value).__name__))
+
+
+def _effective_runtime_metadata(
+    workflow_defaults: Mapping[str, Any], step_overrides: Mapping[str, Any]
+) -> dict[str, Any]:
+    from predict_rlm import PredictRLM
+
+    constructor = inspect.signature(PredictRLM.__init__)
+    effective = {
+        name: parameter.default
+        for name, parameter in constructor.parameters.items()
+        if name not in {"self", "signature", "skills", "tools"}
+        and parameter.default is not inspect.Parameter.empty
+    }
+    effective.update(workflow_defaults)
+    effective.update(step_overrides)
+
+    serialized: dict[str, Any] = {}
+    for name, value in effective.items():
+        if name in _OMITTED_RUNTIME_KEYS or _is_sensitive_key(name):
+            continue
+        safe_value = _safe_runtime_value(value)
+        if safe_value is not _OMIT_METADATA:
+            serialized[name] = safe_value
+    return serialized
+
+
+def _safe_runtime_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else _OMIT_METADATA
+    if isinstance(value, Enum):
+        return _safe_runtime_value(value.value)
+    if isinstance(value, Path) or callable(value):
+        return _OMIT_METADATA
+    if isinstance(value, Mapping):
+        result = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or _is_sensitive_key(key):
+                continue
+            safe_item = _safe_runtime_value(item)
+            if safe_item is not _OMIT_METADATA:
+                result[key] = safe_item
+        return result
+    if isinstance(value, (list, tuple)):
+        result = []
+        for item in value:
+            safe_item = _safe_runtime_value(item)
+            if safe_item is not _OMIT_METADATA:
+                result.append(safe_item)
+        return result
+
+    value_type = type(value)
+    module = value_type.__module__
+    if module == "dspy" or module.startswith(("dspy.", "predict_rlm.")):
+        descriptor = {"type": f"{module}.{value_type.__qualname__}"}
+        instance_name = getattr(value, "model", None) or getattr(value, "name", None)
+        if isinstance(instance_name, str):
+            descriptor["name"] = instance_name
+        return descriptor
+    return _OMIT_METADATA
+
+
+def _is_sensitive_key(name: str) -> bool:
+    lowered = name.lower()
+    return any(part in lowered for part in _SECRET_KEY_PARTS)
 
 
 def agent_step(
@@ -243,9 +548,7 @@ def _public_step_signature(user_fn: Callable[..., Any]) -> inspect.Signature:
         )
 
     parameters = [
-        parameter
-        for name, parameter in signature.parameters.items()
-        if name != "agent"
+        parameter for name, parameter in signature.parameters.items() if name != "agent"
     ]
     return signature.replace(parameters=parameters)
 
@@ -257,13 +560,15 @@ def _build_predictor(
     tools: tuple[Callable[..., Any], ...],
     **runtime_kwargs: Any,
 ) -> Any:
-    """Build PredictRLM behind a testable, lazy import seam."""
+    """Build the agent predictor behind a testable, lazy import seam."""
     from predict_rlm import PredictRLM
 
+    configured_events = tuple(runtime_kwargs.pop("events", ()))
     return PredictRLM(
         signature,
         skills=list(skills),
         tools=list(tools),
+        events=(*configured_events, _AvalancheEvidenceSink()),
         **runtime_kwargs,
     )
 

--- a/src/avalanche/agent/config.py
+++ b/src/avalanche/agent/config.py
@@ -10,15 +10,15 @@ from typing import Any, Mapping
 
 UNSET = object()
 
-# These are not PredictRLM runtime kwargs. Signatures describe only model
-# inputs/outputs; skills and tools belong to the agent-step decorator.
+# These are not agent runtime kwargs. Signatures describe only model inputs and
+# outputs; skills and tools belong to the agent-step decorator.
 _RESERVED_RUNTIME_KWARGS = frozenset({"signature", "skills", "tools"})
 
 
 def validate_runtime_kwargs(kwargs: Mapping[str, Any], *, owner: str) -> dict[str, Any]:
     """Return a copy of runtime kwargs or reject agent-definition fields."""
     if not isinstance(kwargs, Mapping):
-        raise TypeError(f"{owner} must be a mapping of PredictRLM runtime kwargs")
+        raise TypeError(f"{owner} must be a mapping of agent runtime kwargs")
     reserved = sorted(_RESERVED_RUNTIME_KWARGS & set(kwargs))
     if reserved:
         rendered = ", ".join(repr(name) for name in reserved)

--- a/src/runtime/executor.py
+++ b/src/runtime/executor.py
@@ -7,10 +7,35 @@ Provides abstract interface for different execution backends:
 - (Future: DaskExecutor, etc.)
 """
 
+import json
+import os
 from functools import wraps
+from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
 from typing import Any, Callable, Protocol
+from urllib.parse import unquote, urlparse
 
 from ._async import call_sync_or_async, resolve_awaitable
+
+
+def _configure_ray_for_external_predict_rlm() -> None:
+    """Keep Ray workers on this environment when predict-rlm is a sibling edit."""
+    try:
+        direct_url_text = distribution("predict-rlm").read_text("direct_url.json")
+        direct_url = json.loads(direct_url_text or "{}")
+        source_url = direct_url.get("url", "")
+        source_path = Path(unquote(urlparse(source_url).path)).resolve()
+    except (json.JSONDecodeError, PackageNotFoundError, TypeError, ValueError):
+        return
+    editable = direct_url.get("dir_info", {}).get("editable") is True
+    if editable and not source_path.is_relative_to(Path.cwd().resolve()):
+        # Ray's uv hook copies only the current project, so a sibling path source
+        # disappears before workers can resolve the lock. Local Ray workers can
+        # and should reuse the already-synced interpreter instead.
+        os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+
+
+_configure_ray_for_external_predict_rlm()
 
 
 def _normalize_distributed_result(value: Any) -> Any:

--- a/src/runtime/operator/convert.py
+++ b/src/runtime/operator/convert.py
@@ -38,6 +38,8 @@ def workflow_info_to_proto(info: WorkflowInfo) -> pb.FlowInfoMsg:
         root_alias=info.root_alias,
         relative_file=relative_file,
         builder_symbol=info.builder_symbol,
+        agent_node_ids=info.agent_node_ids,
+        agent_metadata_json=info.agent_metadata_json,
     )
 
 
@@ -52,6 +54,8 @@ def workflow_info_from_proto(msg: pb.FlowInfoMsg) -> WorkflowInfo:
         graph=graph,
         node_types=dict(msg.node_types),
         display_names=dict(msg.display_names),
+        agent_node_ids=list(msg.agent_node_ids),
+        agent_metadata_json=dict(msg.agent_metadata_json),
         cron=msg.cron if msg.cron else None,
         next_run_at=msg.next_run_at if msg.next_run_at else None,
         last_run_at=msg.last_run_at if msg.last_run_at else None,
@@ -91,6 +95,7 @@ def node_state_to_proto(ns: NodeState) -> pb.NodeStateMsg:
         status=ns.status.value,
         started_at=ns.started_at or 0.0,
         ended_at=ns.ended_at or 0.0,
+        agent_trace_json=ns.agent_trace_json or "",
     )
 
 
@@ -102,6 +107,7 @@ def node_state_from_proto(msg: pb.NodeStateMsg) -> NodeState:
         status=NodeStatus(msg.status),
         started_at=msg.started_at if msg.started_at else None,
         ended_at=msg.ended_at if msg.ended_at else None,
+        agent_trace_json=msg.agent_trace_json or None,
     )
 
 

--- a/src/runtime/operator/discovery.py
+++ b/src/runtime/operator/discovery.py
@@ -71,9 +71,7 @@ def configure_roots(paths: list[str]) -> tuple[ConfiguredRoot, ...]:
 
 def discover(
     roots: tuple[ConfiguredRoot, ...], *, timeout: float = DEFAULT_DISCOVERY_TIMEOUT
-) -> tuple[
-    tuple[WorkflowDescriptor, ...], tuple[WorkflowDiscoveryDiagnostic, ...]
-]:
+) -> tuple[tuple[WorkflowDescriptor, ...], tuple[WorkflowDiscoveryDiagnostic, ...]]:
     """Discover in a short-lived interpreter and return value-only results."""
     payload = {
         "roots": [
@@ -117,9 +115,7 @@ def discover(
                 try:
                     process.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
-                    return (), (
-                        _discovery_failure(f"Discovery exceeded {timeout:.1f}s"),
-                    )
+                    return (), (_discovery_failure(f"Discovery exceeded {timeout:.1f}s"),)
                 finally:
                     _terminate_discovery_process(process, windows_job)
                     terminated = True
@@ -137,9 +133,7 @@ def discover(
             return (), (_discovery_failure(captured or "Discovery worker failed"),)
         try:
             result = json.loads(result_path.read_text())
-            descriptors = tuple(
-                _descriptor_from_dict(item) for item in result["descriptors"]
-            )
+            descriptors = tuple(_descriptor_from_dict(item) for item in result["descriptors"])
             diagnostics = tuple(
                 WorkflowDiscoveryDiagnostic(**item) for item in result["diagnostics"]
             )
@@ -205,9 +199,7 @@ def _bounded_diagnostic(value: str, limit: int = 4000) -> str:
 
 
 def _discovery_failure(message: str) -> WorkflowDiscoveryDiagnostic:
-    return WorkflowDiscoveryDiagnostic(
-        path="<discovery>", kind="import_error", message=message
-    )
+    return WorkflowDiscoveryDiagnostic(path="<discovery>", kind="import_error", message=message)
 
 
 def load_builder(root: ConfiguredRoot, locator: WorkflowLocator):
@@ -241,11 +233,7 @@ def _iter_files(root: ConfiguredRoot) -> list[Path]:
         return [root.target] if root.target.suffix == ".py" else []
     if not root.target.is_dir():
         return []
-    return [
-        path
-        for path in sorted(root.target.rglob("*.py"))
-        if not path.name.startswith("_")
-    ]
+    return [path for path in sorted(root.target.rglob("*.py")) if not path.name.startswith("_")]
 
 
 def _package_module_name(file_path: Path) -> tuple[str, Path] | None:
@@ -394,6 +382,28 @@ def _descriptor_to_dict(
     workflow: Workflow,
 ) -> dict[str, Any]:
     node_ids = workflow._topological_sort()
+    agent_node_ids = []
+    agent_metadata_json = []
+    for node_id in node_ids:
+        spec = getattr(workflow.nodes[node_id].node.fn, "__agent_step__", None)
+        if spec is None:
+            continue
+        agent_node_ids.append(node_id)
+        try:
+            metadata = spec.declaration_metadata(workflow.agent_defaults)
+            agent_metadata_json.append(
+                [
+                    node_id,
+                    json.dumps(
+                        metadata,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                ]
+            )
+        except Exception:
+            continue
     return {
         "workflow_id": workflow_id,
         "display_name": workflow.name,
@@ -406,6 +416,8 @@ def _descriptor_to_dict(
         "graph": [[key, value] for key, value in workflow.graph.items()],
         "node_types": [[nid, workflow.nodes[nid].node.node_type.value] for nid in node_ids],
         "display_names": [[nid, display_name_from_id(nid)] for nid in node_ids],
+        "agent_node_ids": agent_node_ids,
+        "agent_metadata_json": agent_metadata_json,
         "cron": workflow.cron,
     }
 
@@ -419,6 +431,10 @@ def _descriptor_from_dict(item: dict[str, Any]) -> WorkflowDescriptor:
         graph=tuple((key, tuple(value)) for key, value in item["graph"]),
         node_types=tuple((key, value) for key, value in item["node_types"]),
         display_names=tuple((key, value) for key, value in item["display_names"]),
+        agent_node_ids=tuple(item.get("agent_node_ids", ())),
+        agent_metadata_json=tuple(
+            (key, value) for key, value in item.get("agent_metadata_json", ())
+        ),
         cron=item["cron"],
     )
 

--- a/src/runtime/operator/models.py
+++ b/src/runtime/operator/models.py
@@ -49,6 +49,7 @@ class NodeState:
     status: NodeStatus = NodeStatus.PENDING
     started_at: float | None = None
     ended_at: float | None = None
+    agent_trace_json: str | None = None
 
     @property
     def elapsed(self) -> float | None:
@@ -89,6 +90,8 @@ class WorkflowInfo:
     graph: dict[str, list[str]]  # adjacency list (parent -> children)
     node_types: dict[str, str]  # node_id -> "source" | "step" | "dest"
     display_names: dict[str, str] = field(default_factory=dict)  # node_id -> display name
+    agent_node_ids: list[str] = field(default_factory=list)
+    agent_metadata_json: dict[str, str] = field(default_factory=dict)
     cron: str | None = None  # cron expression for scheduled execution
     next_run_at: float | None = None  # unix timestamp of next scheduled run
     last_run_at: float | None = None  # unix timestamp of last triggered run
@@ -141,6 +144,8 @@ class WorkflowDescriptor:
     graph: tuple[tuple[str, tuple[str, ...]], ...]
     node_types: tuple[tuple[str, str], ...]
     display_names: tuple[tuple[str, str], ...]
+    agent_node_ids: tuple[str, ...] = ()
+    agent_metadata_json: tuple[tuple[str, str], ...] = ()
     cron: str | None = None
 
 

--- a/src/runtime/operator/operator.py
+++ b/src/runtime/operator/operator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import multiprocessing
@@ -759,6 +760,16 @@ class Operator:
                         node.started_at = event["timestamp"]
                     else:
                         node.ended_at = event["timestamp"]
+            elif event_type == "agent_evidence":
+                node_id = event["node_id"]
+                if node_id not in run.nodes:
+                    raise _CoordinatorProtocolError(
+                        "agent evidence references unpublished node "
+                        f"{_bounded_ascii(node_id)}"
+                    )
+                log_entry = self._record_agent_evidence_event(
+                    run, node_id, event["event"], notify=False
+                )
             elif event_type == "log":
                 if run.status in {
                     RunStatus.SUCCESS,
@@ -802,6 +813,113 @@ class Operator:
             self._notify_log(log_entry)
         self._notify_run(run)
         return event_type == "terminal"
+
+    def _record_agent_evidence_event(
+        self,
+        run: RunState,
+        node_id: str,
+        event: dict[str, Any],
+        *,
+        notify: bool = True,
+    ) -> LogEntry | None:
+        """Merge one best-effort agent event into its node trace envelope."""
+        node = run.nodes.get(node_id)
+        if node is None or not isinstance(event, dict):
+            return None
+        try:
+            envelope = (
+                json.loads(node.agent_trace_json)
+                if node.agent_trace_json is not None
+                else {
+                    "schema_version": 1,
+                    "status": "in_progress",
+                    "run_id": None,
+                    "events": [],
+                    "trace": None,
+                    "error": None,
+                }
+            )
+            if not isinstance(envelope, dict):
+                return None
+            events = envelope.get("events")
+            if not isinstance(events, list):
+                return None
+
+            kind = event.get("kind")
+            level = LogLevel.INFO
+            if kind == "evidence":
+                sequence = event.get("sequence")
+                event_kind = event.get("event_kind")
+                timestamp_ns = event.get("timestamp_ns")
+                data = event.get("data", {})
+                if (
+                    not isinstance(sequence, int)
+                    or sequence < 1
+                    or not isinstance(event_kind, str)
+                    or not isinstance(timestamp_ns, int)
+                    or not isinstance(data, dict)
+                ):
+                    return None
+                last_sequence = events[-1].get("sequence", 0) if events else 0
+                if sequence <= last_sequence:
+                    return None
+                events.append(
+                    {
+                        "sequence": sequence,
+                        "event_kind": event_kind,
+                        "timestamp_ns": timestamp_ns,
+                        "data": data,
+                    }
+                )
+                detail = []
+                if data.get("iteration") is not None:
+                    detail.append(f"iteration={data['iteration']}")
+                if data.get("duration_ms") is not None:
+                    detail.append(f"duration={data['duration_ms']}ms")
+                if data.get("error"):
+                    detail.append(f"error={data['error']}")
+                message = f"Agent {event_kind}"
+                if detail:
+                    message += " " + " ".join(detail)
+                if data.get("error") or event_kind in {"run.failed", "run.cancelled"}:
+                    level = LogLevel.ERROR
+                    envelope["status"] = "error"
+                    envelope["error"] = str(data.get("error") or event_kind)
+            elif kind == "trace_finished":
+                trace = event.get("trace")
+                if not isinstance(trace, dict):
+                    return None
+                envelope["trace"] = trace
+                envelope["status"] = str(trace.get("status") or "unavailable")
+                evidence = trace.get("evidence")
+                if isinstance(evidence, dict):
+                    envelope["run_id"] = evidence.get("run_id")
+                message = f"Agent trace {envelope['status']}"
+                if envelope["status"] == "error":
+                    level = LogLevel.ERROR
+            elif kind == "trace_unavailable":
+                error = event.get("error")
+                envelope["status"] = "unavailable"
+                envelope["error"] = str(error or "Agent trace unavailable")
+                message = f"Agent trace unavailable: {envelope['error']}"
+                level = LogLevel.WARN
+            else:
+                return None
+
+            node.agent_trace_json = json.dumps(envelope, default=str)
+            entry = LogEntry(
+                timestamp=datetime.now(),
+                level=level,
+                node_id=node_id,
+                message=message,
+            )
+            run.logs.append(entry)
+            if notify:
+                self._notify_log(entry)
+                self._notify_run(run)
+            return entry
+        except BaseException:
+            return None
 
     def _finish_protocol_fault(
         self,
@@ -918,6 +1036,7 @@ _RUN_EVENT_TYPES = {
     "node_started",
     "node_succeeded",
     "node_failed",
+    "agent_evidence",
     "log",
     "terminal",
 }
@@ -1007,6 +1126,12 @@ def _validate_run_event(event: object, *, validate_result: bool = True) -> str:
         _timestamp_field(event, "timestamp")
         if event_type == "node_failed":
             _string_field(event, "error", maximum_length=_MAX_EVENT_MESSAGE_LENGTH)
+    elif event_type == "agent_evidence":
+        _require_exact_event_keys(event, {"type", "node_id", "event"})
+        _string_field(event, "node_id", maximum_length=_MAX_EVENT_FIELD_LENGTH)
+        agent_event = _required_field(event, "event")
+        if type(agent_event) is not dict:
+            raise _CoordinatorProtocolError("field 'event' must be a dict")
     elif event_type == "log":
         _require_exact_event_keys(
             event,

--- a/src/runtime/operator/proto/operator.proto
+++ b/src/runtime/operator/proto/operator.proto
@@ -77,6 +77,8 @@ message FlowInfoMsg {
   string root_alias = 12;
   string relative_file = 13;
   string builder_symbol = 14;
+  repeated string agent_node_ids = 15;
+  map<string, string> agent_metadata_json = 16;
 }
 
 message FlowList {
@@ -97,6 +99,7 @@ message NodeStateMsg {
   string status = 4;
   double started_at = 5;
   double ended_at = 6;
+  string agent_trace_json = 7;
 }
 
 message LogEntryMsg {

--- a/src/runtime/operator/proto/operator_pb2.py
+++ b/src/runtime/operator/proto/operator_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eoperator.proto\x12\x12\x61valanche.operator\"\x07\n\x05\x45mpty\"\xb2\x01\n\x0fStartRunRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x12\n\ninput_json\x18\x02 \x01(\t\x12\x14\n\x0c\x63ontext_json\x18\x03 \x01(\t\x12\x37\n\x0binput_files\x18\x04 \x03(\x0b\x32\".avalanche.operator.FileAttachment\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x19\n\x11workflow_selector\x18\x07 \x01(\t\"i\n\x0e\x46ileAttachment\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x14\n\x0c\x63ontent_type\x18\x04 \x01(\t\x12\x0e\n\x06sha256\x18\x05 \x01(\t\"\"\n\x10StartRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\"\n\x10\x43\x61ncelRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"?\n\x0fListRunsRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x19\n\x11workflow_selector\x18\x02 \x01(\t\"\x1f\n\rGetRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\'\n\rStreamRequest\x12\x16\n\x0esince_sequence\x18\x01 \x01(\x04\"\x1d\n\tNodeEdges\x12\x10\n\x08\x63hildren\x18\x01 \x03(\t\"\xe3\x04\n\x0b\x46lowInfoMsg\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\x10\n\x08node_ids\x18\x03 \x03(\t\x12\x39\n\x05graph\x18\x04 \x03(\x0b\x32*.avalanche.operator.FlowInfoMsg.GraphEntry\x12\x42\n\nnode_types\x18\x05 \x03(\x0b\x32..avalanche.operator.FlowInfoMsg.NodeTypesEntry\x12H\n\rdisplay_names\x18\x06 \x03(\x0b\x32\x31.avalanche.operator.FlowInfoMsg.DisplayNamesEntry\x12\x0c\n\x04\x63ron\x18\x07 \x01(\t\x12\x13\n\x0bnext_run_at\x18\x08 \x01(\x01\x12\x13\n\x0blast_run_at\x18\t \x01(\x01\x12\x13\n\x0bworkflow_id\x18\n \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x0b \x01(\t\x12\x12\n\nroot_alias\x18\x0c \x01(\t\x12\x15\n\rrelative_file\x18\r \x01(\t\x12\x16\n\x0e\x62uilder_symbol\x18\x0e \x01(\t\x1aK\n\nGraphEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.avalanche.operator.NodeEdges:\x02\x38\x01\x1a\x30\n\x0eNodeTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x33\n\x11\x44isplayNamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"{\n\x08\x46lowList\x12.\n\x05\x66lows\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.FlowInfoMsg\x12?\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32*.avalanche.operator.DiscoveryDiagnosticMsg\"E\n\x16\x44iscoveryDiagnosticMsg\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\"v\n\x0cNodeStateMsg\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tnode_type\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x12\n\nstarted_at\x18\x05 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x06 \x01(\x01\"Q\n\x0bLogEntryMsg\x12\x11\n\ttimestamp\x18\x01 \x01(\x01\x12\r\n\x05level\x18\x02 \x01(\t\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\x0f\n\x07message\x18\x04 \x01(\t\"\x90\x02\n\x0bRunStateMsg\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tflow_name\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12\x12\n\nstarted_at\x18\x04 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x05 \x01(\x01\x12/\n\x05nodes\x18\x06 \x03(\x0b\x32 .avalanche.operator.NodeStateMsg\x12-\n\x04logs\x18\x07 \x03(\x0b\x32\x1f.avalanche.operator.LogEntryMsg\x12\x14\n\x0ctriggered_by\x18\x08 \x01(\t\x12\x13\n\x0bworkflow_id\x18\t \x01(\t\x12\x1d\n\x15workflow_display_name\x18\n \x01(\t\"8\n\x07RunList\x12-\n\x04runs\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.RunStateMsg\"\x92\x01\n\x14ResultFileAttachment\x12\x15\n\rattachment_id\x18\x01 \x01(\t\x12\x11\n\x04name\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x17\n\nmedia_type\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x0e\n\x06sha256\x18\x05 \x01(\tB\x07\n\x05_nameB\r\n\x0b_media_type\"[\n\x0cRunResultMsg\x12\x12\n\nvalue_json\x18\x01 \x01(\t\x12\x37\n\x05\x66iles\x18\x02 \x03(\x0b\x32(.avalanche.operator.ResultFileAttachment\"K\n\tRunUpdate\x12\x10\n\x08sequence\x18\x01 \x01(\x04\x12,\n\x03run\x18\x02 \x01(\x0b\x32\x1f.avalanche.operator.RunStateMsg2\xc2\x04\n\x0fOperatorService\x12\x44\n\tListFlows\x12\x19.avalanche.operator.Empty\x1a\x1c.avalanche.operator.FlowList\x12U\n\x08StartRun\x12#.avalanche.operator.StartRunRequest\x1a$.avalanche.operator.StartRunResponse\x12L\n\tCancelRun\x12$.avalanche.operator.CancelRunRequest\x1a\x19.avalanche.operator.Empty\x12L\n\x08ListRuns\x12#.avalanche.operator.ListRunsRequest\x1a\x1b.avalanche.operator.RunList\x12L\n\x06GetRun\x12!.avalanche.operator.GetRunRequest\x1a\x1f.avalanche.operator.RunStateMsg\x12S\n\x0cGetRunResult\x12!.avalanche.operator.GetRunRequest\x1a .avalanche.operator.RunResultMsg\x12S\n\rStreamUpdates\x12!.avalanche.operator.StreamRequest\x1a\x1d.avalanche.operator.RunUpdate0\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eoperator.proto\x12\x12\x61valanche.operator\"\x07\n\x05\x45mpty\"\xb2\x01\n\x0fStartRunRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x12\n\ninput_json\x18\x02 \x01(\t\x12\x14\n\x0c\x63ontext_json\x18\x03 \x01(\t\x12\x37\n\x0binput_files\x18\x04 \x03(\x0b\x32\".avalanche.operator.FileAttachment\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x19\n\x11workflow_selector\x18\x07 \x01(\t\"i\n\x0e\x46ileAttachment\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x14\n\x0c\x63ontent_type\x18\x04 \x01(\t\x12\x0e\n\x06sha256\x18\x05 \x01(\t\"\"\n\x10StartRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\"\n\x10\x43\x61ncelRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"?\n\x0fListRunsRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x19\n\x11workflow_selector\x18\x02 \x01(\t\"\x1f\n\rGetRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\'\n\rStreamRequest\x12\x16\n\x0esince_sequence\x18\x01 \x01(\x04\"\x1d\n\tNodeEdges\x12\x10\n\x08\x63hildren\x18\x01 \x03(\t\"\x8a\x06\n\x0b\x46lowInfoMsg\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\x10\n\x08node_ids\x18\x03 \x03(\t\x12\x39\n\x05graph\x18\x04 \x03(\x0b\x32*.avalanche.operator.FlowInfoMsg.GraphEntry\x12\x42\n\nnode_types\x18\x05 \x03(\x0b\x32..avalanche.operator.FlowInfoMsg.NodeTypesEntry\x12H\n\rdisplay_names\x18\x06 \x03(\x0b\x32\x31.avalanche.operator.FlowInfoMsg.DisplayNamesEntry\x12\x0c\n\x04\x63ron\x18\x07 \x01(\t\x12\x13\n\x0bnext_run_at\x18\x08 \x01(\x01\x12\x13\n\x0blast_run_at\x18\t \x01(\x01\x12\x13\n\x0bworkflow_id\x18\n \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x0b \x01(\t\x12\x12\n\nroot_alias\x18\x0c \x01(\t\x12\x15\n\rrelative_file\x18\r \x01(\t\x12\x16\n\x0e\x62uilder_symbol\x18\x0e \x01(\t\x12\x16\n\x0e\x61gent_node_ids\x18\x0f \x03(\t\x12S\n\x13\x61gent_metadata_json\x18\x10 \x03(\x0b\x32\x36.avalanche.operator.FlowInfoMsg.AgentMetadataJsonEntry\x1aK\n\nGraphEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.avalanche.operator.NodeEdges:\x02\x38\x01\x1a\x30\n\x0eNodeTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x33\n\x11\x44isplayNamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x38\n\x16\x41gentMetadataJsonEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"{\n\x08\x46lowList\x12.\n\x05\x66lows\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.FlowInfoMsg\x12?\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32*.avalanche.operator.DiscoveryDiagnosticMsg\"E\n\x16\x44iscoveryDiagnosticMsg\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\"\x90\x01\n\x0cNodeStateMsg\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tnode_type\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x12\n\nstarted_at\x18\x05 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x06 \x01(\x01\x12\x18\n\x10\x61gent_trace_json\x18\x07 \x01(\t\"Q\n\x0bLogEntryMsg\x12\x11\n\ttimestamp\x18\x01 \x01(\x01\x12\r\n\x05level\x18\x02 \x01(\t\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\x0f\n\x07message\x18\x04 \x01(\t\"\x90\x02\n\x0bRunStateMsg\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tflow_name\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12\x12\n\nstarted_at\x18\x04 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x05 \x01(\x01\x12/\n\x05nodes\x18\x06 \x03(\x0b\x32 .avalanche.operator.NodeStateMsg\x12-\n\x04logs\x18\x07 \x03(\x0b\x32\x1f.avalanche.operator.LogEntryMsg\x12\x14\n\x0ctriggered_by\x18\x08 \x01(\t\x12\x13\n\x0bworkflow_id\x18\t \x01(\t\x12\x1d\n\x15workflow_display_name\x18\n \x01(\t\"8\n\x07RunList\x12-\n\x04runs\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.RunStateMsg\"\x92\x01\n\x14ResultFileAttachment\x12\x15\n\rattachment_id\x18\x01 \x01(\t\x12\x11\n\x04name\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x17\n\nmedia_type\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x0e\n\x06sha256\x18\x05 \x01(\tB\x07\n\x05_nameB\r\n\x0b_media_type\"[\n\x0cRunResultMsg\x12\x12\n\nvalue_json\x18\x01 \x01(\t\x12\x37\n\x05\x66iles\x18\x02 \x03(\x0b\x32(.avalanche.operator.ResultFileAttachment\"K\n\tRunUpdate\x12\x10\n\x08sequence\x18\x01 \x01(\x04\x12,\n\x03run\x18\x02 \x01(\x0b\x32\x1f.avalanche.operator.RunStateMsg2\xc2\x04\n\x0fOperatorService\x12\x44\n\tListFlows\x12\x19.avalanche.operator.Empty\x1a\x1c.avalanche.operator.FlowList\x12U\n\x08StartRun\x12#.avalanche.operator.StartRunRequest\x1a$.avalanche.operator.StartRunResponse\x12L\n\tCancelRun\x12$.avalanche.operator.CancelRunRequest\x1a\x19.avalanche.operator.Empty\x12L\n\x08ListRuns\x12#.avalanche.operator.ListRunsRequest\x1a\x1b.avalanche.operator.RunList\x12L\n\x06GetRun\x12!.avalanche.operator.GetRunRequest\x1a\x1f.avalanche.operator.RunStateMsg\x12S\n\x0cGetRunResult\x12!.avalanche.operator.GetRunRequest\x1a .avalanche.operator.RunResultMsg\x12S\n\rStreamUpdates\x12!.avalanche.operator.StreamRequest\x1a\x1d.avalanche.operator.RunUpdate0\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -37,6 +37,8 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_options = b'8\001'
   _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._loaded_options = None
   _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_options = b'8\001'
+  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._loaded_options = None
+  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._serialized_options = b'8\001'
   _globals['_EMPTY']._serialized_start=38
   _globals['_EMPTY']._serialized_end=45
   _globals['_STARTRUNREQUEST']._serialized_start=48
@@ -56,31 +58,33 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_NODEEDGES']._serialized_start=546
   _globals['_NODEEDGES']._serialized_end=575
   _globals['_FLOWINFOMSG']._serialized_start=578
-  _globals['_FLOWINFOMSG']._serialized_end=1189
-  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_start=1011
-  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_end=1086
-  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_start=1088
-  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_end=1136
-  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_start=1138
-  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_end=1189
-  _globals['_FLOWLIST']._serialized_start=1191
-  _globals['_FLOWLIST']._serialized_end=1314
-  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_start=1316
-  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_end=1385
-  _globals['_NODESTATEMSG']._serialized_start=1387
-  _globals['_NODESTATEMSG']._serialized_end=1505
-  _globals['_LOGENTRYMSG']._serialized_start=1507
-  _globals['_LOGENTRYMSG']._serialized_end=1588
-  _globals['_RUNSTATEMSG']._serialized_start=1591
-  _globals['_RUNSTATEMSG']._serialized_end=1863
-  _globals['_RUNLIST']._serialized_start=1865
-  _globals['_RUNLIST']._serialized_end=1921
-  _globals['_RESULTFILEATTACHMENT']._serialized_start=1924
-  _globals['_RESULTFILEATTACHMENT']._serialized_end=2070
-  _globals['_RUNRESULTMSG']._serialized_start=2072
-  _globals['_RUNRESULTMSG']._serialized_end=2163
-  _globals['_RUNUPDATE']._serialized_start=2165
-  _globals['_RUNUPDATE']._serialized_end=2240
-  _globals['_OPERATORSERVICE']._serialized_start=2243
-  _globals['_OPERATORSERVICE']._serialized_end=2821
+  _globals['_FLOWINFOMSG']._serialized_end=1356
+  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_start=1120
+  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_end=1195
+  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_start=1197
+  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_end=1245
+  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_start=1247
+  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_end=1298
+  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._serialized_start=1300
+  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._serialized_end=1356
+  _globals['_FLOWLIST']._serialized_start=1358
+  _globals['_FLOWLIST']._serialized_end=1481
+  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_start=1483
+  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_end=1552
+  _globals['_NODESTATEMSG']._serialized_start=1555
+  _globals['_NODESTATEMSG']._serialized_end=1699
+  _globals['_LOGENTRYMSG']._serialized_start=1701
+  _globals['_LOGENTRYMSG']._serialized_end=1782
+  _globals['_RUNSTATEMSG']._serialized_start=1785
+  _globals['_RUNSTATEMSG']._serialized_end=2057
+  _globals['_RUNLIST']._serialized_start=2059
+  _globals['_RUNLIST']._serialized_end=2115
+  _globals['_RESULTFILEATTACHMENT']._serialized_start=2118
+  _globals['_RESULTFILEATTACHMENT']._serialized_end=2264
+  _globals['_RUNRESULTMSG']._serialized_start=2266
+  _globals['_RUNRESULTMSG']._serialized_end=2357
+  _globals['_RUNUPDATE']._serialized_start=2359
+  _globals['_RUNUPDATE']._serialized_end=2434
+  _globals['_OPERATORSERVICE']._serialized_start=2437
+  _globals['_OPERATORSERVICE']._serialized_end=3015
 # @@protoc_insertion_point(module_scope)

--- a/src/runtime/operator/proto/operator_pb2.pyi
+++ b/src/runtime/operator/proto/operator_pb2.pyi
@@ -79,7 +79,7 @@ class NodeEdges(_message.Message):
     def __init__(self, children: _Optional[_Iterable[str]] = ...) -> None: ...
 
 class FlowInfoMsg(_message.Message):
-    __slots__ = ("name", "file_path", "node_ids", "graph", "node_types", "display_names", "cron", "next_run_at", "last_run_at", "workflow_id", "display_name", "root_alias", "relative_file", "builder_symbol")
+    __slots__ = ("name", "file_path", "node_ids", "graph", "node_types", "display_names", "cron", "next_run_at", "last_run_at", "workflow_id", "display_name", "root_alias", "relative_file", "builder_symbol", "agent_node_ids", "agent_metadata_json")
     class GraphEntry(_message.Message):
         __slots__ = ("key", "value")
         KEY_FIELD_NUMBER: _ClassVar[int]
@@ -101,6 +101,13 @@ class FlowInfoMsg(_message.Message):
         key: str
         value: str
         def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    class AgentMetadataJsonEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: str
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
     NAME_FIELD_NUMBER: _ClassVar[int]
     FILE_PATH_FIELD_NUMBER: _ClassVar[int]
     NODE_IDS_FIELD_NUMBER: _ClassVar[int]
@@ -115,6 +122,8 @@ class FlowInfoMsg(_message.Message):
     ROOT_ALIAS_FIELD_NUMBER: _ClassVar[int]
     RELATIVE_FILE_FIELD_NUMBER: _ClassVar[int]
     BUILDER_SYMBOL_FIELD_NUMBER: _ClassVar[int]
+    AGENT_NODE_IDS_FIELD_NUMBER: _ClassVar[int]
+    AGENT_METADATA_JSON_FIELD_NUMBER: _ClassVar[int]
     name: str
     file_path: str
     node_ids: _containers.RepeatedScalarFieldContainer[str]
@@ -129,7 +138,9 @@ class FlowInfoMsg(_message.Message):
     root_alias: str
     relative_file: str
     builder_symbol: str
-    def __init__(self, name: _Optional[str] = ..., file_path: _Optional[str] = ..., node_ids: _Optional[_Iterable[str]] = ..., graph: _Optional[_Mapping[str, NodeEdges]] = ..., node_types: _Optional[_Mapping[str, str]] = ..., display_names: _Optional[_Mapping[str, str]] = ..., cron: _Optional[str] = ..., next_run_at: _Optional[float] = ..., last_run_at: _Optional[float] = ..., workflow_id: _Optional[str] = ..., display_name: _Optional[str] = ..., root_alias: _Optional[str] = ..., relative_file: _Optional[str] = ..., builder_symbol: _Optional[str] = ...) -> None: ...
+    agent_node_ids: _containers.RepeatedScalarFieldContainer[str]
+    agent_metadata_json: _containers.ScalarMap[str, str]
+    def __init__(self, name: _Optional[str] = ..., file_path: _Optional[str] = ..., node_ids: _Optional[_Iterable[str]] = ..., graph: _Optional[_Mapping[str, NodeEdges]] = ..., node_types: _Optional[_Mapping[str, str]] = ..., display_names: _Optional[_Mapping[str, str]] = ..., cron: _Optional[str] = ..., next_run_at: _Optional[float] = ..., last_run_at: _Optional[float] = ..., workflow_id: _Optional[str] = ..., display_name: _Optional[str] = ..., root_alias: _Optional[str] = ..., relative_file: _Optional[str] = ..., builder_symbol: _Optional[str] = ..., agent_node_ids: _Optional[_Iterable[str]] = ..., agent_metadata_json: _Optional[_Mapping[str, str]] = ...) -> None: ...
 
 class FlowList(_message.Message):
     __slots__ = ("flows", "diagnostics")
@@ -150,20 +161,22 @@ class DiscoveryDiagnosticMsg(_message.Message):
     def __init__(self, path: _Optional[str] = ..., kind: _Optional[str] = ..., message: _Optional[str] = ...) -> None: ...
 
 class NodeStateMsg(_message.Message):
-    __slots__ = ("node_id", "name", "node_type", "status", "started_at", "ended_at")
+    __slots__ = ("node_id", "name", "node_type", "status", "started_at", "ended_at", "agent_trace_json")
     NODE_ID_FIELD_NUMBER: _ClassVar[int]
     NAME_FIELD_NUMBER: _ClassVar[int]
     NODE_TYPE_FIELD_NUMBER: _ClassVar[int]
     STATUS_FIELD_NUMBER: _ClassVar[int]
     STARTED_AT_FIELD_NUMBER: _ClassVar[int]
     ENDED_AT_FIELD_NUMBER: _ClassVar[int]
+    AGENT_TRACE_JSON_FIELD_NUMBER: _ClassVar[int]
     node_id: str
     name: str
     node_type: str
     status: str
     started_at: float
     ended_at: float
-    def __init__(self, node_id: _Optional[str] = ..., name: _Optional[str] = ..., node_type: _Optional[str] = ..., status: _Optional[str] = ..., started_at: _Optional[float] = ..., ended_at: _Optional[float] = ...) -> None: ...
+    agent_trace_json: str
+    def __init__(self, node_id: _Optional[str] = ..., name: _Optional[str] = ..., node_type: _Optional[str] = ..., status: _Optional[str] = ..., started_at: _Optional[float] = ..., ended_at: _Optional[float] = ..., agent_trace_json: _Optional[str] = ...) -> None: ...
 
 class LogEntryMsg(_message.Message):
     __slots__ = ("timestamp", "level", "node_id", "message")

--- a/src/runtime/operator/registry.py
+++ b/src/runtime/operator/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 from collections import defaultdict
 from types import MappingProxyType
@@ -44,6 +45,20 @@ def workflow_to_info(
     node_ids = workflow._topological_sort()
     node_types = {nid: workflow.nodes[nid].node.node_type.value for nid in node_ids}
     display_names = {nid: display_name_from_id(nid) for nid in node_ids}
+    agent_node_ids = []
+    agent_metadata_json = {}
+    for nid in node_ids:
+        spec = getattr(workflow.nodes[nid].node.fn, "__agent_step__", None)
+        if spec is None:
+            continue
+        agent_node_ids.append(nid)
+        try:
+            metadata = spec.declaration_metadata(workflow.agent_defaults)
+            agent_metadata_json[nid] = json.dumps(
+                metadata, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+            )
+        except Exception:
+            continue
     return WorkflowInfo(
         name=workflow.name,
         display_name=workflow.name,
@@ -56,6 +71,8 @@ def workflow_to_info(
         graph=dict(workflow.graph),
         node_types=node_types,
         display_names=display_names,
+        agent_node_ids=agent_node_ids,
+        agent_metadata_json=agent_metadata_json,
         cron=workflow.cron,
     )
 
@@ -74,6 +91,8 @@ def descriptor_to_info(descriptor: WorkflowDescriptor) -> WorkflowInfo:
         graph={key: list(value) for key, value in descriptor.graph},
         node_types=dict(descriptor.node_types),
         display_names=dict(descriptor.display_names),
+        agent_node_ids=list(descriptor.agent_node_ids),
+        agent_metadata_json=dict(descriptor.agent_metadata_json),
         cron=descriptor.cron,
     )
 
@@ -108,9 +127,7 @@ class WorkflowRegistry:
         by_id: dict[str, WorkflowDescriptor] = {}
         for descriptor in descriptors:
             if descriptor.workflow_id in by_id:
-                raise ValueError(
-                    f"Duplicate canonical workflow ID: {descriptor.workflow_id}"
-                )
+                raise ValueError(f"Duplicate canonical workflow ID: {descriptor.workflow_id}")
             by_id[descriptor.workflow_id] = descriptor
         short_names: defaultdict[str, list[str]] = defaultdict(list)
         for descriptor in descriptors:

--- a/src/runtime/operator/run_worker.py
+++ b/src/runtime/operator/run_worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import os
 import sys
@@ -13,6 +14,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Any, Callable
 
+from avalanche._agent_evidence import capture_agent_evidence
 from avalanche.dag import Workflow
 
 from ..executor import Executor, LocalExecutor, RayExecutor
@@ -144,8 +146,10 @@ def _run_worker(
             executor = LocalExecutor()
 
             def wrap_fn(node_id: str, fn: Callable[..., Any]) -> Callable[..., Any]:
-                return _with_node_streams(node_id, fn, stdout, stderr)
-
+                wrapped = _with_node_streams(node_id, fn, stdout, stderr)
+                if getattr(fn, "__agent_step__", None) is not None:
+                    return _with_agent_evidence(node_id, wrapped, event_queue)
+                return wrapped
         elif executor_mode == "ray":
             import ray
 
@@ -172,8 +176,10 @@ def _run_worker(
             ray_log_drain.start()
 
             def wrap_fn(node_id: str, fn: Callable[..., Any]) -> Callable[..., Any]:
-                return _with_ray_node_streams(node_id, fn, ray_log_queue)
-
+                wrapped = _with_ray_node_streams(node_id, fn, ray_log_queue)
+                if getattr(fn, "__agent_step__", None) is not None:
+                    return _with_agent_evidence(node_id, wrapped, ray_log_queue)
+                return wrapped
         else:
             raise ValueError(f"Unknown executor mode: {executor_mode}")
 
@@ -411,6 +417,42 @@ def _with_node_streams(
 
     wrapper.__name__ = fn.__name__
     wrapper.__qualname__ = fn.__qualname__
+    return wrapper
+
+
+def _with_agent_evidence(
+    node_id: str,
+    fn: Callable[..., Any],
+    event_queue: Any,
+) -> Callable[..., Any]:
+    """Forward agent evidence through the coordinator's event protocol."""
+
+    def emit(event: dict[str, Any]) -> None:
+        try:
+            event_queue.put(
+                {
+                    "type": "agent_evidence",
+                    "node_id": node_id,
+                    "event": event,
+                }
+            )
+        except BaseException:
+            pass
+
+    if inspect.iscoroutinefunction(fn):
+
+        @wraps(fn)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            with capture_agent_evidence(emit):
+                return await fn(*args, **kwargs)
+
+        return async_wrapper
+
+    @wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        with capture_agent_evidence(emit):
+            return fn(*args, **kwargs)
+
     return wrapper
 
 

--- a/src/runtime/operator/run_worker.py
+++ b/src/runtime/operator/run_worker.py
@@ -146,10 +146,7 @@ def _run_worker(
             executor = LocalExecutor()
 
             def wrap_fn(node_id: str, fn: Callable[..., Any]) -> Callable[..., Any]:
-                wrapped = _with_node_streams(node_id, fn, stdout, stderr)
-                if getattr(fn, "__agent_step__", None) is not None:
-                    return _with_agent_evidence(node_id, wrapped, event_queue)
-                return wrapped
+                return _with_local_node_observers(node_id, fn, stdout, stderr, event_queue)
         elif executor_mode == "ray":
             import ray
 
@@ -176,10 +173,7 @@ def _run_worker(
             ray_log_drain.start()
 
             def wrap_fn(node_id: str, fn: Callable[..., Any]) -> Callable[..., Any]:
-                wrapped = _with_ray_node_streams(node_id, fn, ray_log_queue)
-                if getattr(fn, "__agent_step__", None) is not None:
-                    return _with_agent_evidence(node_id, wrapped, ray_log_queue)
-                return wrapped
+                return _with_ray_node_observers(node_id, fn, ray_log_queue)
         else:
             raise ValueError(f"Unknown executor mode: {executor_mode}")
 
@@ -395,6 +389,18 @@ class _QueueStream:
         )
 
 
+def _with_local_node_observers(
+    node_id: str,
+    fn: Callable[..., Any],
+    stdout: _QueueStream,
+    stderr: _QueueStream,
+    event_queue: Any,
+) -> Callable[..., Any]:
+    if getattr(fn, "__agent_step__", None) is not None:
+        fn = _with_agent_evidence(node_id, fn, event_queue)
+    return _with_node_streams(node_id, fn, stdout, stderr)
+
+
 def _with_node_streams(
     node_id: str,
     fn: Callable[..., Any],
@@ -457,6 +463,16 @@ def _with_agent_evidence(
 
 
 _RAY_LOG_STOP = {"type": "_ray_log_stop"}
+
+
+def _with_ray_node_observers(
+    node_id: str,
+    fn: Callable[..., Any],
+    ray_log_queue: Any,
+) -> Callable[..., Any]:
+    if getattr(fn, "__agent_step__", None) is not None:
+        fn = _with_agent_evidence(node_id, fn, ray_log_queue)
+    return _with_ray_node_streams(node_id, fn, ray_log_queue)
 
 
 def _with_ray_node_streams(

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -14,6 +14,7 @@ from .screens.workflow_detail import WorkflowDetailScreen
 from .state import StateProvider
 from .theme import AVALANCHE_THEME
 from .ui_store import UIStore
+from .widgets.agent_trace import AgentMetadataInspector, AgentTraceInspector
 from .widgets.log_panel import LogWidget
 from .widgets.run_history import RunHistoryWidget
 from .widgets.sidebar import Sidebar
@@ -24,6 +25,7 @@ _PANE_WIDGET_IDS = {
     "dag": "dag-container",
     "run-history": "run-history",
     "log": "log-panel",
+    "trace": "agent-trace-inspector",
 }
 
 
@@ -57,6 +59,7 @@ class AvalancheApp(App):
         ("s", "toggle_autoscroll", "Autoscroll"),
         ("w", "toggle_wrap", "Wrap"),
         ("enter", "activate", "Enter"),
+        Binding("m", "toggle_trace_inspector_tab", "Trace/Metadata", priority=True),
     ]
 
     def __init__(
@@ -68,9 +71,10 @@ class AvalancheApp(App):
         super().__init__()
         self.register_theme(AVALANCHE_THEME)
         self.theme = "avalanche"
-        self.store = UIStore(
-            provider or MockStateProvider(), defer_initial_catalog=provider is not None
-        )
+        defer_initial_catalog = provider is not None
+        if provider is None:
+            provider = MockStateProvider(include_agent_trace=workflow == "agent_trace")
+        self.store = UIStore(provider, defer_initial_catalog=defer_initial_catalog)
         self._timer: Timer | None = None
         self._screen: WorkflowDetailScreen | None = None
         self._leader_pending: bool = False
@@ -85,9 +89,7 @@ class AvalancheApp(App):
         workflow = self._deep_link_workflow
         node = self._deep_link_node
         if workflow:
-            match = next(
-                (p for p in self.store.workflows if p.selector == workflow), None
-            )
+            match = next((p for p in self.store.workflows if p.selector == workflow), None)
             if match is None:
                 short_matches = [
                     p
@@ -148,6 +150,30 @@ class AvalancheApp(App):
         """Refresh all visible widgets to reflect current store state."""
         if not self._screen:
             return
+        try:
+            dashboard = self._screen.query_one("#dashboard-pane")
+            inspector = self._screen.query_one("#agent-trace-inspector")
+            trace_content = self._screen.query_one("#agent-trace-content", AgentTraceInspector)
+            metadata_content = self._screen.query_one(
+                "#agent-metadata-content", AgentMetadataInspector
+            )
+            dashboard.display = not self.store.trace_inspector_open
+            inspector.display = self.store.trace_inspector_open
+            trace_active = self.store.trace_inspector_tab == "trace"
+            trace_content.display = trace_active
+            metadata_content.display = not trace_active
+            node_id = self.store.selected_agent_node_id
+            workflow = self.store.current_workflow
+            display_name = (
+                workflow.display_names.get(node_id, node_id)
+                if workflow is not None and node_id is not None
+                else "Agent step"
+            )
+            inspector.border_title = (
+                f"Agent {display_name} · {self.store.trace_inspector_tab.title()}"
+            )
+        except Exception:
+            pass
         # Show/hide sidebar + grip, sync width
         visible = self.store.sidebar_visible
         try:
@@ -180,6 +206,16 @@ class AvalancheApp(App):
             self._screen.query_one("#run-history-content").refresh(layout=True)
         except Exception:
             pass
+        if self.store.trace_inspector_open:
+            try:
+                content_id = (
+                    "#agent-trace-content"
+                    if self.store.trace_inspector_tab == "trace"
+                    else "#agent-metadata-content"
+                )
+                self._screen.query_one(content_id).refresh(layout=True)
+            except Exception:
+                pass
         # Update sticky headers
         try:
             from .widgets.run_history import RunHistoryWidget
@@ -224,9 +260,7 @@ class AvalancheApp(App):
                 avail = rh.size.width - 6
                 pad = max(3, avail - len(left) - len(right))
                 line_color = (
-                    "#60dce4"
-                    if self.store.focused_pane == "run-history"
-                    else "#5a4f80"
+                    "#60dce4" if self.store.focused_pane == "run-history" else "#5a4f80"
                 )
                 line = f"[{line_color}]{'─' * (pad - 2)}[/]"
                 rh.border_title = f"{left} {line} {right}"
@@ -297,7 +331,6 @@ class AvalancheApp(App):
         except Exception:
             pass
 
-
     # ── Run polling (fallback for missed stream events) ─────────────
 
     _poll_in_flight: bool = False
@@ -346,6 +379,7 @@ class AvalancheApp(App):
         self._ping_counter += 1
         if self._ping_counter % 60 == 0 and not self._ping_in_flight:
             import threading
+
             self._ping_in_flight = True
 
             def _do_ping():
@@ -425,6 +459,9 @@ class AvalancheApp(App):
         elif pane == "dag":
             self.store.move_nav(0, -1)
             self._refresh_widgets()
+        elif pane == "trace" and self.store.trace_inspector_tab == "trace":
+            self.store.move_trace_turn(-1)
+            self._refresh_widgets()
         elif pane == "run-history":
             self.store.select_prev_run()
             self._refresh_widgets()
@@ -443,6 +480,9 @@ class AvalancheApp(App):
             self._screen.query_one("#sidebar", Sidebar).cursor_down()
         elif pane == "dag":
             self.store.move_nav(0, 1)
+            self._refresh_widgets()
+        elif pane == "trace" and self.store.trace_inspector_tab == "trace":
+            self.store.move_trace_turn(1)
             self._refresh_widgets()
         elif pane == "run-history":
             self.store.select_next_run()
@@ -529,9 +569,28 @@ class AvalancheApp(App):
         self._refresh_widgets()
 
     def action_activate(self) -> None:
-        """Enter: activate sidebar cursor item."""
+        """Enter: activate the focused item or collapse the selected agent turn."""
         if self.store.focused_pane == "sidebar":
             self._screen.query_one("#sidebar", Sidebar).activate_cursor()
+        elif self.store.focused_pane == "trace" and self.store.trace_inspector_tab == "trace":
+            self.store.toggle_trace_turn()
+            self._refresh_widgets()
+        elif self.store.focused_pane == "dag" and self.store.open_trace_inspector():
+            self._refresh_widgets()
+            try:
+                self._screen.query_one("#agent-trace-inspector").scroll_end(animate=False)
+            except Exception:
+                pass
+
+    def action_toggle_trace_inspector_tab(self) -> None:
+        if not self.store.trace_inspector_open:
+            return
+        self.store.toggle_trace_inspector_tab()
+        self._refresh_widgets()
+        try:
+            self._screen.query_one("#agent-trace-inspector").scroll_home(animate=False)
+        except Exception:
+            pass
 
     # ── Other actions ──────────────────────────────────────────────
 
@@ -544,6 +603,10 @@ class AvalancheApp(App):
         self._refresh_widgets()
 
     def action_escape_key(self) -> None:
+        if self.store.trace_inspector_open:
+            self.store.close_trace_inspector()
+            self._refresh_widgets()
+            return
         if self.store.searching:
             self.store.cancel_search()
         elif self.store.search_query:
@@ -574,6 +637,12 @@ class AvalancheApp(App):
 
     def action_log_page_up(self) -> None:
         """Page Up: scroll log panel up, disable autoscroll."""
+        if self.store.trace_inspector_open:
+            try:
+                self._screen.query_one("#agent-trace-inspector").scroll_page_up(animate=False)
+            except Exception:
+                pass
+            return
         self._log_autoscroll = False
         try:
             log_view = self._screen.query_one("#log-content", LogWidget)
@@ -583,6 +652,12 @@ class AvalancheApp(App):
 
     def action_log_page_down(self) -> None:
         """Page Down: scroll log panel down; re-enable autoscroll at bottom."""
+        if self.store.trace_inspector_open:
+            try:
+                self._screen.query_one("#agent-trace-inspector").scroll_page_down(animate=False)
+            except Exception:
+                pass
+            return
         try:
             log_view = self._screen.query_one("#log-content", LogWidget)
             log_view.scroll_page_down(animate=False)
@@ -603,6 +678,17 @@ class AvalancheApp(App):
                 self.store.search_backspace()
             elif event.is_printable and event.character:
                 self.store.search_append(event.character)
+            event.prevent_default()
+            event.stop()
+            self._refresh_widgets()
+            return
+
+        if (
+            event.character == "o"
+            and self.store.trace_inspector_open
+            and self.store.trace_inspector_tab == "trace"
+        ):
+            self.store.toggle_trace_full_output()
             event.prevent_default()
             event.stop()
             self._refresh_widgets()

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -14,7 +14,11 @@ from .screens.workflow_detail import WorkflowDetailScreen
 from .state import StateProvider
 from .theme import AVALANCHE_THEME
 from .ui_store import UIStore
-from .widgets.agent_trace import AgentMetadataInspector, AgentTraceInspector
+from .widgets.agent_trace import (
+    AgentMetadataInspector,
+    AgentOutputInspector,
+    AgentTraceInspector,
+)
 from .widgets.log_panel import LogWidget
 from .widgets.run_history import RunHistoryWidget
 from .widgets.sidebar import Sidebar
@@ -59,7 +63,6 @@ class AvalancheApp(App):
         ("s", "toggle_autoscroll", "Autoscroll"),
         ("w", "toggle_wrap", "Wrap"),
         ("enter", "activate", "Enter"),
-        Binding("m", "toggle_trace_inspector_tab", "Trace/Metadata", priority=True),
     ]
 
     def __init__(
@@ -157,11 +160,15 @@ class AvalancheApp(App):
             metadata_content = self._screen.query_one(
                 "#agent-metadata-content", AgentMetadataInspector
             )
+            output_content = self._screen.query_one(
+                "#agent-output-content", AgentOutputInspector
+            )
             dashboard.display = not self.store.trace_inspector_open
             inspector.display = self.store.trace_inspector_open
-            trace_active = self.store.trace_inspector_tab == "trace"
-            trace_content.display = trace_active
-            metadata_content.display = not trace_active
+            active_tab = self.store.trace_inspector_tab
+            trace_content.display = active_tab == "trace"
+            output_content.display = active_tab == "output"
+            metadata_content.display = active_tab == "metadata"
             node_id = self.store.selected_agent_node_id
             workflow = self.store.current_workflow
             display_name = (
@@ -169,9 +176,7 @@ class AvalancheApp(App):
                 if workflow is not None and node_id is not None
                 else "Agent step"
             )
-            inspector.border_title = (
-                f"Agent {display_name} · {self.store.trace_inspector_tab.title()}"
-            )
+            inspector.border_title = f"Agent {display_name}"
         except Exception:
             pass
         # Show/hide sidebar + grip, sync width
@@ -207,15 +212,15 @@ class AvalancheApp(App):
         except Exception:
             pass
         if self.store.trace_inspector_open:
-            try:
-                content_id = (
-                    "#agent-trace-content"
-                    if self.store.trace_inspector_tab == "trace"
-                    else "#agent-metadata-content"
-                )
-                self._screen.query_one(content_id).refresh(layout=True)
-            except Exception:
-                pass
+            for content_id in (
+                "agent-trace-content",
+                "agent-output-content",
+                "agent-metadata-content",
+            ):
+                try:
+                    self._screen.query_one(f"#{content_id}").refresh(layout=True)
+                except Exception:
+                    pass
         # Update sticky headers
         try:
             from .widgets.run_history import RunHistoryWidget
@@ -560,11 +565,25 @@ class AvalancheApp(App):
             pass
         self._refresh_widgets()
 
+    def _move_trace_inspector_tab(self, delta: int) -> None:
+        self.store.move_trace_inspector_tab(delta)
+        self._refresh_widgets()
+        try:
+            self._screen.query_one("#agent-trace-inspector").scroll_home(animate=False)
+        except Exception:
+            pass
+
     def action_nav_left(self) -> None:
+        if self.store.focused_pane == "trace":
+            self._move_trace_inspector_tab(-1)
+            return
         self.store.move_nav(-1, 0)
         self._refresh_widgets()
 
     def action_nav_right(self) -> None:
+        if self.store.focused_pane == "trace":
+            self._move_trace_inspector_tab(1)
+            return
         self.store.move_nav(1, 0)
         self._refresh_widgets()
 
@@ -581,16 +600,6 @@ class AvalancheApp(App):
                 self._screen.query_one("#agent-trace-inspector").scroll_end(animate=False)
             except Exception:
                 pass
-
-    def action_toggle_trace_inspector_tab(self) -> None:
-        if not self.store.trace_inspector_open:
-            return
-        self.store.toggle_trace_inspector_tab()
-        self._refresh_widgets()
-        try:
-            self._screen.query_one("#agent-trace-inspector").scroll_home(animate=False)
-        except Exception:
-            pass
 
     # ── Other actions ──────────────────────────────────────────────
 

--- a/src/tui/mock.py
+++ b/src/tui/mock.py
@@ -275,7 +275,17 @@ AGENT_TRACE_METADATA = {
                 "name": "summary",
                 "annotation": "InspectionSummary",
                 "description": "structured inspection summary",
-            }
+            },
+            {
+                "name": "labels",
+                "annotation": "list[str]",
+                "description": "inspection labels",
+            },
+            {
+                "name": "note",
+                "annotation": "str | None",
+                "description": "optional inspection note",
+            },
         ],
     },
     "runtime": {
@@ -620,7 +630,7 @@ class MockStateProvider:
                 "sequence": 2,
                 "kind": "code.executed",
                 "timestamp_ns": 2,
-                "data": {"iteration": 1, "output": "{'active_count': 2}"},
+                "data": {"iteration": 1, "output": "SANDBOX_STDOUT_SENTINEL"},
             },
             {
                 "sequence": 3,
@@ -628,12 +638,25 @@ class MockStateProvider:
                 "timestamp_ns": 3,
                 "data": {"step": {"iteration": 1}},
             },
+            {
+                "sequence": 4,
+                "kind": "run.succeeded",
+                "timestamp_ns": 4,
+                "data": {
+                    "status": "completed",
+                    "outputs": {
+                        "summary": {"active_count": 1, "ready": False},
+                        "labels": ["reviewed"],
+                        "note": None,
+                    },
+                },
+            },
         ]
         trace_step = {
             "iteration": 1,
             "reasoning": "Filter active records and summarize their names.",
             "code": trace_events[0]["data"]["code"],
-            "output": "{'active_count': 2}",
+            "output": "SANDBOX_STDOUT_SENTINEL",
             "untruncated_output": (
                 "FULL OUTPUT: {'active_count': 2, 'names': "
                 "['Ada Lovelace', 'Grace Hopper']}\\n" + "wrapped output line " * 12

--- a/src/tui/mock.py
+++ b/src/tui/mock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 from datetime import datetime
@@ -25,8 +26,13 @@ ORDER_WORKFLOW = WorkflowInfo(
     name="order_workflow",
     file_path="workflows/etl/order_workflow.py",
     node_ids=[
-        "fetch_orders_1", "fetch_inventory_1", "validate_1",
-        "enrich_1", "aggregate_1", "save_warehouse_1", "notify_1",
+        "fetch_orders_1",
+        "fetch_inventory_1",
+        "validate_1",
+        "enrich_1",
+        "aggregate_1",
+        "save_warehouse_1",
+        "notify_1",
     ],
     graph={
         "fetch_orders_1": ["validate_1"],
@@ -67,8 +73,12 @@ ANALYTICS_WORKFLOW = WorkflowInfo(
     name="analytics_workflow",
     file_path="workflows/etl/analytics_workflow.py",
     node_ids=[
-        "load_events_1", "load_users_1", "join_data_1",
-        "compute_metrics_1", "export_dashboard_1", "export_alerts_1",
+        "load_events_1",
+        "load_users_1",
+        "join_data_1",
+        "compute_metrics_1",
+        "export_dashboard_1",
+        "export_alerts_1",
     ],
     graph={
         "load_events_1": ["join_data_1"],
@@ -90,9 +100,15 @@ ML_WORKFLOW = WorkflowInfo(
     name="ml_workflow",
     file_path="workflows/ml/ml_workflow.py",
     node_ids=[
-        "fetch_training_1", "fetch_validation_1", "fetch_features_1",
-        "preprocess_1", "train_model_1", "evaluate_1",
-        "export_onnx_1", "deploy_staging_1", "deploy_prod_1",
+        "fetch_training_1",
+        "fetch_validation_1",
+        "fetch_features_1",
+        "preprocess_1",
+        "train_model_1",
+        "evaluate_1",
+        "export_onnx_1",
+        "deploy_staging_1",
+        "deploy_prod_1",
         "notify_slack_1",
     ],
     graph={
@@ -124,16 +140,25 @@ DATA_PLATFORM_WORKFLOW = WorkflowInfo(
     file_path="workflows/etl/data_platform.py",
     node_ids=[
         # 3-way source fan-in
-        "ingest_clicks_1", "ingest_txns_1", "ingest_crm_1",
+        "ingest_clicks_1",
+        "ingest_txns_1",
+        "ingest_crm_1",
         # merge → step chain
-        "deduplicate_1", "normalize_1", "validate_1",
+        "deduplicate_1",
+        "normalize_1",
+        "validate_1",
         # 2-way scoring fork
-        "score_churn_1", "score_ltv_1",
+        "score_churn_1",
+        "score_ltv_1",
         # merge → 4-way export fan-out
         "build_profile_1",
-        "export_warehouse_1", "export_redis_1", "export_api_1", "send_alerts_1",
+        "export_warehouse_1",
+        "export_redis_1",
+        "export_api_1",
+        "send_alerts_1",
         # 2-way uneven fan-in
-        "update_catalog_1", "notify_team_1",
+        "update_catalog_1",
+        "notify_team_1",
     ],
     graph={
         "ingest_clicks_1": ["deduplicate_1"],
@@ -156,13 +181,21 @@ DATA_PLATFORM_WORKFLOW = WorkflowInfo(
         "send_alerts_1": ["notify_team_1"],
     },
     node_types={
-        "ingest_clicks_1": "source", "ingest_txns_1": "source", "ingest_crm_1": "source",
-        "deduplicate_1": "step", "normalize_1": "step", "validate_1": "step",
-        "score_churn_1": "step", "score_ltv_1": "step",
+        "ingest_clicks_1": "source",
+        "ingest_txns_1": "source",
+        "ingest_crm_1": "source",
+        "deduplicate_1": "step",
+        "normalize_1": "step",
+        "validate_1": "step",
+        "score_churn_1": "step",
+        "score_ltv_1": "step",
         "build_profile_1": "step",
-        "export_warehouse_1": "dest", "export_redis_1": "dest",
-        "export_api_1": "dest", "send_alerts_1": "dest",
-        "update_catalog_1": "dest", "notify_team_1": "dest",
+        "export_warehouse_1": "dest",
+        "export_redis_1": "dest",
+        "export_api_1": "dest",
+        "send_alerts_1": "dest",
+        "update_catalog_1": "dest",
+        "notify_team_1": "dest",
     },
 )
 
@@ -170,11 +203,19 @@ DOC_PROCESSING_WORKFLOW = WorkflowInfo(
     name="doc_processing",
     file_path="workflows/ml/doc_processing.py",
     node_ids=[
-        "chunk_new_docs_1", "predict_chunks_1", "push_to_cdn_1",
-        "push_chunks_pg_1", "embed_new_docs_1", "feed_into_vespa_1",
-        "page_highlights_1", "push_questions_1", "push_chunk_preds_1",
-        "corpus_prediction_1", "push_corpus_preds_1",
-        "doc_prediction_1", "push_doc_preds_1",
+        "chunk_new_docs_1",
+        "predict_chunks_1",
+        "push_to_cdn_1",
+        "push_chunks_pg_1",
+        "embed_new_docs_1",
+        "feed_into_vespa_1",
+        "page_highlights_1",
+        "push_questions_1",
+        "push_chunk_preds_1",
+        "corpus_prediction_1",
+        "push_corpus_preds_1",
+        "doc_prediction_1",
+        "push_doc_preds_1",
         "delete_tagged_docs_1",
     ],
     graph={
@@ -202,20 +243,91 @@ DOC_PROCESSING_WORKFLOW = WorkflowInfo(
     },
     node_types={
         "chunk_new_docs_1": "step",
-        "predict_chunks_1": "step", "push_to_cdn_1": "dest",
-        "push_chunks_pg_1": "dest", "embed_new_docs_1": "step",
+        "predict_chunks_1": "step",
+        "push_to_cdn_1": "dest",
+        "push_chunks_pg_1": "dest",
+        "embed_new_docs_1": "step",
         "feed_into_vespa_1": "dest",
         "page_highlights_1": "step",
-        "push_questions_1": "dest", "push_chunk_preds_1": "dest",
-        "corpus_prediction_1": "step", "push_corpus_preds_1": "dest",
-        "doc_prediction_1": "step", "push_doc_preds_1": "dest",
+        "push_questions_1": "dest",
+        "push_chunk_preds_1": "dest",
+        "corpus_prediction_1": "step",
+        "push_corpus_preds_1": "dest",
+        "doc_prediction_1": "step",
+        "push_doc_preds_1": "dest",
         "delete_tagged_docs_1": "dest",
     },
 )
 
+AGENT_TRACE_METADATA = {
+    "signature": {
+        "name": "InspectRecords",
+        "instructions": "Inspect records and summarize active entries.",
+        "inputs": [
+            {
+                "name": "records",
+                "annotation": "list[Record]",
+                "description": "records to inspect",
+            }
+        ],
+        "outputs": [
+            {
+                "name": "summary",
+                "annotation": "InspectionSummary",
+                "description": "structured inspection summary",
+            }
+        ],
+    },
+    "runtime": {
+        "lm": "main-model",
+        "sub_lm": "sub-model",
+        "max_iterations": 4,
+    },
+    "skills": [
+        {
+            "name": "audit",
+            "instructions": "Verify active status before summarizing.",
+            "packages": ["pydantic"],
+            "modules": ["record_helpers"],
+            "tools": ["lookup_record"],
+        }
+    ],
+    "aggregated_static_instructions": (
+        "Inspect records and summarize active entries.\n\n"
+        "## Skill: audit\n\nVerify active status before summarizing."
+    ),
+    "packages": ["pydantic"],
+    "modules": ["record_helpers"],
+    "tools": [
+        {
+            "name": "lookup_record",
+            "description": "Look up a record by identifier.",
+        }
+    ],
+}
+
+
+AGENT_TRACE_WORKFLOW = WorkflowInfo(
+    name="agent_trace",
+    file_path="workflows/agents/agent_trace.py",
+    node_ids=["inspect_agent_1"],
+    graph={"inspect_agent_1": []},
+    node_types={"inspect_agent_1": "step"},
+    display_names={"inspect_agent_1": "inspect_agent"},
+    agent_node_ids=["inspect_agent_1"],
+    agent_metadata_json={
+        "inspect_agent_1": json.dumps(AGENT_TRACE_METADATA, separators=(",", ":"))
+    },
+)
+
+
 ALL_WORKFLOWS = [
-    ORDER_WORKFLOW, INGEST_WORKFLOW, ANALYTICS_WORKFLOW,
-    ML_WORKFLOW, DATA_PLATFORM_WORKFLOW, DOC_PROCESSING_WORKFLOW,
+    ORDER_WORKFLOW,
+    INGEST_WORKFLOW,
+    ANALYTICS_WORKFLOW,
+    ML_WORKFLOW,
+    DATA_PLATFORM_WORKFLOW,
+    DOC_PROCESSING_WORKFLOW,
 ]
 
 # ── Fake log templates ────────────────────────────────────────────────────
@@ -425,8 +537,10 @@ SKIP_ON_FAIL = {"aggregate_1", "save_warehouse_1", "notify_1"}
 class MockStateProvider:
     """Implements StateProvider with timer-driven simulation."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, include_agent_trace: bool = False) -> None:
         self._workflows = {p.selector: p for p in ALL_WORKFLOWS}
+        if include_agent_trace:
+            self._workflows[AGENT_TRACE_WORKFLOW.selector] = AGENT_TRACE_WORKFLOW
         self._runs: dict[str, RunState] = {}
         self._run_callbacks: list[Callable[[RunState], None]] = []
         self._log_callbacks: list[Callable[[LogEntry], None]] = []
@@ -449,9 +563,12 @@ class MockStateProvider:
         for nid in self._workflows["order_workflow"].node_ids:
             nt = self._workflows["order_workflow"].node_types[nid]
             run1.nodes[nid] = NodeState(
-                node_id=nid, name=display_name_from_id(nid), node_type=nt,
+                node_id=nid,
+                name=display_name_from_id(nid),
+                node_type=nt,
                 status=NodeStatus.SUCCESS,
-                started_at=base_time, ended_at=base_time + 2.0,
+                started_at=base_time,
+                ended_at=base_time + 2.0,
             )
         self._runs[run1.run_id] = run1
 
@@ -467,17 +584,132 @@ class MockStateProvider:
             nt = self._workflows["ingest_workflow"].node_types[nid]
             status = NodeStatus.SUCCESS if nid == "extract_1" else NodeStatus.FAILED
             run2.nodes[nid] = NodeState(
-                node_id=nid, name=display_name_from_id(nid), node_type=nt,
+                node_id=nid,
+                name=display_name_from_id(nid),
+                node_type=nt,
                 status=status,
-                started_at=base_time + 60, ended_at=base_time + 62,
+                started_at=base_time + 60,
+                ended_at=base_time + 62,
             )
         for nid in ["deduplicate_1", "load_1"]:
             nt = self._workflows["ingest_workflow"].node_types[nid]
             run2.nodes[nid] = NodeState(
-                node_id=nid, name=display_name_from_id(nid), node_type=nt,
+                node_id=nid,
+                name=display_name_from_id(nid),
+                node_type=nt,
                 status=NodeStatus.SKIPPED,
             )
         self._runs[run2.run_id] = run2
+
+        trace_events = [
+            {
+                "sequence": 1,
+                "kind": "code.generated",
+                "timestamp_ns": 1,
+                "data": {
+                    "iteration": 1,
+                    "code": (
+                        "records = [item for item in input_records if item.get('active')]\\n"
+                        "summary = {'active_count': len(records), 'names': "
+                        "[item['name'] for item in records]}\\n"
+                        "print(summary)"
+                    ),
+                },
+            },
+            {
+                "sequence": 2,
+                "kind": "code.executed",
+                "timestamp_ns": 2,
+                "data": {"iteration": 1, "output": "{'active_count': 2}"},
+            },
+            {
+                "sequence": 3,
+                "kind": "iteration.recorded",
+                "timestamp_ns": 3,
+                "data": {"step": {"iteration": 1}},
+            },
+        ]
+        trace_step = {
+            "iteration": 1,
+            "reasoning": "Filter active records and summarize their names.",
+            "code": trace_events[0]["data"]["code"],
+            "output": "{'active_count': 2}",
+            "untruncated_output": (
+                "FULL OUTPUT: {'active_count': 2, 'names': "
+                "['Ada Lovelace', 'Grace Hopper']}\\n" + "wrapped output line " * 12
+            ),
+            "error": False,
+            "duration_ms": 14,
+            "tool_calls": [],
+            "predict_calls": [],
+            "lm": {"finish_reason": "stop"},
+            "usage": {"main": {}, "sub": {}},
+        }
+        trace_envelope = {
+            "schema_version": 1,
+            "status": "completed",
+            "run_id": "agent-mock",
+            "events": [
+                {
+                    "sequence": event["sequence"],
+                    "event_kind": event["kind"],
+                    "timestamp_ns": event["timestamp_ns"],
+                    "data": event["data"],
+                }
+                for event in trace_events
+            ],
+            "trace": {
+                "status": "completed",
+                "model": "mock-main",
+                "sub_model": "mock-sub",
+                "iterations": 1,
+                "max_iterations": 4,
+                "duration_ms": 20,
+                "usage": {"main": {}, "sub": {}},
+                "steps": [trace_step],
+                "evidence": {
+                    "run_id": "agent-mock",
+                    "complete": True,
+                    "terminal_outcome": "completed",
+                    "events": trace_events,
+                },
+            },
+            "error": None,
+        }
+        agent_run = RunState(
+            run_id="run_agent",
+            flow_name="agent_trace",
+            status=RunStatus.SUCCESS,
+            started_at=base_time,
+            ended_at=base_time + 1,
+        )
+        agent_run.nodes["inspect_agent_1"] = NodeState(
+            node_id="inspect_agent_1",
+            name="inspect_agent",
+            node_type="step",
+            status=NodeStatus.SUCCESS,
+            started_at=base_time,
+            ended_at=base_time + 1,
+            agent_trace_json=json.dumps(trace_envelope),
+        )
+        agent_run.logs.extend(
+            [
+                LogEntry(
+                    datetime.now(),
+                    LogLevel.INFO,
+                    "inspect_agent_1",
+                    "Agent code.generated iteration=1",
+                ),
+                LogEntry(
+                    datetime.now(),
+                    LogLevel.INFO,
+                    "inspect_agent_1",
+                    "Agent iteration.recorded iteration=1 duration=14ms",
+                ),
+            ]
+        )
+        if "agent_trace" in self._workflows:
+            self._runs[agent_run.run_id] = agent_run
 
     def list_workflows(self) -> list[WorkflowInfo]:
         return list(self._workflows.values())
@@ -516,7 +748,9 @@ class MockStateProvider:
         for nid in info.node_ids:
             nt = info.node_types[nid]
             run.nodes[nid] = NodeState(
-                node_id=nid, name=display_name_from_id(nid), node_type=nt,
+                node_id=nid,
+                name=display_name_from_id(nid),
+                node_type=nt,
                 status=NodeStatus.PENDING,
             )
         self._runs[run_id] = run

--- a/src/tui/screens/workflow_detail.py
+++ b/src/tui/screens/workflow_detail.py
@@ -11,7 +11,11 @@ from textual.screen import Screen
 from textual.scrollbar import ScrollBar, ScrollBarRender
 from textual.widgets import Header, Static
 
-from ..widgets.agent_trace import AgentMetadataInspector, AgentTraceInspector
+from ..widgets.agent_trace import (
+    AgentMetadataInspector,
+    AgentOutputInspector,
+    AgentTraceInspector,
+)
 from ..widgets.dag import DagWidget
 from ..widgets.log_panel import LogWidget
 from ..widgets.run_history import RunHistoryWidget
@@ -247,7 +251,7 @@ class WorkflowDetailScreen(Screen):
     #agent-trace-inspector {
         display: none;
     }
-    #agent-metadata-content {
+    #agent-output-content, #agent-metadata-content {
         display: none;
     }
 
@@ -354,8 +358,9 @@ class WorkflowDetailScreen(Screen):
                         yield Static(id="log-header", classes="pane-header")
                         yield LogWidget(id="log-content")
                 with _ThinScrollContainer(id="agent-trace-inspector") as inspector:
-                    inspector.border_title = "Agent · Trace"
+                    inspector.border_title = "Agent"
                     yield AgentTraceInspector(id="agent-trace-content")
+                    yield AgentOutputInspector(id="agent-output-content")
                     yield AgentMetadataInspector(id="agent-metadata-content")
         from textual.containers import Container
 

--- a/src/tui/screens/workflow_detail.py
+++ b/src/tui/screens/workflow_detail.py
@@ -11,6 +11,7 @@ from textual.screen import Screen
 from textual.scrollbar import ScrollBar, ScrollBarRender
 from textual.widgets import Header, Static
 
+from ..widgets.agent_trace import AgentMetadataInspector, AgentTraceInspector
 from ..widgets.dag import DagWidget
 from ..widgets.log_panel import LogWidget
 from ..widgets.run_history import RunHistoryWidget
@@ -69,6 +70,7 @@ class _HalfHeightScrollBarRender(ScrollBarRender):
 
         if window_size and size and virtual_size and size != virtual_size:
             from math import ceil
+
             bar_ratio = virtual_size / size
             thumb_size = max(1, window_size / bar_ratio)
             position_ratio = position / (virtual_size - window_size)
@@ -79,9 +81,7 @@ class _HalfHeightScrollBarRender(ScrollBarRender):
             segments[end:] = [Segment("▃", track_style_lower)] * (size - end)
             segments[start:end] = [Segment("▃", thumb_style)] * (end - start)
 
-        return Segments(
-            (segments + [Segment.line()]) * thickness, new_lines=False
-        )
+        return Segments((segments + [Segment.line()]) * thickness, new_lines=False)
 
 
 class _ThinScrollContainer(ScrollableContainer):
@@ -183,8 +183,6 @@ class _TableScrollContainer(_ThinScrollContainer):
 
 
 
-
-
 class _DagCenterBtn(Static):
     """Clickable button that re-centers the DAG in its scroll container."""
 
@@ -228,7 +226,7 @@ class WorkflowDetailScreen(Screen):
     }
 
     /* ── Shared border title styling ── */
-    #sidebar, #dag-container, #run-history, #log-panel {
+    #sidebar, #dag-container, #run-history, #log-panel, #agent-trace-inspector {
         border: solid #5a4f80;
         border-title-color: $accent;
         border-title-style: bold;
@@ -237,8 +235,20 @@ class WorkflowDetailScreen(Screen):
     #sidebar.-pane-active,
     #dag-container.-pane-active,
     #run-history.-pane-active,
-    #log-panel.-pane-active {
+    #log-panel.-pane-active,
+    #agent-trace-inspector.-pane-active {
         border: solid $accent;
+    }
+
+    #dashboard-pane, #agent-trace-inspector {
+        width: 100%;
+        height: 100%;
+    }
+    #agent-trace-inspector {
+        display: none;
+    }
+    #agent-metadata-content {
+        display: none;
     }
 
     /* ── Sidebar ── */
@@ -328,21 +338,27 @@ class WorkflowDetailScreen(Screen):
         with Horizontal(id="main-layout"):
             yield Sidebar(id="sidebar")
             with Vertical(id="right-pane"):
-                with _TableScrollContainer(id="run-history") as rh:
-                    rh.border_title = "Runs"
-                    yield Static(id="run-history-header", classes="pane-header")
-                    yield RunHistoryWidget(id="run-history-content")
-                with _DagScrollContainer(id="dag-container") as dag_container:
-                    dag_container.border_title = "DAG"
-                    dag_container.styles.height = "2fr"
-                    yield DagWidget(id="dag-panel")
-                    yield _DagCenterBtn(" ⊡ center ", id="dag-center-btn")
-                with Vertical(id="log-panel") as lp:
-                    lp.border_title = "Logs"
-                    lp.styles.height = "2fr"
-                    yield Static(id="log-header", classes="pane-header")
-                    yield LogWidget(id="log-content")
+                with Vertical(id="dashboard-pane"):
+                    with _TableScrollContainer(id="run-history") as rh:
+                        rh.border_title = "Runs"
+                        yield Static(id="run-history-header", classes="pane-header")
+                        yield RunHistoryWidget(id="run-history-content")
+                    with _DagScrollContainer(id="dag-container") as dag_container:
+                        dag_container.border_title = "DAG"
+                        dag_container.styles.height = "2fr"
+                        yield DagWidget(id="dag-panel")
+                        yield _DagCenterBtn(" ⊡ center ", id="dag-center-btn")
+                    with Vertical(id="log-panel") as lp:
+                        lp.border_title = "Logs"
+                        lp.styles.height = "2fr"
+                        yield Static(id="log-header", classes="pane-header")
+                        yield LogWidget(id="log-content")
+                with _ThinScrollContainer(id="agent-trace-inspector") as inspector:
+                    inspector.border_title = "Agent · Trace"
+                    yield AgentTraceInspector(id="agent-trace-content")
+                    yield AgentMetadataInspector(id="agent-metadata-content")
         from textual.containers import Container
+
         with Container(id="disconnect-wrapper"):
             yield Static(id="disconnect-box")
         yield StatusBar(id="status-bar")
@@ -386,7 +402,6 @@ class WorkflowDetailScreen(Screen):
                 hdr.styles.offset = (-container.scroll_x, 0)
             except Exception:
                 pass
-
 
     # ── Message handlers ───────────────────────────────────────────
 

--- a/src/tui/ui_store.py
+++ b/src/tui/ui_store.py
@@ -11,6 +11,13 @@ from .dag_layout import DagNode, SeqGroup, build_nav_grid, nav_move, workflow_to
 from .models import LogEntry, NodeStatus, RunState, RunStatus, WorkflowInfo
 from .state import StateProvider
 
+TraceInspectorTab = Literal["trace", "output", "metadata"]
+_TRACE_INSPECTOR_TABS: tuple[TraceInspectorTab, ...] = (
+    "trace",
+    "output",
+    "metadata",
+)
+
 
 def _fmt_time(secs: float) -> str:
     mins, s = divmod(secs, 60)
@@ -61,7 +68,7 @@ class UIStore:
         # ── Pane focus ─────────────────────────────────────────────
         self.focused_pane: str = "dag"  # "sidebar" | "dag" | "run-history" | "log"
         self.trace_inspector_open: bool = False
-        self.trace_inspector_tab: Literal["trace", "metadata"] = "trace"
+        self.trace_inspector_tab: TraceInspectorTab = "trace"
         self.trace_turn_index: int = 0
         self.trace_collapsed_turns: set[int] = set()
         self.trace_show_full_output: bool = False
@@ -254,6 +261,30 @@ class UIStore:
         if not isinstance(events, list):
             return []
         return [event for event in events if isinstance(event, dict)]
+
+    @property
+    def selected_agent_outputs(self) -> dict[str, Any] | None:
+        envelope = self.selected_agent_trace_envelope
+        trace = envelope.get("trace") if envelope is not None else None
+        if not isinstance(trace, dict):
+            return None
+        evidence = trace.get("evidence")
+        if not isinstance(evidence, dict):
+            return None
+        events = evidence.get("events")
+        if not isinstance(events, list):
+            return None
+        for event in reversed(events):
+            if not isinstance(event, dict):
+                continue
+            if (event.get("event_kind") or event.get("kind")) != "run.succeeded":
+                continue
+            data = event.get("data")
+            if not isinstance(data, dict):
+                return None
+            outputs = data.get("outputs")
+            return outputs if isinstance(outputs, dict) else None
+        return None
 
     @property
     def selected_agent_steps(self) -> list[dict]:
@@ -470,12 +501,13 @@ class UIStore:
         if self.focused_pane == "trace":
             self.focused_pane = "dag"
 
-    def toggle_trace_inspector_tab(self) -> None:
+    def move_trace_inspector_tab(self, delta: int) -> None:
         if not self.trace_inspector_open:
             return
-        self.trace_inspector_tab = (
-            "metadata" if self.trace_inspector_tab == "trace" else "trace"
-        )
+        index = _TRACE_INSPECTOR_TABS.index(self.trace_inspector_tab)
+        self.trace_inspector_tab = _TRACE_INSPECTOR_TABS[
+            (index + delta) % len(_TRACE_INSPECTOR_TABS)
+        ]
 
     def move_trace_turn(self, delta: int) -> None:
         steps = self.selected_agent_steps

--- a/src/tui/ui_store.py
+++ b/src/tui/ui_store.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import time
 from queue import SimpleQueue
-from typing import Any
+from typing import Any, Literal
 
 from .dag_layout import DagNode, SeqGroup, build_nav_grid, nav_move, workflow_to_layout
 from .models import LogEntry, NodeStatus, RunState, RunStatus, WorkflowInfo
@@ -25,9 +26,7 @@ class UIStore:
     Access from any widget via ``self.app.store``.
     """
 
-    def __init__(
-        self, provider: StateProvider, *, defer_initial_catalog: bool = False
-    ) -> None:
+    def __init__(self, provider: StateProvider, *, defer_initial_catalog: bool = False) -> None:
         self.provider = provider
 
         # ── Workflow / Run ──────────────────────────────────────────
@@ -61,6 +60,11 @@ class UIStore:
 
         # ── Pane focus ─────────────────────────────────────────────
         self.focused_pane: str = "dag"  # "sidebar" | "dag" | "run-history" | "log"
+        self.trace_inspector_open: bool = False
+        self.trace_inspector_tab: Literal["trace", "metadata"] = "trace"
+        self.trace_turn_index: int = 0
+        self.trace_collapsed_turns: set[int] = set()
+        self.trace_show_full_output: bool = False
 
         # ── Search ─────────────────────────────────────────────────
         self.searching: bool = False
@@ -195,6 +199,114 @@ class UIStore:
                 return _fmt_time(ns.elapsed)
         return ""
 
+    @property
+    def selected_agent_node_id(self) -> str | None:
+        workflow = self.current_workflow
+        node = self.selected_node
+        if workflow is None or node is None or node.name not in workflow.agent_node_ids:
+            return None
+        return node.name
+
+    @property
+    def selected_agent_metadata_json(self) -> str | None:
+        workflow = self.current_workflow
+        node_id = self.selected_agent_node_id
+        if workflow is None or node_id is None:
+            return None
+        return workflow.agent_metadata_json.get(node_id)
+
+    @property
+    def selected_agent_metadata(self) -> dict | None:
+        metadata_json = self.selected_agent_metadata_json
+        if not metadata_json:
+            return None
+        try:
+            metadata = json.loads(metadata_json)
+        except (TypeError, ValueError):
+            return None
+        return metadata if isinstance(metadata, dict) else None
+
+    @property
+    def selected_agent_trace_envelope(self) -> dict | None:
+        node_id = self.selected_agent_node_id
+        if node_id is None or self.current_run is None:
+            return None
+        state = self.current_run.nodes.get(node_id)
+        if state is None or not state.agent_trace_json:
+            return None
+        try:
+            envelope = json.loads(state.agent_trace_json)
+        except (TypeError, ValueError):
+            return None
+        return envelope if isinstance(envelope, dict) else None
+
+    @property
+    def selected_agent_events(self) -> list[dict]:
+        envelope = self.selected_agent_trace_envelope
+        if envelope is None:
+            return []
+        trace = envelope.get("trace")
+        if isinstance(trace, dict):
+            evidence = trace.get("evidence")
+            if isinstance(evidence, dict) and isinstance(evidence.get("events"), list):
+                return [event for event in evidence["events"] if isinstance(event, dict)]
+        events = envelope.get("events")
+        if not isinstance(events, list):
+            return []
+        return [event for event in events if isinstance(event, dict)]
+
+    @property
+    def selected_agent_steps(self) -> list[dict]:
+        envelope = self.selected_agent_trace_envelope
+        trace = envelope.get("trace") if envelope is not None else None
+        if not isinstance(trace, dict):
+            return self.selected_agent_live_steps
+        steps = trace.get("steps")
+        if not isinstance(steps, list):
+            return []
+        return [step for step in steps if isinstance(step, dict)]
+
+    @property
+    def selected_agent_live_steps(self) -> list[dict]:
+        """Build partial turn records from ordered live agent evidence."""
+        steps_by_iteration: dict[int, dict] = {}
+        for event in self.selected_agent_events:
+            kind = event.get("event_kind") or event.get("kind")
+            data = event.get("data")
+            if not isinstance(kind, str) or not isinstance(data, dict):
+                continue
+            recorded_step = data.get("step")
+            iteration = data.get("iteration")
+            if iteration is None and isinstance(recorded_step, dict):
+                iteration = recorded_step.get("iteration")
+            if not isinstance(iteration, int):
+                continue
+            step = steps_by_iteration.setdefault(
+                iteration,
+                {
+                    "iteration": iteration,
+                    "code": "",
+                    "output": None,
+                    "error": None,
+                    "duration_ms": 0,
+                    "tool_calls": [],
+                    "predict_calls": [],
+                    "lm": {},
+                    "usage": {},
+                },
+            )
+            if kind == "code.generated":
+                step["code"] = data.get("code") or ""
+            elif kind == "code.executed":
+                step["output"] = data.get("output")
+                step["error"] = data.get("error")
+            elif kind == "iteration.recorded":
+                source = recorded_step if isinstance(recorded_step, dict) else data
+                for field in ("duration_ms", "error", "tool_count", "predict_count"):
+                    if field in source:
+                        step[field] = source[field]
+        return [steps_by_iteration[key] for key in sorted(steps_by_iteration)]
+
     # ── Mutation: tick ──────────────────────────────────────────────
 
     def tick(self) -> None:
@@ -265,6 +377,7 @@ class UIStore:
         """Switch to a different workflow — recompute DAG, reset selection."""
         self._run_interaction_generation += 1
         self._workflow_context_epoch += 1
+        self.close_trace_inspector()
         self.current_workflow = workflow
         self.dag, self.all_nodes = workflow_to_layout(workflow)
         self.nav_grid = build_nav_grid(self.dag)
@@ -280,12 +393,14 @@ class UIStore:
 
     def switch_run(self, run: RunState) -> None:
         self._run_interaction_generation += 1
+        self.close_trace_inspector()
         self.current_run = run
         self.run_pinned = True
 
     def deselect_run(self) -> None:
         """Unpin the current run — auto-follow will take over."""
         self._run_interaction_generation += 1
+        self.close_trace_inspector()
         self.run_pinned = False
         self.selected_node = None
 
@@ -296,6 +411,7 @@ class UIStore:
         runs = self.runs_for_current_workflow
         latest = runs[-1] if runs else None
         if latest and (self.current_run is None or latest.run_id != self.current_run.run_id):
+            self.close_trace_inspector()
             self.current_run = latest
 
     # ── Mutation: pane focus ───────────────────────────────────────
@@ -333,11 +449,61 @@ class UIStore:
 
     # ── Mutation: node selection / navigation ──────────────────────
 
+    def open_trace_inspector(self) -> bool:
+        if self.selected_agent_node_id is None:
+            return False
+        self.trace_inspector_open = True
+        self.trace_inspector_tab = "trace"
+        self.focused_pane = "trace"
+        steps = self.selected_agent_steps
+        self.trace_turn_index = max(0, len(steps) - 1)
+        self.trace_collapsed_turns.clear()
+        self.trace_show_full_output = False
+        return True
+
+    def close_trace_inspector(self) -> None:
+        self.trace_inspector_open = False
+        self.trace_inspector_tab = "trace"
+        self.trace_turn_index = 0
+        self.trace_collapsed_turns.clear()
+        self.trace_show_full_output = False
+        if self.focused_pane == "trace":
+            self.focused_pane = "dag"
+
+    def toggle_trace_inspector_tab(self) -> None:
+        if not self.trace_inspector_open:
+            return
+        self.trace_inspector_tab = (
+            "metadata" if self.trace_inspector_tab == "trace" else "trace"
+        )
+
+    def move_trace_turn(self, delta: int) -> None:
+        steps = self.selected_agent_steps
+        if not steps:
+            self.trace_turn_index = 0
+            return
+        self.trace_turn_index = min(len(steps) - 1, max(0, self.trace_turn_index + delta))
+
+    def toggle_trace_turn(self) -> None:
+        index = self.trace_turn_index
+        if index in self.trace_collapsed_turns:
+            self.trace_collapsed_turns.remove(index)
+        elif self.selected_agent_steps:
+            self.trace_collapsed_turns.add(index)
+
+    def toggle_trace_full_output(self) -> None:
+        self.trace_show_full_output = not self.trace_show_full_output
+
     def select_node(self, node: DagNode) -> None:
+        if self.trace_inspector_open and (
+            self.selected_node is None or self.selected_node.name != node.name
+        ):
+            self.close_trace_inspector()
         self.selected_node = node
         self.preferred_row = node.row
 
     def deselect_node(self) -> None:
+        self.close_trace_inspector()
         self.selected_node = None
 
     def move_nav(self, dx: int, dy: int) -> None:
@@ -394,9 +560,7 @@ class UIStore:
             try:
                 run_id = provider.start_run(workflow_selector)
                 if not run_id:
-                    error = (
-                        getattr(provider, "last_error", "") or "Run failed to start"
-                    )
+                    error = getattr(provider, "last_error", "") or "Run failed to start"
                 else:
                     run = provider.get_run(run_id)
                     if getattr(provider, "connected", True) is False:
@@ -412,9 +576,7 @@ class UIStore:
                                 or "Failed to refresh runs after starting"
                             )
                         elif run is None:
-                            run = next(
-                                (item for item in runs if item.run_id == run_id), None
-                            )
+                            run = next((item for item in runs if item.run_id == run_id), None)
                             if run is None:
                                 error = f"Started run {run_id} was not found"
             except Exception as exc:
@@ -775,10 +937,7 @@ class UIStore:
             workflow.builder_symbol,
             tuple(workflow.node_ids),
             tuple(
-                sorted(
-                    (parent, tuple(children))
-                    for parent, children in workflow.graph.items()
-                )
+                sorted((parent, tuple(children)) for parent, children in workflow.graph.items())
             ),
             tuple(sorted(workflow.node_types.items())),
             tuple(sorted(workflow.display_names.items())),

--- a/src/tui/widgets/agent_trace.py
+++ b/src/tui/widgets/agent_trace.py
@@ -1,0 +1,545 @@
+"""Scrollable turn-by-turn rendering for finalized agent traces."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from rich.syntax import Syntax
+from rich.text import Text
+from textual.widgets import Static
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, indent=2, default=str, ensure_ascii=False)
+
+
+def _event_kind(event: dict[str, Any]) -> str:
+    return str(event.get("event_kind") or event.get("kind") or "unknown")
+
+
+def _event_data(event: dict[str, Any]) -> dict[str, Any]:
+    data = event.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _usage_label(usage: Any) -> str:
+    if not isinstance(usage, dict):
+        return "0 in / 0 out · 0 cache · $0.000000"
+    return (
+        f"{usage.get('input_tokens', 0)} in / {usage.get('output_tokens', 0)} out"
+        f" · {usage.get('cache_hits', 0)} cache"
+        f" · ${float(usage.get('cost', 0) or 0):.6f}"
+    )
+
+
+def _append_block(
+    text: Text,
+    label: str,
+    value: Any,
+    *,
+    indent: int = 4,
+    style: str = "dim",
+) -> None:
+    text.append(f"{' ' * indent}{label}:\n", style="bold")
+    rendered = value if isinstance(value, str) else _json(value)
+    rendered = rendered if rendered else "(empty)"
+    body_indent = " " * (indent + 4)
+    for line in rendered.splitlines() or [rendered]:
+        text.append(f"{body_indent}{line}\n", style=style)
+
+
+def _append_python(text: Text, code: str, *, indent: int = 4) -> None:
+    text.append(f"{' ' * indent}code:\n", style="bold #60dce4")
+    source = code or "(empty)"
+    highlighted = Syntax(
+        source,
+        "python",
+        theme="monokai",
+        background_color="default",
+        word_wrap=False,
+    ).highlight(source)
+    body_indent = " " * (indent + 4)
+    for line in highlighted.split("\n", allow_blank=True):
+        text.append(body_indent)
+        text.append_text(line)
+        text.append("\n")
+
+
+def _count_predict_calls(step: dict[str, Any]) -> int:
+    groups = step.get("predict_calls")
+    if not isinstance(groups, list):
+        return 0
+    return sum(len(group.get("calls") or []) for group in groups if isinstance(group, dict))
+
+
+def _append_tabs(text: Text, active: str) -> None:
+    for name in ("Trace", "Metadata"):
+        style = "bold reverse #60dce4" if name.lower() == active else "dim"
+        text.append(f" {name} ", style=style)
+        if name == "Trace":
+            text.append(" ")
+    text.append("\n\n")
+
+
+class AgentTraceInspector(Static):
+    """Render live agent status followed by the finalized structured trace."""
+
+    DEFAULT_CSS = """
+    AgentTraceInspector {
+        width: 100%;
+        height: auto;
+        padding: 0 1;
+    }
+    """
+
+    def render(self) -> Text:
+        store = self.app.store
+        node_id = store.selected_agent_node_id
+        workflow = store.current_workflow
+        display_name = (
+            workflow.display_names.get(node_id, node_id)
+            if workflow is not None and node_id is not None
+            else "Agent step"
+        )
+        envelope = store.selected_agent_trace_envelope
+        text = Text()
+        _append_tabs(text, "trace")
+        text.append(f"AGENT TRACE · {display_name}\n", style="bold #60dce4")
+        if envelope is None:
+            state = None
+            if store.current_run is not None and node_id is not None:
+                state = store.current_run.nodes.get(node_id)
+            state_label = getattr(getattr(state, "status", None), "value", "unavailable")
+            if state_label in {"pending", "running"}:
+                text.append(
+                    f"Status: {state_label} · waiting for live updates\n", style="yellow"
+                )
+            else:
+                text.append("Trace unavailable or malformed\n", style="bold red")
+            return text
+
+        trace_value = envelope.get("trace")
+        trace = trace_value if isinstance(trace_value, dict) else None
+        status = str(envelope.get("status") or "unavailable")
+        evidence = trace.get("evidence") if trace is not None else None
+        evidence = evidence if isinstance(evidence, dict) else None
+        run_id = envelope.get("run_id") or (evidence or {}).get("run_id") or "—"
+        status_style = "green" if status in {"completed", "max_iterations"} else "yellow"
+        if status in {"error", "unavailable"}:
+            status_style = "bold red"
+        text.append(f"Status: {status}", style=status_style)
+        text.append(f" · Run: {run_id}\n")
+
+        if envelope.get("error"):
+            text.append(f"Error: {envelope['error']}\n", style="bold red")
+
+        if trace is None:
+            self._append_live_status(text, store.selected_agent_events)
+            steps = store.selected_agent_live_steps
+            text.append(f"\nLIVE TRACE · {len(steps)} turn(s)\n", style="bold #b38cff")
+            if not steps:
+                text.append("No executable turn captured yet.\n", style="dim")
+                return text
+            self._append_turns(
+                text,
+                steps,
+                max_turns=len(steps),
+                selected_index=store.trace_turn_index,
+                collapsed_turns=store.trace_collapsed_turns,
+                show_full_output=store.trace_show_full_output,
+                live=True,
+            )
+            text.append(
+                "\n↑/↓ select turn · Enter collapse · o full output · "
+                "PgUp/PgDn scroll · Esc back\n",
+                style="dim",
+            )
+            return text
+
+        self._append_trace_summary(text, trace, evidence)
+        steps = store.selected_agent_steps
+        text.append(f"\nSTRUCTURED TRACE · {len(steps)} turn(s)\n", style="bold #b38cff")
+        if not steps:
+            text.append("No structured turns captured.\n", style="dim")
+            return text
+        self._append_turns(
+            text,
+            steps,
+            max_turns=trace.get("max_iterations") or len(steps),
+            selected_index=store.trace_turn_index,
+            collapsed_turns=store.trace_collapsed_turns,
+            show_full_output=store.trace_show_full_output,
+        )
+
+        text.append(
+            "\n↑/↓ select turn · Enter collapse · o full output · "
+            "PgUp/PgDn scroll · Esc back\n",
+            style="dim",
+        )
+        return text
+
+    @staticmethod
+    def _append_trace_summary(
+        text: Text, trace: dict[str, Any], evidence: dict[str, Any] | None
+    ) -> None:
+        usage = trace.get("usage") if isinstance(trace.get("usage"), dict) else {}
+        main_usage = usage.get("main") if isinstance(usage, dict) else {}
+        sub_usage = usage.get("sub") if isinstance(usage, dict) else {}
+        text.append(
+            f"Model: {trace.get('model', '—')}"
+            f" · Sub-model: {trace.get('sub_model') or '—'}\n"
+        )
+        text.append(
+            f"Turns: {trace.get('iterations', 0)}/{trace.get('max_iterations', '—')}"
+            f" · Duration: {trace.get('duration_ms', 0)}ms\n"
+        )
+        text.append(f"Main: {_usage_label(main_usage)}\n")
+        text.append(f"Sub:  {_usage_label(sub_usage)}\n")
+        if evidence is None:
+            text.append("Live record: unavailable\n", style="yellow")
+            return
+        complete = bool(evidence.get("complete"))
+        terminal = evidence.get("terminal_outcome") or "unknown"
+        text.append(
+            f"Live record: {'complete' if complete else 'incomplete'}"
+            f" · terminal={terminal}\n",
+            style="green" if complete else "yellow",
+        )
+
+    @staticmethod
+    def _append_live_status(text: Text, events: list[dict]) -> None:
+        text.append(f"\nLIVE AGENT STATUS · {len(events)} update(s)\n", style="bold #b38cff")
+        if not events:
+            text.append("No live updates observed yet.\n", style="dim")
+            return
+        labels = {
+            "run.started": "Run started",
+            "code.generated": "Code generated",
+            "code.executed": "Sandbox output received",
+            "iteration.recorded": "Turn completed",
+            "predict.started": "Sub-model call started",
+            "predict.finished": "Sub-model call finished",
+            "tool.started": "Tool call started",
+            "tool.finished": "Tool call finished",
+            "run.succeeded": "Run completed",
+            "run.failed": "Run failed",
+            "run.cancelled": "Run cancelled",
+        }
+        for event in events:
+            kind = _event_kind(event)
+            data = _event_data(event)
+            iteration = data.get("iteration")
+            recorded_step = data.get("step")
+            if iteration is None and isinstance(recorded_step, dict):
+                iteration = recorded_step.get("iteration")
+            detail = f" · turn {iteration}" if iteration is not None else ""
+            name = data.get("name") or data.get("signature")
+            if name:
+                detail += f" · {name}"
+            failed = bool(data.get("error")) or kind in {"run.failed", "run.cancelled"}
+            marker = "!" if failed else "•"
+            text.append(
+                f"{marker} {labels.get(kind, kind)}{detail}\n",
+                style="red" if failed else "",
+            )
+
+    @classmethod
+    def _append_turns(
+        cls,
+        text: Text,
+        steps: list[dict],
+        *,
+        max_turns: int,
+        selected_index: int,
+        collapsed_turns: set[int],
+        show_full_output: bool,
+        live: bool = False,
+    ) -> None:
+        selected_index = min(selected_index, len(steps) - 1)
+        for index, step in enumerate(steps):
+            cls._append_turn(
+                text,
+                step,
+                index=index,
+                max_turns=max_turns,
+                selected=index == selected_index,
+                collapsed=index in collapsed_turns,
+                show_full_output=show_full_output,
+                live=live,
+            )
+
+    @staticmethod
+    def _append_turn(
+        text: Text,
+        step: dict[str, Any],
+        *,
+        index: int,
+        max_turns: int,
+        selected: bool,
+        collapsed: bool,
+        show_full_output: bool,
+        live: bool = False,
+    ) -> None:
+        iteration = step.get("iteration", index + 1)
+        duration = step.get("duration_ms", 0)
+        tool_calls = step.get("tool_calls") if isinstance(step.get("tool_calls"), list) else []
+        tool_count = step.get("tool_count")
+        tool_count = tool_count if isinstance(tool_count, int) else len(tool_calls)
+        predict_count = step.get("predict_count")
+        predict_count = (
+            predict_count if isinstance(predict_count, int) else _count_predict_calls(step)
+        )
+        error = bool(step.get("error"))
+        marker = "▶" if selected else " "
+        disclosure = "▸" if collapsed else "▾"
+        counts = f"{tool_count} tool · {predict_count} predict"
+        header = (
+            f"\n{marker} {disclosure} AGENT TURN {iteration}/{max_turns}"
+            f" · {duration}ms · {counts}"
+            f"{' · LIVE' if live else ''}"
+            f"{' · ERROR' if error else ''}\n"
+        )
+        style = "reverse" if selected else ("bold red" if error else "bold #60dce4")
+        text.append(header, style=style)
+        if collapsed:
+            return
+
+        reasoning = step.get("reasoning")
+        if reasoning:
+            _append_block(text, "reasoning", reasoning, style="dim italic")
+        _append_python(text, str(step.get("code") or ""))
+
+        output_key = "untruncated_output" if show_full_output else "output"
+        output_label = "output (full)" if show_full_output else "output"
+        _append_block(
+            text,
+            output_label,
+            step.get(output_key) or "(no output)",
+            style="red" if error else "green",
+        )
+
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            call_error = call.get("error")
+            text.append(f"    tool · {call.get('name', 'unknown')}\n", style="bold magenta")
+            payload = {key: call.get(key) for key in ("args", "kwargs") if call.get(key)}
+            if payload:
+                _append_block(text, "input", payload, indent=8)
+            _append_block(
+                text,
+                "error" if call_error else "result",
+                call_error or call.get("result"),
+                indent=8,
+                style="red" if call_error else "dim",
+            )
+
+        predict_groups = step.get("predict_calls")
+        if isinstance(predict_groups, list):
+            for group in predict_groups:
+                if not isinstance(group, dict):
+                    continue
+                text.append(
+                    f"    predict · {group.get('signature', 'unknown')}"
+                    f" · {group.get('model', '—')}\n",
+                    style="bold magenta",
+                )
+                for call_index, call in enumerate(group.get("calls") or [], start=1):
+                    if not isinstance(call, dict):
+                        continue
+                    text.append(f"        call {call_index}\n", style="bold")
+                    _append_block(text, "input", call.get("input"), indent=12)
+                    call_error = call.get("error")
+                    _append_block(
+                        text,
+                        "error" if call_error else "output",
+                        call_error or call.get("output"),
+                        indent=12,
+                        style="red" if call_error else "dim",
+                    )
+
+        lm = step.get("lm")
+        usage = step.get("usage") if isinstance(step.get("usage"), dict) else {}
+        finish_reason = lm.get("finish_reason") if isinstance(lm, dict) else None
+        text.append(
+            f"    turn meta: finish={finish_reason or '—'}"
+            f" · main {_usage_label(usage.get('main'))}"
+            f" · sub {_usage_label(usage.get('sub'))}\n",
+            style="dim",
+        )
+
+
+class AgentMetadataInspector(Static):
+    """Render static agent declaration metadata as hierarchical text."""
+
+    DEFAULT_CSS = """
+    AgentMetadataInspector {
+        width: 100%;
+        height: auto;
+        padding: 0 1;
+    }
+    """
+
+    def render(self) -> Text:
+        store = self.app.store
+        node_id = store.selected_agent_node_id
+        workflow = store.current_workflow
+        display_name = (
+            workflow.display_names.get(node_id, node_id)
+            if workflow is not None and node_id is not None
+            else "Agent step"
+        )
+        metadata = store.selected_agent_metadata
+        text = Text()
+        _append_tabs(text, "metadata")
+        text.append(f"AGENT METADATA · {display_name}\n", style="bold #60dce4")
+        if metadata is None:
+            text.append("Metadata unavailable or malformed\n", style="bold red")
+            text.append("\nm switch tab · PgUp/PgDn scroll · Esc back\n", style="dim")
+            return text
+
+        self._append_signature(text, metadata.get("signature"))
+        self._append_runtime(text, metadata.get("runtime"))
+        self._append_skills(text, metadata.get("skills"))
+        self._append_text_section(
+            text,
+            "AGGREGATED STATIC INSTRUCTIONS",
+            metadata.get("aggregated_static_instructions"),
+        )
+        self._append_names(text, "PACKAGES", metadata.get("packages"))
+        self._append_names(text, "MODULES", metadata.get("modules"))
+        self._append_tools(text, metadata.get("tools"))
+        text.append("\nm switch tab · PgUp/PgDn scroll · Esc back\n", style="dim")
+        return text
+
+    @classmethod
+    def _append_signature(cls, text: Text, value: Any) -> None:
+        text.append("\nSIGNATURE\n", style="bold #b38cff")
+        if not isinstance(value, dict):
+            text.append("  Unavailable\n", style="dim")
+            return
+        text.append(f"  Name: {cls._scalar(value.get('name'))}\n")
+        cls._append_text_block(text, "Instructions", value.get("instructions"))
+        cls._append_fields(text, "Inputs", value.get("inputs"))
+        cls._append_fields(text, "Outputs", value.get("outputs"))
+
+    @classmethod
+    def _append_fields(cls, text: Text, label: str, value: Any) -> None:
+        text.append(f"  {label}:\n", style="bold")
+        fields = value if isinstance(value, list) else []
+        if not fields:
+            text.append("    None\n", style="dim")
+            return
+        for field in fields:
+            if not isinstance(field, dict):
+                continue
+            name = cls._scalar(field.get("name"))
+            annotation = cls._scalar(field.get("annotation"))
+            description = cls._scalar(field.get("description"))
+            suffix = f" — {description}" if description else ""
+            text.append(f"    {name}: {annotation}{suffix}\n")
+
+    @classmethod
+    def _append_runtime(cls, text: Text, value: Any) -> None:
+        text.append("\nMODEL / RUNTIME SETTINGS\n", style="bold #b38cff")
+        runtime = value if isinstance(value, dict) else {}
+        if not runtime:
+            text.append("  Unavailable\n", style="dim")
+            return
+        preferred = ("lm", "sub_lm", "max_iterations", "max_llm_calls")
+        names = [name for name in preferred if name in runtime]
+        names.extend(sorted(name for name in runtime if name not in preferred))
+        for name in names:
+            text.append(f"  {name}: {cls._metadata_value(runtime[name])}\n")
+
+    @classmethod
+    def _append_skills(cls, text: Text, value: Any) -> None:
+        text.append("\nSKILLS\n", style="bold #b38cff")
+        skills = value if isinstance(value, list) else []
+        if not skills:
+            text.append("  None\n", style="dim")
+            return
+        for index, skill in enumerate(skills, start=1):
+            if not isinstance(skill, dict):
+                continue
+            text.append(f"  {index}. {cls._scalar(skill.get('name'))}\n", style="bold magenta")
+            cls._append_text_block(text, "Instructions", skill.get("instructions"), indent=4)
+            for label, key in (
+                ("Packages", "packages"),
+                ("Modules", "modules"),
+                ("Tools", "tools"),
+            ):
+                names = skill.get(key)
+                rendered = cls._name_list(names)
+                text.append(f"    {label}: {rendered}\n")
+
+    @classmethod
+    def _append_text_section(cls, text: Text, label: str, value: Any) -> None:
+        text.append(f"\n{label}\n", style="bold #b38cff")
+        cls._append_text_lines(text, value, indent=2)
+
+    @classmethod
+    def _append_names(cls, text: Text, label: str, value: Any) -> None:
+        text.append(f"\n{label}\n", style="bold #b38cff")
+        text.append(f"  {cls._name_list(value)}\n")
+
+    @classmethod
+    def _append_tools(cls, text: Text, value: Any) -> None:
+        text.append("\nTOOLS\n", style="bold #b38cff")
+        tools = value if isinstance(value, list) else []
+        if not tools:
+            text.append("  None\n", style="dim")
+            return
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            text.append(f"  {cls._scalar(tool.get('name'))}\n", style="bold magenta")
+            cls._append_text_lines(text, tool.get("description"), indent=4)
+
+    @classmethod
+    def _append_text_block(cls, text: Text, label: str, value: Any, *, indent: int = 2) -> None:
+        text.append(f"{' ' * indent}{label}:\n", style="bold")
+        cls._append_text_lines(text, value, indent=indent + 2)
+
+    @classmethod
+    def _append_text_lines(cls, text: Text, value: Any, *, indent: int) -> None:
+        rendered = cls._scalar(value) or "(empty)"
+        for line in rendered.splitlines() or [rendered]:
+            text.append(f"{' ' * indent}{line}\n", style="dim")
+
+    @classmethod
+    def _metadata_value(cls, value: Any) -> str:
+        if isinstance(value, dict):
+            type_name = value.get("type")
+            if isinstance(type_name, str):
+                short_type = type_name.rsplit(".", 1)[-1]
+                instance_name = value.get("name")
+                if isinstance(instance_name, str):
+                    return f"{instance_name} ({short_type})"
+                return short_type
+            return ", ".join(
+                f"{key}={cls._metadata_value(item)}"
+                for key, item in value.items()
+                if isinstance(key, str)
+            )
+        if isinstance(value, list):
+            return ", ".join(cls._metadata_value(item) for item in value) or "None"
+        return cls._scalar(value)
+
+    @classmethod
+    def _name_list(cls, value: Any) -> str:
+        if not isinstance(value, list):
+            return "None"
+        names = [cls._scalar(item) for item in value]
+        return ", ".join(name for name in names if name) or "None"
+
+    @staticmethod
+    def _scalar(value: Any) -> str:
+        if value is None:
+            return "None"
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (str, int, float)):
+            return str(value)
+        return type(value).__name__

--- a/src/tui/widgets/agent_trace.py
+++ b/src/tui/widgets/agent_trace.py
@@ -74,12 +74,24 @@ def _count_predict_calls(step: dict[str, Any]) -> int:
 
 
 def _append_tabs(text: Text, active: str) -> None:
-    for name in ("Trace", "Metadata"):
+    names = ("Trace", "Output", "Metadata")
+    for index, name in enumerate(names):
         style = "bold reverse #60dce4" if name.lower() == active else "dim"
         text.append(f" {name} ", style=style)
-        if name == "Trace":
+        if index < len(names) - 1:
             text.append(" ")
     text.append("\n\n")
+
+
+def _agent_state_label(store: Any, node_id: str | None) -> str:
+    run = store.current_run
+    if run is None or node_id is None:
+        return "unavailable"
+    state = run.nodes.get(node_id)
+    if state is None:
+        return "pending"
+    status = getattr(state, "status", None)
+    return str(getattr(status, "value", status) or "unavailable")
 
 
 class AgentTraceInspector(Static):
@@ -107,14 +119,11 @@ class AgentTraceInspector(Static):
         _append_tabs(text, "trace")
         text.append(f"AGENT TRACE · {display_name}\n", style="bold #60dce4")
         if envelope is None:
-            state = None
-            if store.current_run is not None and node_id is not None:
-                state = store.current_run.nodes.get(node_id)
-            state_label = getattr(getattr(state, "status", None), "value", "unavailable")
-            if state_label in {"pending", "running"}:
-                text.append(
-                    f"Status: {state_label} · waiting for live updates\n", style="yellow"
-                )
+            state_label = _agent_state_label(store, node_id)
+            if state_label == "pending":
+                text.append("This agent step has not run yet for this run.\n", style="yellow")
+            elif state_label == "running":
+                text.append("Status: running · waiting for live updates\n", style="yellow")
             else:
                 text.append("Trace unavailable or malformed\n", style="bold red")
             return text
@@ -151,7 +160,7 @@ class AgentTraceInspector(Static):
                 live=True,
             )
             text.append(
-                "\n↑/↓ select turn · Enter collapse · o full output · "
+                "←/→ tabs · ↑/↓ select turn · Enter collapse · o full output · "
                 "PgUp/PgDn scroll · Esc back\n",
                 style="dim",
             )
@@ -173,7 +182,7 @@ class AgentTraceInspector(Static):
         )
 
         text.append(
-            "\n↑/↓ select turn · Enter collapse · o full output · "
+            "←/→ tabs · ↑/↓ select turn · Enter collapse · o full output · "
             "PgUp/PgDn scroll · Esc back\n",
             style="dim",
         )
@@ -370,6 +379,69 @@ class AgentTraceInspector(Static):
         )
 
 
+class AgentOutputInspector(Static):
+    """Render the final structured prediction declared by the agent signature."""
+
+    DEFAULT_CSS = """
+    AgentOutputInspector {
+        width: 100%;
+        height: auto;
+        padding: 0 1;
+    }
+    """
+
+    def render(self) -> Text:
+        store = self.app.store
+        node_id = store.selected_agent_node_id
+        workflow = store.current_workflow
+        display_name = (
+            workflow.display_names.get(node_id, node_id)
+            if workflow is not None and node_id is not None
+            else "Agent step"
+        )
+        outputs = store.selected_agent_outputs
+        text = Text()
+        _append_tabs(text, "output")
+        text.append(f"AGENT OUTPUT · {display_name}\n", style="bold #60dce4")
+        if outputs is None:
+            state_label = _agent_state_label(store, node_id)
+            if state_label == "pending":
+                text.append("This agent step has not run yet for this run.\n", style="yellow")
+            elif state_label == "running":
+                text.append(
+                    "Output will be available after this agent step completes.\n",
+                    style="yellow",
+                )
+            else:
+                text.append("Output unavailable\n", style="bold red")
+            text.append("\n←/→ tabs · PgUp/PgDn scroll · Esc back\n", style="dim")
+            return text
+
+        metadata = store.selected_agent_metadata
+        signature = metadata.get("signature") if isinstance(metadata, dict) else None
+        fields = signature.get("outputs") if isinstance(signature, dict) else None
+        if isinstance(fields, list):
+            for field in fields:
+                if not isinstance(field, dict) or not isinstance(field.get("name"), str):
+                    continue
+                name = field["name"]
+                annotation = field.get("annotation")
+                description = field.get("description")
+                label = name
+                if isinstance(annotation, str) and annotation:
+                    label += f": {annotation}"
+                if isinstance(description, str) and description:
+                    label += f" — {description}"
+                rendered = _json(outputs[name]) if name in outputs else "Unavailable"
+                _append_block(text, label, rendered, indent=2)
+        else:
+            for name, value in outputs.items():
+                _append_block(text, str(name), _json(value), indent=2)
+
+        text.append("\n←/→ tabs · PgUp/PgDn scroll · Esc back\n", style="dim")
+        return text
+
+
 class AgentMetadataInspector(Static):
     """Render static agent declaration metadata as hierarchical text."""
 
@@ -396,7 +468,7 @@ class AgentMetadataInspector(Static):
         text.append(f"AGENT METADATA · {display_name}\n", style="bold #60dce4")
         if metadata is None:
             text.append("Metadata unavailable or malformed\n", style="bold red")
-            text.append("\nm switch tab · PgUp/PgDn scroll · Esc back\n", style="dim")
+            text.append("\n←/→ tabs · PgUp/PgDn scroll · Esc back\n", style="dim")
             return text
 
         self._append_signature(text, metadata.get("signature"))
@@ -410,7 +482,7 @@ class AgentMetadataInspector(Static):
         self._append_names(text, "PACKAGES", metadata.get("packages"))
         self._append_names(text, "MODULES", metadata.get("modules"))
         self._append_tools(text, metadata.get("tools"))
-        text.append("\nm switch tab · PgUp/PgDn scroll · Esc back\n", style="dim")
+        text.append("\n←/→ tabs · PgUp/PgDn scroll · Esc back\n", style="dim")
         return text
 
     @classmethod

--- a/src/tui/widgets/sidebar.py
+++ b/src/tui/widgets/sidebar.py
@@ -130,7 +130,9 @@ class Sidebar(Static, can_focus=True):
         text.append("\n")  # visual gap below border title
 
         content_w = self.content_size.width if self.content_size.width > 0 else 0
-        row_width = content_w or (store.sidebar_width - 2)
+        configured_w = max(0, store.sidebar_width - 2)
+        # Textual may expose the previous content size for one layout tick after a resize.
+        row_width = min(content_w, configured_w) if content_w else configured_w
         has_focus = store.focused_pane == "sidebar"
         cursor = store.sidebar_cursor
         selected_id = store.sidebar_selected_id

--- a/test/agent/agent_step_test.py
+++ b/test/agent/agent_step_test.py
@@ -1,7 +1,9 @@
 """Tests for bodyful ``@ava.agent_step`` workflow nodes."""
+
 from __future__ import annotations
 
 import importlib
+import json
 from types import SimpleNamespace
 from typing import Any
 
@@ -9,6 +11,7 @@ import pytest
 from pydantic import BaseModel
 
 import avalanche as ava
+from avalanche._agent_evidence import capture_agent_evidence
 from avalanche.agent import AgentStepError, AgentStepExecutionError
 from avalanche.executor import LocalExecutor
 
@@ -217,6 +220,99 @@ def test_workflow_agent_defaults_reject_capabilities(name, defaults):
             return "unreachable"
 
 
+def test_agent_declaration_metadata_is_complete_static_and_redacted():
+    from pathlib import Path
+
+    from predict_rlm import Skill
+
+    def skill_tool(record_id: str) -> str:
+        """Fetch a record by identifier."""
+        return record_id
+
+    def explicit_tool(text: str) -> str:
+        """Normalize text for review."""
+        return text.strip()
+
+    audit_skill = Skill(
+        name="audit",
+        instructions="Check every claim.",
+        packages=["pydantic"],
+        modules={"audit_helpers": "/private/audit_helpers.py"},
+        tools={"fetch_record": skill_tool},
+    )
+
+    @ava.agent_step(
+        SummarySignature,
+        skills=[audit_skill],
+        tools=[explicit_tool],
+        max_iterations=7,
+        output_dir=Path("/private/output"),
+        submit_confirmation=lambda _context: "secret callback",
+    )
+    async def summarize(person: Person, *, agent: ava.Agent) -> str:
+        return (await agent(person=person)).note
+
+    spec = summarize.fn.__agent_step__
+    metadata = spec.declaration_metadata(
+        {
+            "max_iterations": 3,
+            "debug": True,
+            "api_key": "secret",
+            "opaque": object(),
+        }
+    )
+
+    assert metadata["signature"] == {
+        "name": "SummarySignature",
+        "instructions": "Summarize the supplied person.",
+        "inputs": [
+            {
+                "name": "person",
+                "annotation": "Person",
+                "description": "person to summarize",
+            }
+        ],
+        "outputs": [
+            {
+                "name": "summary",
+                "annotation": "Summary",
+                "description": "structured summary",
+            },
+            {
+                "name": "note",
+                "annotation": "str",
+                "description": "review note",
+            },
+        ],
+    }
+    assert metadata["skills"] == [
+        {
+            "name": "audit",
+            "instructions": "Check every claim.",
+            "packages": ["pydantic"],
+            "modules": ["audit_helpers"],
+            "tools": ["fetch_record"],
+        }
+    ]
+    assert metadata["aggregated_static_instructions"] == (
+        "Summarize the supplied person.\n\n## Skill: audit\n\nCheck every claim."
+    )
+    assert metadata["packages"] == ["pydantic"]
+    assert metadata["modules"] == ["audit_helpers"]
+    assert metadata["tools"] == [
+        {"name": "fetch_record", "description": "Fetch a record by identifier."},
+        {"name": "explicit_tool", "description": "Normalize text for review."},
+    ]
+    assert metadata["runtime"]["max_iterations"] == 7
+    assert metadata["runtime"]["debug"] is True
+    assert metadata["runtime"]["max_llm_calls"] == 50
+    rendered = json.dumps(metadata)
+    assert "secret" not in rendered
+    assert "/private" not in rendered
+    assert "opaque" not in rendered
+    assert "submit_confirmation" not in metadata["runtime"]
+
+
 @pytest.mark.parametrize(
     ("name", "declare", "message"),
     [
@@ -270,3 +366,228 @@ def _decorate_wrongly_annotated_agent(signature):
     @ava.agent.step(signature)
     async def summarize(person: Person, *, agent: object) -> str:
         return person.name
+
+
+class _RecordingSink:
+    strict = True
+
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event):
+        self.events.append(event)
+
+    async def flush(self, run_id):
+        return None
+
+    async def close(self, run_id, terminal_event=None):
+        if terminal_event is not None:
+            self.events.append(terminal_event)
+
+
+class _ExportableTrace:
+    def __init__(self, status="completed", *, fail=False):
+        self.status = status
+        self.fail = fail
+        self.called = False
+
+    def to_exportable_json(self):
+        self.called = True
+        if self.fail:
+            raise ValueError("trace export failed")
+        return json.dumps(
+            {
+                "status": self.status,
+                "model": "main",
+                "sub_model": "sub",
+                "iterations": 1,
+                "max_iterations": 2,
+                "duration_ms": 10,
+                "usage": {"main": {}, "sub": {}},
+                "steps": [],
+                "evidence": {
+                    "run_id": "rlm-run",
+                    "complete": True,
+                    "terminal_outcome": self.status,
+                    "events": [],
+                },
+                "image": "data:image/png;base64,<IMAGE_BASE_64_ENCODED(12)>",
+            }
+        )
+
+
+class _EvidencePredictor:
+    def __init__(self, sinks, response=None, error=None):
+        self.sinks = sinks
+        self.response = response
+        self.error = error
+
+    async def acall(self, **inputs):
+        from predict_rlm import RunEvent, RunEventKind
+
+        payloads = [
+            (RunEventKind.RUN_STARTED, {"inputs": inputs}),
+            (RunEventKind.CODE_GENERATED, {"iteration": 1, "code": "print('ok')"}),
+            (RunEventKind.CODE_EXECUTED, {"iteration": 1, "output": "ok"}),
+            (
+                RunEventKind.PREDICT_STARTED,
+                {
+                    "call_id": "predict-1",
+                    "signature": "text -> answer",
+                    "instructions": "answer",
+                    "model": "sub",
+                    "input": {"secret": "hidden"},
+                },
+            ),
+            (
+                RunEventKind.PREDICT_FINISHED,
+                {"call_id": "predict-1", "output": {"secret": "hidden"}},
+            ),
+            (
+                RunEventKind.TOOL_STARTED,
+                {"call_id": "tool-1", "name": "lookup", "args": ["secret"]},
+            ),
+            (
+                RunEventKind.TOOL_FINISHED,
+                {"call_id": "tool-1", "name": "lookup", "result": "secret"},
+            ),
+            (
+                RunEventKind.ITERATION_RECORDED,
+                {
+                    "step": {
+                        "iteration": 1,
+                        "duration_ms": 9,
+                        "error": False,
+                        "tool_calls": [{}],
+                        "predict_calls": [{"calls": [{}]}],
+                    }
+                },
+            ),
+        ]
+        for sequence, (kind, data) in enumerate(payloads, 1):
+            event = RunEvent("rlm-run", sequence, kind, sequence, data)
+            for sink in self.sinks:
+                await sink.emit(event)
+        terminal_kind = (
+            RunEventKind.RUN_FAILED if self.error is not None else RunEventKind.RUN_SUCCEEDED
+        )
+        terminal = RunEvent(
+            "rlm-run",
+            len(payloads) + 1,
+            terminal_kind,
+            len(payloads) + 1,
+            {"error": str(self.error)} if self.error is not None else {},
+        )
+        for sink in self.sinks:
+            await sink.flush("rlm-run")
+            await sink.close("rlm-run", terminal)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_agent_streams_sanitized_evidence_and_exported_trace(monkeypatch):
+    """The observer retains user sinks and publishes only compact live fields."""
+    user_sink = _RecordingSink()
+    trace = _ExportableTrace()
+    prediction = SimpleNamespace(
+        summary=Summary(headline="done", person_count=1),
+        note="unchanged",
+        trace=trace,
+    )
+
+    def fake_build(signature, *, skills, tools, **runtime_kwargs):
+        sinks = (*runtime_kwargs["events"], agent_step_module._AvalancheEvidenceSink())
+        return _EvidencePredictor(sinks, response=prediction)
+
+    monkeypatch.setattr(agent_step_module, "_build_predictor", fake_build)
+    agent = agent_step_module.Agent(
+        signature=SummarySignature,
+        step_name="summarize",
+        runtime_kwargs={"events": (user_sink,)},
+    )
+    observed = []
+    with capture_agent_evidence(observed.append):
+        result = await agent(person=Person(id=1, name="Ada"))
+
+    assert result is prediction
+    assert [event.kind.value for event in user_sink.events] == [
+        "run.started",
+        "code.generated",
+        "code.executed",
+        "predict.started",
+        "predict.finished",
+        "tool.started",
+        "tool.finished",
+        "iteration.recorded",
+        "run.succeeded",
+    ]
+    live = [event for event in observed if event["kind"] == "evidence"]
+    assert [event["sequence"] for event in live] == list(range(1, 10))
+    assert live[0]["data"] == {"input_fields": ["person"]}
+    assert live[3]["data"]["call_id"] == "predict-1"
+    assert "input" not in live[3]["data"]
+    assert "output" not in live[4]["data"]
+    assert "args" not in live[5]["data"]
+    assert "result" not in live[6]["data"]
+    terminal = observed[-1]
+    assert terminal["kind"] == "trace_finished"
+    assert terminal["trace"]["evidence"]["complete"] is True
+    assert "IMAGE_BASE_64_ENCODED" in json.dumps(terminal)
+    assert trace.called is True
+
+
+@pytest.mark.asyncio
+async def test_agent_observer_and_trace_export_failures_do_not_change_prediction(monkeypatch):
+    trace = _ExportableTrace(fail=True)
+    prediction = SimpleNamespace(
+        summary=Summary(headline="done", person_count=1),
+        note="unchanged",
+        trace=trace,
+    )
+
+    monkeypatch.setattr(
+        agent_step_module,
+        "_build_predictor",
+        lambda *args, **kwargs: _EvidencePredictor(
+            (agent_step_module._AvalancheEvidenceSink(),), response=prediction
+        ),
+    )
+    agent = agent_step_module.Agent(
+        signature=SummarySignature,
+        step_name="summarize",
+        runtime_kwargs={},
+    )
+
+    def broken_observer(_event):
+        raise RuntimeError("devtools unavailable")
+
+    with capture_agent_evidence(broken_observer):
+        assert await agent(person=Person(id=1, name="Ada")) is prediction
+
+
+@pytest.mark.asyncio
+async def test_agent_exports_exception_trace_before_preserving_wrapped_error(monkeypatch):
+    trace = _ExportableTrace(status="error")
+    failure = ValueError("provider unavailable")
+    failure.trace = trace
+    monkeypatch.setattr(
+        agent_step_module,
+        "_build_predictor",
+        lambda *args, **kwargs: _EvidencePredictor(
+            (agent_step_module._AvalancheEvidenceSink(),), error=failure
+        ),
+    )
+    agent = agent_step_module.Agent(
+        signature=SummarySignature,
+        step_name="summarize",
+        runtime_kwargs={},
+    )
+    observed = []
+    with capture_agent_evidence(observed.append):
+        with pytest.raises(AgentStepExecutionError, match="provider unavailable"):
+            await agent(person=Person(id=1, name="Ada"))
+
+    assert observed[-1]["kind"] == "trace_finished"
+    assert observed[-1]["trace"]["status"] == "error"

--- a/test/operator_tests/test_grpc.py
+++ b/test/operator_tests/test_grpc.py
@@ -14,12 +14,14 @@ import pytest
 from avalanche.operator import Operator
 from avalanche.operator.client import GrpcStateProvider
 from avalanche.operator.convert import (
+    node_state_from_proto,
+    node_state_to_proto,
     run_state_from_proto,
     run_state_to_proto,
     workflow_info_from_proto,
     workflow_info_to_proto,
 )
-from avalanche.operator.models import RunState, RunStatus, WorkflowInfo
+from avalanche.operator.models import NodeState, RunState, RunStatus, WorkflowInfo
 from avalanche.operator.server import serve
 from avalanche.runtime import File
 from runtime.operator._grpc import MAX_GRPC_MESSAGE_BYTES
@@ -55,6 +57,7 @@ def test_start_run_wire_preserves_surviving_field_numbers():
         flow_name="input_workflow",
         run_id="run_01KCVST2FP4QC5NKZNN5NS0Z2W",
         workflow_selector="flows/input.py::input_workflow",
+
     )
 
     assert request.run_id == "run_01KCVST2FP4QC5NKZNN5NS0Z2W"
@@ -1020,3 +1023,75 @@ def test_server_non_loopback_binding_is_explicit_and_warned(monkeypatch, caplog)
 
     assert fake_server.bind_address == "0.0.0.0:7433"
     assert "trusted and authenticated boundary" in caplog.text
+def test_agent_fields_roundtrip_and_legacy_defaults():
+    workflow = WorkflowInfo(
+        name="agent-flow",
+        file_path="flow.py",
+        node_ids=["agent_1"],
+        graph={"agent_1": []},
+        node_types={"agent_1": "step"},
+        agent_node_ids=["agent_1"],
+        agent_metadata_json={"agent_1": '{"signature":{"name":"Inspect"}}'},
+    )
+    restored = workflow_info_from_proto(workflow_info_to_proto(workflow))
+    assert restored.agent_node_ids == ["agent_1"]
+    assert restored.agent_metadata_json == workflow.agent_metadata_json
+
+    legacy = workflow_info_from_proto(pb.FlowInfoMsg())
+    assert legacy.agent_node_ids == []
+    assert legacy.agent_metadata_json == {}
+
+    envelope = json.dumps(
+        {
+            "schema_version": 1,
+            "status": "completed",
+            "run_id": "rlm-run",
+            "events": [],
+            "trace": {"status": "completed", "evidence": {"complete": True}},
+            "error": None,
+        }
+    )
+    node = NodeState(
+        node_id="agent_1",
+        name="agent",
+        node_type="step",
+        agent_trace_json=envelope,
+    )
+    assert node_state_from_proto(node_state_to_proto(node)).agent_trace_json == envelope
+    assert (
+        node_state_from_proto(
+            pb.NodeStateMsg(
+                node_id="legacy",
+                name="legacy",
+                node_type="step",
+                status="pending",
+            )
+        ).agent_trace_json
+        is None
+    )
+
+
+def test_run_state_proto_retains_complete_agent_envelope():
+    envelope = json.dumps(
+        {
+            "schema_version": 1,
+            "status": "completed",
+            "run_id": "rlm-run",
+            "events": [{"sequence": 1}],
+            "trace": {
+                "status": "completed",
+                "evidence": {"complete": True, "events": [{"sequence": 1}]},
+            },
+            "error": None,
+        }
+    )
+    run = RunState(run_id="run", flow_name="agent-flow")
+    run.nodes["agent_1"] = NodeState(
+        node_id="agent_1",
+        name="agent",
+        node_type="step",
+        agent_trace_json=envelope,
+    )
+
+    decoded = run_state_from_proto(run_state_to_proto(run))
+    assert decoded.nodes["agent_1"].agent_trace_json == envelope

--- a/test/operator_tests/test_operator.py
+++ b/test/operator_tests/test_operator.py
@@ -7,6 +7,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
+from types import SimpleNamespace
 
 import pytest
 
@@ -596,6 +597,11 @@ class TestAgentEvidenceTransport:
         run = self._state()
         with operator._lock:
             operator._runs[run.run_id] = run
+        handle = SimpleNamespace(
+            cancel_event=threading.Event(),
+            result_bundle=None,
+            success_quiesced=False,
+        )
 
         evidence = {
             "type": "agent_evidence",
@@ -608,11 +614,12 @@ class TestAgentEvidenceTransport:
                 "data": {"iteration": 1, "code": "print('ok')"},
             },
         }
-        assert operator._apply_event(run.run_id, evidence) is False
-        assert operator._apply_event(run.run_id, evidence) is False
+        assert operator._apply_event(run.run_id, handle, evidence) is False
+        assert operator._apply_event(run.run_id, handle, evidence) is False
         assert (
             operator._apply_event(
                 run.run_id,
+                handle,
                 {
                     "type": "agent_evidence",
                     "node_id": "agent_1",

--- a/test/operator_tests/test_operator.py
+++ b/test/operator_tests/test_operator.py
@@ -1,5 +1,7 @@
 """Tests for Operator — workflow execution and state management."""
 
+import asyncio
+import json
 import os
 import threading
 import time
@@ -9,10 +11,12 @@ from functools import partial
 import pytest
 
 from avalanche import LocalExecutor, RayExecutor
+from avalanche._agent_evidence import emit_agent_evidence
 from avalanche.operator import Operator
-from avalanche.operator.models import NodeStatus, RunState, RunStatus
+from avalanche.operator.models import NodeState, NodeStatus, RunState, RunStatus
 from avalanche.operator.operator import RunAlreadyExistsError
 from avalanche.operator.scheduler import Scheduler
+from runtime.operator.run_worker import _with_agent_evidence
 
 FIXTURES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "fixtures")
 
@@ -60,9 +64,7 @@ class TestOperatorLifecycle:
             results = list(pool.map(lambda _: reserve(), range(2)))
 
         assert results.count("run_concurrent") == 1
-        failures = [
-            result for result in results if isinstance(result, RunAlreadyExistsError)
-        ]
+        failures = [result for result in results if isinstance(result, RunAlreadyExistsError)]
         assert len(failures) == 1
 
     def test_run_completes_successfully(self):
@@ -175,9 +177,7 @@ class TestOperatorLifecycle:
             "def scheduled():\n"
             "    return None\n"
         )
-        operator = Operator(
-            workflow_paths=[str(workflow_file)], schedule=False, watch=False
-        )
+        operator = Operator(workflow_paths=[str(workflow_file)], schedule=False, watch=False)
         assert [item.workflow_id for item in operator.list_workflows()] == [
             "scheduled.py::scheduled"
         ]
@@ -212,13 +212,9 @@ class TestOperatorLifecycle:
             ),
         ],
     )
-    def test_deprecated_exact_executor_factories_remain_supported(
-        self, factory, expected
-    ):
+    def test_deprecated_exact_executor_factories_remain_supported(self, factory, expected):
         with pytest.warns(DeprecationWarning, match="executor_factory is deprecated"):
-            operator = Operator(
-                [], executor_factory=factory, watch=False, schedule=False
-            )
+            operator = Operator([], executor_factory=factory, watch=False, schedule=False)
         try:
             assert operator._executor_config == expected
         finally:
@@ -234,9 +230,7 @@ class TestOperatorLifecycle:
             ),
         ],
     )
-    def test_deprecated_executor_factories_remain_positional(
-        self, factory, expected
-    ):
+    def test_deprecated_executor_factories_remain_positional(self, factory, expected):
         with pytest.warns(DeprecationWarning, match="executor_factory is deprecated"):
             operator = Operator([], factory, False, False)
         try:
@@ -255,9 +249,7 @@ class TestOperatorLifecycle:
         self, monkeypatch, watch, schedule, expected_calls
     ):
         calls = []
-        monkeypatch.setattr(
-            Operator, "_start_watcher", lambda self: calls.append("watch")
-        )
+        monkeypatch.setattr(Operator, "_start_watcher", lambda self: calls.append("watch"))
         monkeypatch.setattr(Scheduler, "start", lambda self: calls.append("schedule"))
 
         with pytest.warns(DeprecationWarning, match="executor_factory is deprecated"):
@@ -348,9 +340,7 @@ class TestOperatorLifecycle:
             {"ray_init_kwargs": {}},
         ],
     )
-    def test_deprecated_factory_conflicts_with_explicit_configuration(
-        self, explicit_config
-    ):
+    def test_deprecated_factory_conflicts_with_explicit_configuration(self, explicit_config):
         with pytest.warns(DeprecationWarning, match="executor_factory is deprecated"):
             with pytest.raises(TypeError, match="cannot be combined"):
                 Operator(
@@ -533,3 +523,103 @@ class TestOperatorSubscription:
                 queued.append(subscriptions[0].get_nowait())
             assert [(seq, state.run_id) for seq, state in queued] == [(1, run.run_id)]
             op.close()
+
+
+class TestAgentEvidenceTransport:
+    @staticmethod
+    def _state():
+        run = RunState(run_id="run-agent", flow_name="agent-flow")
+        run.nodes["agent_1"] = NodeState(
+            node_id="agent_1",
+            name="agent",
+            node_type="step",
+            status=NodeStatus.RUNNING,
+        )
+        return run
+
+    def test_worker_wrapper_forwards_async_agent_evidence(self):
+        class Queue:
+            def __init__(self):
+                self.items = []
+
+            def put(self, value):
+                self.items.append(value)
+
+        async def agent_node():
+            await asyncio.sleep(0)
+            emit_agent_evidence(
+                {
+                    "kind": "evidence",
+                    "sequence": 1,
+                    "event_kind": "run.started",
+                    "timestamp_ns": 1,
+                    "data": {"input_fields": ["query"]},
+                }
+            )
+            return "result"
+
+        queue = Queue()
+        wrapped = _with_agent_evidence("agent_1", agent_node, queue)
+        assert asyncio.run(wrapped()) == "result"
+        assert queue.items == [
+            {
+                "type": "agent_evidence",
+                "node_id": "agent_1",
+                "event": {
+                    "kind": "evidence",
+                    "sequence": 1,
+                    "event_kind": "run.started",
+                    "timestamp_ns": 1,
+                    "data": {"input_fields": ["query"]},
+                },
+            }
+        ]
+
+    def test_operator_merges_ordered_evidence_and_final_trace(self):
+        operator = Operator([], watch=False, schedule=False)
+        run = self._state()
+        with operator._lock:
+            operator._runs[run.run_id] = run
+
+        evidence = {
+            "type": "agent_evidence",
+            "node_id": "agent_1",
+            "event": {
+                "kind": "evidence",
+                "sequence": 1,
+                "event_kind": "code.generated",
+                "timestamp_ns": 10,
+                "data": {"iteration": 1, "code": "print('ok')"},
+            },
+        }
+        assert operator._apply_event(run.run_id, evidence) is False
+        assert operator._apply_event(run.run_id, evidence) is False
+        assert (
+            operator._apply_event(
+                run.run_id,
+                {
+                    "type": "agent_evidence",
+                    "node_id": "agent_1",
+                    "event": {
+                        "kind": "trace_finished",
+                        "trace": {
+                            "status": "completed",
+                            "evidence": {
+                                "run_id": "agent-run",
+                                "complete": True,
+                                "events": [],
+                            },
+                            "steps": [],
+                        },
+                    },
+                },
+            )
+            is False
+        )
+
+        envelope = json.loads(run.nodes["agent_1"].agent_trace_json)
+        assert envelope["status"] == "completed"
+        assert envelope["run_id"] == "agent-run"
+        assert [item["sequence"] for item in envelope["events"]] == [1]
+        assert [entry.node_id for entry in run.logs] == ["agent_1", "agent_1"]
+        operator.close()

--- a/test/operator_tests/test_operator.py
+++ b/test/operator_tests/test_operator.py
@@ -16,7 +16,11 @@ from avalanche.operator import Operator
 from avalanche.operator.models import NodeState, NodeStatus, RunState, RunStatus
 from avalanche.operator.operator import RunAlreadyExistsError
 from avalanche.operator.scheduler import Scheduler
-from runtime.operator.run_worker import _with_agent_evidence
+from runtime.operator.run_worker import (
+    _QueueStream,
+    _with_local_node_observers,
+    _with_ray_node_observers,
+)
 
 FIXTURES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "fixtures")
 
@@ -537,7 +541,8 @@ class TestAgentEvidenceTransport:
         )
         return run
 
-    def test_worker_wrapper_forwards_async_agent_evidence(self):
+    @pytest.mark.parametrize("backend", ["local", "ray"])
+    def test_node_observers_keep_evidence_context_while_awaiting(self, backend):
         class Queue:
             def __init__(self):
                 self.items = []
@@ -558,10 +563,21 @@ class TestAgentEvidenceTransport:
             )
             return "result"
 
+        agent_node.__agent_step__ = object()
         queue = Queue()
-        wrapped = _with_agent_evidence("agent_1", agent_node, queue)
+        if backend == "local":
+            wrapped = _with_local_node_observers(
+                "agent_1",
+                agent_node,
+                _QueueStream(queue, "operator", 20),
+                _QueueStream(queue, "operator", 40),
+                queue,
+            )
+        else:
+            wrapped = _with_ray_node_observers("agent_1", agent_node, queue)
+
         assert asyncio.run(wrapped()) == "result"
-        assert queue.items == [
+        assert [item for item in queue.items if item.get("type") == "agent_evidence"] == [
             {
                 "type": "agent_evidence",
                 "node_id": "agent_1",

--- a/test/operator_tests/test_registry.py
+++ b/test/operator_tests/test_registry.py
@@ -1,6 +1,7 @@
 """Tests for WorkflowRegistry — workflow discovery from Python files."""
 
 import importlib
+import json
 import os
 import signal
 import sys
@@ -151,10 +152,7 @@ class TestWorkflowRegistry:
         left.mkdir()
         right.mkdir()
         source = (
-            "import avalanche as ava\n"
-            "@ava.workflow\n"
-            "def shared():\n"
-            "    return None\n"
+            "import avalanche as ava\n" "@ava.workflow\n" "def shared():\n" "    return None\n"
         )
         (left / "flow.py").write_text(source)
         (right / "flow.py").write_text(source)
@@ -286,9 +284,7 @@ class TestWorkflowRegistry:
         )
         registry = WorkflowRegistry()
         registry.scan([str(workflow_file)])
-        assert [item.workflow_id for item in registry.descriptors()] == [
-            "flow.py::scheduled"
-        ]
+        assert [item.workflow_id for item in registry.descriptors()] == ["flow.py::scheduled"]
 
         workflow_file.write_text("this is not valid Python !!!\n")
         registry.rescan()
@@ -335,9 +331,7 @@ class TestWorkflowRegistry:
         registry = WorkflowRegistry(discovery_timeout=2.0)
         registry.scan([str(workflow_file)])
 
-        assert [item.workflow_id for item in registry.descriptors()] == [
-            "flow.py::noisy"
-        ]
+        assert [item.workflow_id for item in registry.descriptors()] == ["flow.py::noisy"]
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group assertion")
     def test_successful_discovery_terminates_import_spawned_descendant(self, tmp_path):
@@ -385,10 +379,7 @@ class TestWorkflowRegistry:
 
     def test_explicit_alias_ids_are_stable_after_root_relocation(self, tmp_path):
         source = (
-            "import avalanche as ava\n"
-            "@ava.workflow\n"
-            "def build():\n"
-            "    return None\n"
+            "import avalanche as ava\n" "@ava.workflow\n" "def build():\n" "    return None\n"
         )
         first_root = tmp_path / "checkout-a" / "flows"
         second_root = tmp_path / "checkout-b" / "renamed"
@@ -450,9 +441,7 @@ class TestWorkflowRegistry:
         assert first_output == {"deployment": "first", "value": 1}
         assert second_output == {"deployment": "second", "value": "two"}
 
-    def test_package_scan_isolates_and_restores_preloaded_package(
-        self, tmp_path, monkeypatch
-    ):
+    def test_package_scan_isolates_and_restores_preloaded_package(self, tmp_path, monkeypatch):
         package_name = "registry_shared"
         first = tmp_path / "first"
         second = tmp_path / "second"
@@ -474,9 +463,7 @@ class TestWorkflowRegistry:
         registry = WorkflowRegistry()
         registry.scan([str(second / package_name / "flow.py")])
 
-        assert [item.display_name for item in registry.descriptors()] == [
-            "deployment_workflow"
-        ]
+        assert [item.display_name for item in registry.descriptors()] == ["deployment_workflow"]
         assert registry.list_diagnostics() == []
         assert sys.path == original_path
         assert all(sys.modules[name] is module for name, module in preloaded.items())
@@ -584,3 +571,57 @@ def _preload_deployment(monkeypatch, root, package_name):
         monkeypatch.delitem(sys.modules, name, raising=False)
     monkeypatch.syspath_prepend(str(root))
     return {name: importlib.import_module(name) for name in module_names}
+
+
+def test_agent_steps_are_identified_without_changing_node_type():
+    class Analyze(ava.Signature):
+        text: str = ava.InputField()
+        result: str = ava.OutputField()
+
+    @ava.source
+    def load() -> str:
+        return "input"
+
+    @ava.agent_step(Analyze)
+    async def analyze(text: str, *, agent: ava.Agent) -> str:
+        return (await agent(text=text)).result
+
+    @ava.workflow
+    def agent_flow():
+        return analyze(load())
+
+    info = workflow_to_info(agent_flow(), "<test>")
+    assert info.agent_node_ids == ["analyze_1"]
+    assert info.node_types["analyze_1"] == "step"
+
+
+def test_agent_metadata_failure_does_not_hide_workflow(monkeypatch):
+    class Analyze(ava.Signature):
+        """Analyze text."""
+
+        text: str = ava.InputField(desc="text to analyze")
+        result: str = ava.OutputField(desc="analysis")
+
+    @ava.agent_step(Analyze, max_iterations=4)
+    async def analyze(text: str, *, agent: ava.Agent) -> str:
+        return (await agent(text=text)).result
+
+    @ava.workflow(agent_defaults={"max_iterations": 2})
+    def agent_flow():
+        return analyze("input")
+
+    workflow = agent_flow()
+    info = workflow_to_info(workflow, "<test>")
+    metadata = json.loads(info.agent_metadata_json["analyze_1"])
+    assert metadata["signature"]["name"] == "Analyze"
+    assert metadata["runtime"]["max_iterations"] == 4
+
+    spec = workflow.nodes["analyze_1"].node.fn.__agent_step__
+
+    def fail_metadata(_defaults):
+        raise ValueError("invalid metadata")
+
+    monkeypatch.setattr(spec, "declaration_metadata", fail_metadata)
+    fallback = workflow_to_info(workflow, "<test>")
+    assert fallback.agent_node_ids == ["analyze_1"]
+    assert fallback.agent_metadata_json == {}

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -2750,6 +2750,9 @@ class TestInteractions:
             assert app.store.selected_run_id == first_run, "Alt+Up should restore run"
 
 
+_SANDBOX_STDOUT_SENTINEL = "SANDBOX_STDOUT_SENTINEL_DO_NOT_USE_AS_AGENT_OUTPUT"
+
+
 def _agent_trace_provider():
     metadata = {
         "signature": {
@@ -2764,10 +2767,20 @@ def _agent_trace_provider():
             ],
             "outputs": [
                 {
-                    "name": "report",
-                    "annotation": "InspectionReport",
-                    "description": "structured inspection report",
-                }
+                    "name": "summary",
+                    "annotation": "InspectionSummary",
+                    "description": "structured inspection summary",
+                },
+                {
+                    "name": "labels",
+                    "annotation": "list[str]",
+                    "description": "inspection labels",
+                },
+                {
+                    "name": "note",
+                    "annotation": "str | None",
+                    "description": "optional inspection note",
+                },
             ],
         },
         "runtime": {
@@ -2819,13 +2832,26 @@ def _agent_trace_provider():
             "sequence": 3,
             "kind": "code.executed",
             "timestamp_ns": 3,
-            "data": {"iteration": 2, "output": "short-second"},
+            "data": {"iteration": 2, "output": _SANDBOX_STDOUT_SENTINEL},
         },
         {
             "sequence": 4,
             "kind": "iteration.recorded",
             "timestamp_ns": 4,
             "data": {"step": {"iteration": 2}},
+        },
+        {
+            "sequence": 5,
+            "kind": "run.succeeded",
+            "timestamp_ns": 5,
+            "data": {
+                "status": "completed",
+                "outputs": {
+                    "summary": {"active_count": 1, "ready": False},
+                    "labels": ["reviewed"],
+                    "note": None,
+                },
+            },
         },
     ]
     steps = [
@@ -2846,7 +2872,7 @@ def _agent_trace_provider():
             "iteration": 2,
             "reasoning": "second reasoning",
             "code": "print('second')",
-            "output": "short-second",
+            "output": _SANDBOX_STDOUT_SENTINEL,
             "untruncated_output": "FULL-SECOND",
             "error": False,
             "duration_ms": 8,
@@ -2958,6 +2984,7 @@ async def test_agent_trace_inspector_interactions_and_log_retention():
     from avalanche.tui.app import AvalancheApp
     from avalanche.tui.widgets.agent_trace import (
         AgentMetadataInspector,
+        AgentOutputInspector,
         AgentTraceInspector,
     )
     from avalanche.tui.widgets.log_panel import LogWidget
@@ -3005,7 +3032,57 @@ async def test_agent_trace_inspector_interactions_and_log_retention():
             span.start <= code_offset < span.end for span in rendered.spans
         ), "Python code should carry syntax-highlighting spans"
 
-        await pilot.press("m")
+        await pilot.press("enter", "o")
+        preserved_turn_index = app.store.trace_turn_index
+        preserved_collapsed_turns = set(app.store.trace_collapsed_turns)
+        preserved_full_output = app.store.trace_show_full_output
+
+        await pilot.press("right")
+        await pilot.pause()
+        assert app.store.trace_inspector_tab == "output"
+        output_content = app._screen.query_one("#agent-output-content", AgentOutputInspector)
+        output_plain = output_content.render().plain
+        assert output_content.display is True
+        assert content.display is False
+        assert app._screen.query_one("#agent-trace-inspector").border_title == "Agent agent"
+        summary_header = "summary: InspectionSummary — structured inspection summary"
+        labels_header = "labels: list[str] — inspection labels"
+        note_header = "note: str | None — optional inspection note"
+        assert (
+            output_plain.index(summary_header)
+            < output_plain.index(labels_header)
+            < output_plain.index(note_header)
+        )
+        for expected in (
+            "AGENT OUTPUT · agent",
+            '"active_count": 1',
+            '"ready": false',
+            '"reviewed"',
+            "null",
+        ):
+            assert expected in output_plain
+        assert _SANDBOX_STDOUT_SENTINEL not in output_plain
+
+        await pilot.press("d", "m", "up", "enter", "o")
+        assert app.store.trace_inspector_tab == "output"
+        assert app.store.trace_turn_index == preserved_turn_index
+        assert app.store.trace_collapsed_turns == preserved_collapsed_turns
+        assert app.store.trace_show_full_output is preserved_full_output
+
+        await pilot.press("left")
+        await pilot.pause()
+        assert app.store.trace_inspector_tab == "trace"
+        assert content.display is True
+        assert output_content.display is False
+        assert app.store.trace_turn_index == preserved_turn_index
+        assert app.store.trace_collapsed_turns == preserved_collapsed_turns
+        assert app.store.trace_show_full_output is preserved_full_output
+
+        await pilot.press("enter", "o")
+        assert app.store.trace_collapsed_turns == set()
+        assert app.store.trace_show_full_output is False
+
+        await pilot.press("left")
         await pilot.pause()
         assert app.store.trace_inspector_tab == "metadata"
         metadata_content = app._screen.query_one(
@@ -3014,10 +3091,7 @@ async def test_agent_trace_inspector_interactions_and_log_retention():
         metadata_plain = metadata_content.render().plain
         assert metadata_content.display is True
         assert content.display is False
-        assert (
-            "Agent agent · Metadata"
-            in app._screen.query_one("#agent-trace-inspector").border_title
-        )
+        assert app._screen.query_one("#agent-trace-inspector").border_title == "Agent agent"
         for expected in (
             "InspectRecords",
             "records: list[Record] — records to inspect",
@@ -3039,7 +3113,7 @@ async def test_agent_trace_inspector_interactions_and_log_retention():
         assert app.store.trace_collapsed_turns == collapsed_turns
         assert app.store.trace_show_full_output is show_full_output
 
-        await pilot.press("m")
+        await pilot.press("right")
         await pilot.pause()
         assert app.store.trace_inspector_tab == "trace"
         assert content.display is True
@@ -3066,7 +3140,8 @@ async def test_agent_trace_inspector_interactions_and_log_retention():
         assert app.store.trace_inspector_open is False
         assert app.store.focused_pane == "dag"
         assert app._screen.query_one("#dashboard-pane").display is True
-        logs = app._screen.query_one("#log-content", LogWidget).render().plain
+        log_view = app._screen.query_one("#log-content", LogWidget)
+        logs = "\n".join(line.text for line in log_view.lines)
         assert "Agent code.generated" in logs
         assert "Agent iteration.recorded" in logs
 
@@ -3076,6 +3151,7 @@ async def test_agent_trace_inspector_renders_pending_failed_malformed_and_incomp
     from avalanche.tui.app import AvalancheApp
     from avalanche.tui.widgets.agent_trace import (
         AgentMetadataInspector,
+        AgentOutputInspector,
         AgentTraceInspector,
     )
 
@@ -3089,24 +3165,120 @@ async def test_agent_trace_inspector_renders_pending_failed_malformed_and_incomp
         content = app._screen.query_one("#agent-trace-content", AgentTraceInspector)
         node = app.store.current_run.nodes["agent_1"]
 
-        await pilot.press("m")
+        await pilot.press("left")
         metadata_content = app._screen.query_one(
             "#agent-metadata-content", AgentMetadataInspector
         )
         workflow = app.store.current_workflow
+        original_metadata_json = workflow.agent_metadata_json["agent_1"]
         workflow.agent_metadata_json["agent_1"] = "{malformed"
         assert "Metadata unavailable or malformed" in metadata_content.render().plain
         workflow.agent_metadata_json.pop("agent_1")
         assert "Metadata unavailable or malformed" in metadata_content.render().plain
-        await pilot.press("m")
+        await pilot.press("left")
+        output_content = app._screen.query_one("#agent-output-content", AgentOutputInspector)
+        fallback_output = output_content.render().plain
+        assert app.store.trace_inspector_tab == "output"
+        assert "summary:" in fallback_output
+        assert "labels:" in fallback_output
+        assert "note:" in fallback_output
+        assert "InspectionSummary" not in fallback_output
+        assert '"ready": false' in fallback_output
+        assert _SANDBOX_STDOUT_SENTINEL not in fallback_output
+
+        await pilot.press("right")
+        assert app.store.trace_inspector_tab == "metadata"
+        await pilot.press("right")
+        assert app.store.trace_inspector_tab == "trace"
+        workflow.agent_metadata_json["agent_1"] = original_metadata_json
+
+        projected = json.loads(json.dumps(envelope))
+        projected_success = projected["trace"]["evidence"]["events"][-1]
+        projected_success["event_kind"] = projected_success.pop("kind")
+        node.agent_trace_json = json.dumps(projected)
+        assert app.store.selected_agent_outputs == {
+            "summary": {"active_count": 1, "ready": False},
+            "labels": ["reviewed"],
+            "note": None,
+        }
+
+        absent_field = json.loads(json.dumps(envelope))
+        absent_field["trace"]["evidence"]["events"][-1]["data"]["outputs"].pop("note")
+        node.agent_trace_json = json.dumps(absent_field)
+        await pilot.press("right")
+        absent_output = output_content.render().plain
+        note_header = "note: str | None — optional inspection note"
+        assert note_header in absent_output
+        assert "Unavailable" in absent_output[absent_output.index(note_header) :]
+        await pilot.press("left")
+
+        malformed_success = json.loads(json.dumps(envelope))
+        malformed_success["trace"]["evidence"]["events"].append(
+            {
+                "sequence": 6,
+                "kind": "run.succeeded",
+                "data": {"status": "completed", "outputs": []},
+            }
+        )
+        node.agent_trace_json = json.dumps(malformed_success)
+        await pilot.press("right")
+        assert "Output unavailable" in output_content.render().plain
+        await pilot.press("left")
+
+        legacy = json.loads(json.dumps(envelope))
+        legacy["trace"]["evidence"]["events"] = [
+            event
+            for event in legacy["trace"]["evidence"]["events"]
+            if event.get("kind") != "run.succeeded"
+        ]
+        node.agent_trace_json = json.dumps(legacy)
+        await pilot.press("right")
+        assert "Output unavailable" in output_content.render().plain
+        await pilot.press("left")
+
+        assert app.store.trace_inspector_tab == "trace"
+        node.agent_trace_json = json.dumps(envelope)
+        assert app.store.selected_agent_outputs is not None
+        assert _SANDBOX_STDOUT_SENTINEL not in output_content.render().plain
+
+        node.agent_trace_json = "{malformed"
+        await pilot.press("right")
+        assert "Output unavailable" in output_content.render().plain
+        await pilot.press("left")
         assert app.store.trace_inspector_tab == "trace"
 
         node.agent_trace_json = "{malformed"
         assert "unavailable or malformed" in content.render().plain
 
-        node.status = NodeStatus.RUNNING
+        missing_node = app.store.current_run.nodes.pop("agent_1")
+        missing_trace = content.render().plain
+        assert "This agent step has not run yet for this run." in missing_trace
+        assert "Trace unavailable or malformed" not in missing_trace
+        await pilot.press("right")
+        missing_output = output_content.render().plain
+        assert "This agent step has not run yet for this run." in missing_output
+        assert "Output unavailable" not in missing_output
+        await pilot.press("left")
+        app.store.current_run.nodes["agent_1"] = missing_node
+
+        node.status = NodeStatus.PENDING
         node.agent_trace_json = None
+        pending_trace = content.render().plain
+        assert "This agent step has not run yet for this run." in pending_trace
+        assert "Trace unavailable or malformed" not in pending_trace
+        await pilot.press("right")
+        pending_output = output_content.render().plain
+        assert "This agent step has not run yet for this run." in pending_output
+        assert "Output unavailable" not in pending_output
+        await pilot.press("left")
+
+        node.status = NodeStatus.RUNNING
         assert "waiting for live updates" in content.render().plain
+        await pilot.press("right")
+        running_output = output_content.render().plain
+        assert "Output will be available after this agent step completes." in running_output
+        assert "This agent step has not run yet for this run." not in running_output
+        await pilot.press("left")
 
         live = dict(envelope)
         live.update({"status": "in_progress", "trace": None, "error": None})
@@ -3116,7 +3288,7 @@ async def test_agent_trace_inspector_renders_pending_failed_malformed_and_incomp
         assert "LIVE TRACE · 2 turn(s)" in live_render
         assert "AGENT TURN 1/2 · 0ms · 0 tool · 0 predict · LIVE" in live_render
         assert "print('first')" in live_render
-        assert "short-second" in live_render
+        assert _SANDBOX_STDOUT_SENTINEL in live_render
 
         failed = dict(live)
         failed.update({"status": "error", "error": "provider failed"})
@@ -3128,6 +3300,11 @@ async def test_agent_trace_inspector_renders_pending_failed_malformed_and_incomp
         assert "Code generated · turn 1" in failed_render
         assert "Turn completed · turn 2" in failed_render
         assert "iteration.recorded" not in failed_render
+        node.status = NodeStatus.FAILED
+        await pilot.press("right")
+        assert "Output unavailable" in output_content.render().plain
+        assert _SANDBOX_STDOUT_SENTINEL not in output_content.render().plain
+        await pilot.press("left")
 
         incomplete = json.loads(json.dumps(envelope))
         incomplete["trace"]["evidence"]["complete"] = False

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -1,5 +1,7 @@
 """Tests for the Avalanche TUI module."""
 
+import asyncio
+import json
 import threading
 import time
 from dataclasses import replace
@@ -45,6 +47,15 @@ def _apply_async_updates(store: UIStore, timeout: float = 1.0) -> None:
     store._apply_background_updates()
 
 
+async def _wait_for_current_run(app, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while app.store.current_run is None and time.monotonic() < deadline:
+        app.store._apply_background_updates()
+        await asyncio.sleep(0.005)
+    app.store._apply_background_updates()
+    assert app.store.current_run is not None
+
+
 class _SignalingQueue:
     def __init__(self, queue):
         self._queue = queue
@@ -82,8 +93,11 @@ class TestModels:
 
     def test_node_state_elapsed_running(self):
         ns = NodeState(
-            node_id="x", name="x", node_type="step",
-            status=NodeStatus.RUNNING, started_at=time.monotonic() - 2.0,
+            node_id="x",
+            name="x",
+            node_type="step",
+            status=NodeStatus.RUNNING,
+            started_at=time.monotonic() - 2.0,
         )
         assert ns.elapsed is not None
         assert ns.elapsed >= 1.9
@@ -91,8 +105,12 @@ class TestModels:
     def test_node_state_elapsed_completed(self):
         t = time.monotonic()
         ns = NodeState(
-            node_id="x", name="x", node_type="step",
-            status=NodeStatus.SUCCESS, started_at=t - 5.0, ended_at=t - 2.0,
+            node_id="x",
+            name="x",
+            node_type="step",
+            status=NodeStatus.SUCCESS,
+            started_at=t - 5.0,
+            ended_at=t - 2.0,
         )
         assert abs(ns.elapsed - 3.0) < 0.1
 
@@ -211,13 +229,12 @@ class TestRenderDag:
         statuses = {n.name: NodeStatus.PENDING for n in nodes}
         lines = render_dag_rich(dag, statuses, 0, None)
         combined = "\n".join(line.plain for line in lines)
-        assert "&" in combined, (
-            f"Expected '&' between parallel branches, got:\n{combined}"
-        )
+        assert "&" in combined, f"Expected '&' between parallel branches, got:\n{combined}"
 
     def test_cross_fork_fanin_dedup_page_highlights(self):
         """page_highlights should appear exactly once in doc_processing layout."""
         from avalanche.tui.mock import DOC_PROCESSING_WORKFLOW
+
         dag, nodes = workflow_to_layout(DOC_PROCESSING_WORKFLOW)
         ph_count = sum(1 for n in nodes if n.name == "page_highlights_1")
         assert ph_count == 1, f"page_highlights appears {ph_count} times, expected 1"
@@ -225,10 +242,11 @@ class TestRenderDag:
     def test_cross_fork_fanin_skip_edge_recorded(self):
         """push_to_cdn → page_highlights should be a skip edge after dedup."""
         from avalanche.tui.mock import DOC_PROCESSING_WORKFLOW
+
         dag, nodes = workflow_to_layout(DOC_PROCESSING_WORKFLOW)
-        assert ("push_to_cdn_1", "page_highlights_1") in dag.skip_edges, (
-            f"Expected skip edge push_to_cdn→page_highlights, got: {dag.skip_edges}"
-        )
+        assert (
+            ("push_to_cdn_1", "page_highlights_1") in dag.skip_edges
+        ), f"Expected skip edge push_to_cdn→page_highlights, got: {dag.skip_edges}"
 
     def test_partial_convergence_dedup(self):
         """Fan-in nodes reachable from some (not all) branches get deduped."""
@@ -246,12 +264,12 @@ class TestRenderDag:
         must lay out as a single linear spine with skip-edge annotations,
         never duplicating nodes."""
         ids = [f"s{i}_1" for i in range(1, 8)]
-        graph = {
-            ids[i]: [ids[j] for j in range(i + 1, 7)]
-            for i in range(6)
-        }
+        graph = {ids[i]: [ids[j] for j in range(i + 1, 7)] for i in range(6)}
         info = WorkflowInfo(
-            name="dense", file_path="f", node_ids=ids, graph=graph,
+            name="dense",
+            file_path="f",
+            node_ids=ids,
+            graph=graph,
             node_types={i: "step" for i in ids},
         )
         dag, nodes = workflow_to_layout(info)
@@ -276,9 +294,9 @@ class TestRenderDag:
         # Each line should be self-contained (no wrapping artifacts)
         for i, line in enumerate(lines):
             plain = line.plain
-            assert "─┐" not in plain or "┌──" in plain or "├" in plain, (
-                f"Line {i} has closing bracket without opening — possible wrap: {plain}"
-            )
+            assert (
+                "─┐" not in plain or "┌──" in plain or "├" in plain
+            ), f"Line {i} has closing bracket without opening — possible wrap: {plain}"
 
 
 # ── Mock Provider ──────────────────────────────────────────────────────────
@@ -394,9 +412,7 @@ class TestUIStore:
             def on_log(self, callback):
                 pass
 
-        app = AvalancheApp(
-            BlockingCatalogProvider(), workflow="desired", node="shared_node"
-        )
+        app = AvalancheApp(BlockingCatalogProvider(), workflow="desired", node="shared_node")
         updates = _signal_background_updates(app.store)
         assert entered[0].wait(1.0)
         assert app.store.workflows == []
@@ -490,9 +506,7 @@ class TestUIStore:
         assert store.start_run_async()
         assert provider.entered.wait(1.0)
         other = next(
-            workflow
-            for workflow in store.workflows
-            if workflow.selector != started_selector
+            workflow for workflow in store.workflows if workflow.selector != started_selector
         )
         store.switch_workflow(other)
         _apply_async_updates(store)
@@ -1577,8 +1591,11 @@ class TestRunHistory:
         store = UIStore(MockStateProvider())
         # Point to a non-existent workflow so list_runs returns []
         store.current_workflow = WorkflowInfo(
-            name="nonexistent", file_path="x/y.py",
-            node_ids=[], graph={}, node_types={},
+            name="nonexistent",
+            file_path="x/y.py",
+            node_ids=[],
+            graph={},
+            node_types={},
         )
         store.current_run = None
         w = RunHistoryWidget()
@@ -1623,6 +1640,7 @@ class TestRunHistory:
         w._test_store = store
         rendered = w.render().plain
         import re
+
         assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", rendered)
 
 
@@ -1876,6 +1894,7 @@ class TestInteractions:
 
     async def _make_app(self):
         from avalanche.tui.app import AvalancheApp
+
         return AvalancheApp()
 
     def _sidebar_workflow_order(self, app) -> list[str]:
@@ -2088,9 +2107,7 @@ class TestInteractions:
             items = sidebar._flat_items
 
             # Find workflow items (won't toggle folders and change tree)
-            workflow_indices = [
-                i for i, it in enumerate(items) if not it.is_folder
-            ]
+            workflow_indices = [i for i, it in enumerate(items) if not it.is_folder]
             assert len(workflow_indices) >= 2, "Need at least 2 workflows"
 
             for target_idx in workflow_indices[:3]:
@@ -2106,6 +2123,7 @@ class TestInteractions:
     async def test_run_history_click_selects_correct_run(self):
         """Clicking a run in run history should select that run, not an adjacent one."""
         import asyncio
+
         app = await self._make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -2127,9 +2145,9 @@ class TestInteractions:
             await pilot.pause()
 
             target_run = display[1]
-            assert app.store.selected_run_id == target_run.run_id, (
-                f"Expected run {target_run.run_id}, got {app.store.selected_run_id}"
-            )
+            assert (
+                app.store.selected_run_id == target_run.run_id
+            ), f"Expected run {target_run.run_id}, got {app.store.selected_run_id}"
 
     async def test_border_titles_present(self):
         """All panes should have border titles rendered on their borders."""
@@ -2167,9 +2185,9 @@ class TestInteractions:
             await pilot.pause()
 
             node_name = app.store.selected_node.display_name
-            assert node_name in str(lp.border_title), (
-                f"Expected '{node_name}' in border title, got '{lp.border_title}'"
-            )
+            assert node_name in str(
+                lp.border_title
+            ), f"Expected '{node_name}' in border title, got '{lp.border_title}'"
 
     async def test_sticky_headers_exist(self):
         """Run history and log panes should have separate sticky header widgets."""
@@ -2185,6 +2203,7 @@ class TestInteractions:
             # Verify the static render_header methods produce column headers
             from avalanche.tui.widgets.log_panel import LogWidget
             from avalanche.tui.widgets.run_history import RunHistoryWidget
+
             assert "Run ID" in RunHistoryWidget.render_header().plain
             assert "Timestamp" in LogWidget.render_header().plain
 
@@ -2197,28 +2216,56 @@ class TestInteractions:
             original_width = app.store.sidebar_width
 
             from textual.events import MouseDown, MouseMove, MouseUp
-            sidebar.on_mouse_down(MouseDown(
-                sidebar, x=sidebar.size.width - 1, y=5,
-                delta_x=0, delta_y=0, button=1,
-                shift=False, meta=False, ctrl=False,
-                screen_x=original_width - 1, screen_y=5,
-            ))
+
+            sidebar.on_mouse_down(
+                MouseDown(
+                    sidebar,
+                    x=sidebar.size.width - 1,
+                    y=5,
+                    delta_x=0,
+                    delta_y=0,
+                    button=1,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                    screen_x=original_width - 1,
+                    screen_y=5,
+                )
+            )
             assert sidebar._dragging is True
 
-            sidebar.on_mouse_move(MouseMove(
-                sidebar, x=0, y=5,
-                delta_x=5, delta_y=0, button=1,
-                shift=False, meta=False, ctrl=False,
-                screen_x=original_width + 5, screen_y=5,
-            ))
+            sidebar.on_mouse_move(
+                MouseMove(
+                    sidebar,
+                    x=0,
+                    y=5,
+                    delta_x=5,
+                    delta_y=0,
+                    button=1,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                    screen_x=original_width + 5,
+                    screen_y=5,
+                )
+            )
             assert app.store.sidebar_width == original_width + 5
 
-            sidebar.on_mouse_up(MouseUp(
-                sidebar, x=0, y=5,
-                delta_x=0, delta_y=0, button=1,
-                shift=False, meta=False, ctrl=False,
-                screen_x=original_width + 5, screen_y=5,
-            ))
+            sidebar.on_mouse_up(
+                MouseUp(
+                    sidebar,
+                    x=0,
+                    y=5,
+                    delta_x=0,
+                    delta_y=0,
+                    button=1,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                    screen_x=original_width + 5,
+                    screen_y=5,
+                )
+            )
             assert sidebar._dragging is False
 
     async def test_sidebar_drag_enforces_minimum_width(self):
@@ -2229,26 +2276,54 @@ class TestInteractions:
             sidebar = app._screen.query_one("#sidebar")
 
             from textual.events import MouseDown, MouseMove, MouseUp
-            sidebar.on_mouse_down(MouseDown(
-                sidebar, x=sidebar.size.width - 1, y=5,
-                delta_x=0, delta_y=0, button=1,
-                shift=False, meta=False, ctrl=False,
-                screen_x=30, screen_y=5,
-            ))
-            sidebar.on_mouse_move(MouseMove(
-                sidebar, x=0, y=5,
-                delta_x=-20, delta_y=0, button=1,
-                shift=False, meta=False, ctrl=False,
-                screen_x=5, screen_y=5,
-            ))
+
+            sidebar.on_mouse_down(
+                MouseDown(
+                    sidebar,
+                    x=sidebar.size.width - 1,
+                    y=5,
+                    delta_x=0,
+                    delta_y=0,
+                    button=1,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                    screen_x=30,
+                    screen_y=5,
+                )
+            )
+            sidebar.on_mouse_move(
+                MouseMove(
+                    sidebar,
+                    x=0,
+                    y=5,
+                    delta_x=-20,
+                    delta_y=0,
+                    button=1,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                    screen_x=5,
+                    screen_y=5,
+                )
+            )
             assert app.store.sidebar_width >= 15
 
-            sidebar.on_mouse_up(MouseUp(
-                sidebar, x=0, y=5,
-                delta_x=0, delta_y=0, button=1,
-                shift=False, meta=False, ctrl=False,
-                screen_x=5, screen_y=5,
-            ))
+            sidebar.on_mouse_up(
+                MouseUp(
+                    sidebar,
+                    x=0,
+                    y=5,
+                    delta_x=0,
+                    delta_y=0,
+                    button=1,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                    screen_x=5,
+                    screen_y=5,
+                )
+            )
 
     async def test_sidebar_text_clips_to_width(self):
         """Sidebar should clip long labels to fit within content width."""
@@ -2273,6 +2348,7 @@ class TestInteractions:
     async def test_run_history_arrow_scrolls_to_selected(self):
         """Arrow keys in run history should keep the selected run visible."""
         import asyncio
+
         app = await self._make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -2301,6 +2377,7 @@ class TestInteractions:
         since headless layout doesn't faithfully reproduce scrollbar sizing.
         """
         import asyncio
+
         app = await self._make_app()
         async with app.run_test(size=(50, 50)) as pilot:
             await pilot.pause()
@@ -2313,9 +2390,9 @@ class TestInteractions:
             # Verify our CSS is at least being applied
             for widget_id in ("#run-history", "#dag-container", "#log-content"):
                 w = app._screen.query_one(widget_id)
-                assert w.styles.scrollbar_size_vertical == 1, (
-                    f"{widget_id} scrollbar_size_vertical={w.styles.scrollbar_size_vertical}"
-                )
+                assert (
+                    w.styles.scrollbar_size_vertical == 1
+                ), f"{widget_id} scrollbar_size_vertical={w.styles.scrollbar_size_vertical}"
                 assert w.styles.scrollbar_size_horizontal == 1, (
                     f"{widget_id} scrollbar_size_horizontal="
                     f"{w.styles.scrollbar_size_horizontal}"
@@ -2324,6 +2401,7 @@ class TestInteractions:
     async def test_log_panel_allows_horizontal_scroll(self):
         """Log panel should support horizontal scrolling when content is wider than pane."""
         import asyncio
+
         app = await self._make_app()
         async with app.run_test(size=(50, 40)) as pilot:  # very narrow to force overflow
             await pilot.pause()
@@ -2439,6 +2517,7 @@ class TestInteractions:
         (no border offset needed in on_click).
         """
         from textual.pilot import OutOfBounds
+
         app = await self._make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -2456,9 +2535,9 @@ class TestInteractions:
                 except OutOfBounds:
                     continue  # node scrolled off-screen
                 await pilot.pause()
-                assert app.store.selected_node is not None, (
-                    f"Click at ({target_col}, {row_idx}) should select {node.name}"
-                )
+                assert (
+                    app.store.selected_node is not None
+                ), f"Click at ({target_col}, {row_idx}) should select {node.name}"
                 assert app.store.selected_node.name == node.name, (
                     f"Clicked {node.name} at row={row_idx}, "
                     f"but selected {app.store.selected_node.name}"
@@ -2483,9 +2562,7 @@ class TestInteractions:
             lines = rendered.plain.split("\n")
             # Should have DAG rows + possible spacer/skip-edge rows
             non_empty = [line for line in lines if line.strip()]
-            assert len(non_empty) >= 3, (
-                f"Expected at least 3 DAG rows, got {len(non_empty)}"
-            )
+            assert len(non_empty) >= 3, f"Expected at least 3 DAG rows, got {len(non_empty)}"
             # All 3 fetch nodes must appear
             combined = "\n".join(lines)
             for name in ("fetch_training", "fetch_validation", "fetch_features"):
@@ -2494,6 +2571,7 @@ class TestInteractions:
     async def test_deep_link_workflow(self):
         """App should support starting with a specific workflow selected."""
         from avalanche.tui.app import AvalancheApp
+
         app = AvalancheApp(workflow="ml_workflow")
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -2503,6 +2581,7 @@ class TestInteractions:
     async def test_deep_link_node_matches_display_name(self):
         """Deep-link node segment should accept the rendered display name."""
         from avalanche.tui.app import AvalancheApp
+
         app = AvalancheApp(workflow="ml_workflow", node="export_onnx")
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -2560,9 +2639,9 @@ class TestInteractions:
                 # Check the scroll containers didn't move
                 widget_id = "#run-history" if pane == "run-history" else "#log-panel"
                 w = app._screen.query_one(widget_id)
-                assert w.scroll_x == 0, (
-                    f"{pane}: left/right arrows should not scroll horizontally"
-                )
+                assert (
+                    w.scroll_x == 0
+                ), f"{pane}: left/right arrows should not scroll horizontally"
 
     async def test_focused_log_up_down_scrolls_log_content(self):
         """Up/down in the log pane should scroll the actual RichLog."""
@@ -2624,26 +2703,27 @@ class TestInteractions:
                 await pilot.press("right")
                 await pilot.pause()
                 assert app.store.focused_pane == pane
-                assert app.store.selected_node is not None, (
-                    f"Right should select a DAG node while {pane} is focused"
-                )
+                assert (
+                    app.store.selected_node is not None
+                ), f"Right should select a DAG node while {pane} is focused"
                 first = app.store.selected_node
 
                 await pilot.press("right")
                 await pilot.pause()
-                assert app.store.selected_node.col > first.col, (
-                    f"Right should advance DAG selection while {pane} is focused"
-                )
+                assert (
+                    app.store.selected_node.col > first.col
+                ), f"Right should advance DAG selection while {pane} is focused"
 
                 await pilot.press("left")
                 await pilot.pause()
-                assert app.store.selected_node.col == first.col, (
-                    f"Left should move DAG selection back while {pane} is focused"
-                )
+                assert (
+                    app.store.selected_node.col == first.col
+                ), f"Left should move DAG selection back while {pane} is focused"
 
     async def test_alt_arrows_change_run_without_changing_pane(self):
         """Alt+Up/Down should cycle runs without changing the focused pane."""
         import asyncio
+
         app = await self._make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -2668,3 +2748,391 @@ class TestInteractions:
             await pilot.pause()
             assert app.store.focused_pane == "dag", "Alt+Up should not change pane"
             assert app.store.selected_run_id == first_run, "Alt+Up should restore run"
+
+
+def _agent_trace_provider():
+    metadata = {
+        "signature": {
+            "name": "InspectRecords",
+            "instructions": "Inspect the supplied records.",
+            "inputs": [
+                {
+                    "name": "records",
+                    "annotation": "list[Record]",
+                    "description": "records to inspect",
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "report",
+                    "annotation": "InspectionReport",
+                    "description": "structured inspection report",
+                }
+            ],
+        },
+        "runtime": {
+            "lm": "main-model",
+            "sub_lm": "sub-model",
+            "max_iterations": 5,
+            "debug": False,
+        },
+        "skills": [
+            {
+                "name": "audit",
+                "instructions": "Check every claim.",
+                "packages": ["pydantic"],
+                "modules": ["audit_helpers"],
+                "tools": ["lookup"],
+            }
+        ],
+        "aggregated_static_instructions": (
+            "Inspect the supplied records.\n\n" "## Skill: audit\n\nCheck every claim."
+        ),
+        "packages": ["pydantic"],
+        "modules": ["audit_helpers"],
+        "tools": [{"name": "lookup", "description": "Look up a record."}],
+    }
+    workflow = WorkflowInfo(
+        name="agent_flow",
+        file_path="workflows/agent_flow.py",
+        node_ids=["agent_1"],
+        graph={"agent_1": []},
+        node_types={"agent_1": "step"},
+        display_names={"agent_1": "agent"},
+        agent_node_ids=["agent_1"],
+        agent_metadata_json={"agent_1": json.dumps(metadata)},
+    )
+    events = [
+        {
+            "sequence": 1,
+            "kind": "code.generated",
+            "timestamp_ns": 1,
+            "data": {"iteration": 1, "code": "print('first')"},
+        },
+        {
+            "sequence": 2,
+            "kind": "iteration.recorded",
+            "timestamp_ns": 2,
+            "data": {"step": {"iteration": 1}},
+        },
+        {
+            "sequence": 3,
+            "kind": "code.executed",
+            "timestamp_ns": 3,
+            "data": {"iteration": 2, "output": "short-second"},
+        },
+        {
+            "sequence": 4,
+            "kind": "iteration.recorded",
+            "timestamp_ns": 4,
+            "data": {"step": {"iteration": 2}},
+        },
+    ]
+    steps = [
+        {
+            "iteration": 1,
+            "reasoning": "first reasoning",
+            "code": "print('first')",
+            "output": "first",
+            "untruncated_output": "FULL-FIRST",
+            "error": False,
+            "duration_ms": 5,
+            "tool_calls": [],
+            "predict_calls": [],
+            "lm": {"finish_reason": "stop"},
+            "usage": {"main": {}, "sub": {}},
+        },
+        {
+            "iteration": 2,
+            "reasoning": "second reasoning",
+            "code": "print('second')",
+            "output": "short-second",
+            "untruncated_output": "FULL-SECOND",
+            "error": False,
+            "duration_ms": 8,
+            "tool_calls": [
+                {
+                    "name": "lookup",
+                    "args": [],
+                    "kwargs": {},
+                    "result": "value",
+                    "error": None,
+                    "duration_ms": 1,
+                }
+            ],
+            "predict_calls": [
+                {
+                    "signature": "text -> answer",
+                    "instructions": "answer",
+                    "model": "sub",
+                    "total_usage": {},
+                    "calls": [
+                        {
+                            "duration_ms": 2,
+                            "usage": {},
+                            "input": {"text": "x"},
+                            "output": {"answer": "y"},
+                            "error": None,
+                            "lm": {"finish_reason": "stop"},
+                        }
+                    ],
+                }
+            ],
+            "lm": {"finish_reason": "stop"},
+            "usage": {
+                "main": {"input_tokens": 10, "output_tokens": 2, "cost": 0.01},
+                "sub": {"input_tokens": 4, "output_tokens": 1, "cost": 0.002},
+            },
+        },
+    ]
+    envelope = {
+        "schema_version": 1,
+        "status": "completed",
+        "run_id": "agent-run",
+        "events": [
+            {
+                "sequence": event["sequence"],
+                "event_kind": event["kind"],
+                "timestamp_ns": event["timestamp_ns"],
+                "data": event["data"],
+            }
+            for event in events
+        ],
+        "trace": {
+            "status": "completed",
+            "model": "main-model",
+            "sub_model": "sub-model",
+            "iterations": 2,
+            "max_iterations": 5,
+            "duration_ms": 20,
+            "usage": {
+                "main": {
+                    "input_tokens": 20,
+                    "output_tokens": 4,
+                    "cache_hits": 1,
+                    "cost": 0.02,
+                },
+                "sub": {
+                    "input_tokens": 8,
+                    "output_tokens": 2,
+                    "cache_hits": 0,
+                    "cost": 0.004,
+                },
+            },
+            "steps": steps,
+            "evidence": {
+                "run_id": "agent-run",
+                "complete": True,
+                "terminal_outcome": "completed",
+                "events": events,
+            },
+        },
+        "error": None,
+    }
+    run = RunState(
+        run_id="run-agent",
+        flow_name="agent_flow",
+        status=RunStatus.SUCCESS,
+    )
+    run.nodes["agent_1"] = NodeState(
+        node_id="agent_1",
+        name="agent",
+        node_type="step",
+        status=NodeStatus.SUCCESS,
+        agent_trace_json=json.dumps(envelope),
+    )
+    run.logs.extend(
+        [
+            LogEntry(datetime.now(), LogLevel.INFO, "agent_1", "Agent code.generated"),
+            LogEntry(datetime.now(), LogLevel.INFO, "agent_1", "Agent iteration.recorded"),
+        ]
+    )
+    provider = MockStateProvider()
+    provider._workflows = {"agent_flow": workflow}
+    provider._runs = {run.run_id: run}
+    return provider, envelope
+
+
+@pytest.mark.asyncio
+async def test_agent_trace_inspector_interactions_and_log_retention():
+    from avalanche.tui.app import AvalancheApp
+    from avalanche.tui.widgets.agent_trace import (
+        AgentMetadataInspector,
+        AgentTraceInspector,
+    )
+    from avalanche.tui.widgets.log_panel import LogWidget
+
+    provider, _ = _agent_trace_provider()
+    app = AvalancheApp(provider=provider, workflow="agent_flow", node="agent")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await _wait_for_current_run(app)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.store.trace_inspector_open is True
+        assert app.store.focused_pane == "trace"
+        assert app.store.trace_turn_index == 1
+        assert app.store.trace_collapsed_turns == set()
+        assert app._screen.query_one("#dashboard-pane").display is False
+        assert app._screen.query_one("#agent-trace-inspector").display is True
+
+        content = app._screen.query_one("#agent-trace-content", AgentTraceInspector)
+        rendered = content.render()
+        plain = rendered.plain
+        assert "STRUCTURED TRACE · 2 turn(s)" in plain
+        assert "AGENT TURN 1/5" in plain
+        assert "AGENT TURN 2/5" in plain
+        assert "first reasoning" in plain
+        assert "second reasoning" in plain
+        assert "tool · lookup" in plain
+        assert "predict · text -> answer · sub" in plain
+        assert "Live record: complete · terminal=completed" in plain
+        lines = plain.splitlines()
+        reasoning_label = next(line for line in lines if line.strip() == "reasoning:")
+        reasoning_body = next(line for line in lines if "first reasoning" in line)
+        code_label = next(line for line in lines if line.strip() == "code:")
+        code_body = next(line for line in lines if "print('first')" in line)
+        tool_label = next(line for line in lines if "tool · lookup" in line)
+        assert reasoning_label.startswith("    ")
+        assert reasoning_body.startswith("        ")
+        assert code_label.startswith("    ")
+        assert code_body.startswith("        ")
+        assert tool_label.startswith("    ")
+        code_offset = plain.index("print('second')")
+        assert any(
+            span.start <= code_offset < span.end for span in rendered.spans
+        ), "Python code should carry syntax-highlighting spans"
+
+        await pilot.press("m")
+        await pilot.pause()
+        assert app.store.trace_inspector_tab == "metadata"
+        metadata_content = app._screen.query_one(
+            "#agent-metadata-content", AgentMetadataInspector
+        )
+        metadata_plain = metadata_content.render().plain
+        assert metadata_content.display is True
+        assert content.display is False
+        assert (
+            "Agent agent · Metadata"
+            in app._screen.query_one("#agent-trace-inspector").border_title
+        )
+        for expected in (
+            "InspectRecords",
+            "records: list[Record] — records to inspect",
+            "MODEL / RUNTIME SETTINGS",
+            "audit",
+            "AGGREGATED STATIC INSTRUCTIONS",
+            "pydantic",
+            "audit_helpers",
+            "lookup",
+        ):
+            assert expected in metadata_plain
+        assert "RLM" not in metadata_plain
+
+        turn_index = app.store.trace_turn_index
+        collapsed_turns = set(app.store.trace_collapsed_turns)
+        show_full_output = app.store.trace_show_full_output
+        await pilot.press("up", "enter", "o")
+        assert app.store.trace_turn_index == turn_index
+        assert app.store.trace_collapsed_turns == collapsed_turns
+        assert app.store.trace_show_full_output is show_full_output
+
+        await pilot.press("m")
+        await pilot.pause()
+        assert app.store.trace_inspector_tab == "trace"
+        assert content.display is True
+        assert metadata_content.display is False
+
+        await pilot.press("o")
+        await pilot.pause()
+        assert "output (full):" in content.render().plain
+        assert "FULL-SECOND" in content.render().plain
+
+        await pilot.press("up")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.store.trace_turn_index == 0
+        assert 0 in app.store.trace_collapsed_turns
+        assert "first reasoning" not in content.render().plain
+
+        await pilot.press("down")
+        await pilot.press("enter")
+        assert 1 in app.store.trace_collapsed_turns
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.store.trace_inspector_open is False
+        assert app.store.focused_pane == "dag"
+        assert app._screen.query_one("#dashboard-pane").display is True
+        logs = app._screen.query_one("#log-content", LogWidget).render().plain
+        assert "Agent code.generated" in logs
+        assert "Agent iteration.recorded" in logs
+
+
+@pytest.mark.asyncio
+async def test_agent_trace_inspector_renders_pending_failed_malformed_and_incomplete():
+    from avalanche.tui.app import AvalancheApp
+    from avalanche.tui.widgets.agent_trace import (
+        AgentMetadataInspector,
+        AgentTraceInspector,
+    )
+
+    provider, envelope = _agent_trace_provider()
+    app = AvalancheApp(provider=provider, workflow="agent_flow", node="agent")
+    async with app.run_test(size=(100, 35)) as pilot:
+        await pilot.pause()
+        await _wait_for_current_run(app)
+        await pilot.pause()
+        await pilot.press("enter")
+        content = app._screen.query_one("#agent-trace-content", AgentTraceInspector)
+        node = app.store.current_run.nodes["agent_1"]
+
+        await pilot.press("m")
+        metadata_content = app._screen.query_one(
+            "#agent-metadata-content", AgentMetadataInspector
+        )
+        workflow = app.store.current_workflow
+        workflow.agent_metadata_json["agent_1"] = "{malformed"
+        assert "Metadata unavailable or malformed" in metadata_content.render().plain
+        workflow.agent_metadata_json.pop("agent_1")
+        assert "Metadata unavailable or malformed" in metadata_content.render().plain
+        await pilot.press("m")
+        assert app.store.trace_inspector_tab == "trace"
+
+        node.agent_trace_json = "{malformed"
+        assert "unavailable or malformed" in content.render().plain
+
+        node.status = NodeStatus.RUNNING
+        node.agent_trace_json = None
+        assert "waiting for live updates" in content.render().plain
+
+        live = dict(envelope)
+        live.update({"status": "in_progress", "trace": None, "error": None})
+        node.agent_trace_json = json.dumps(live)
+        live_render = content.render().plain
+        assert "LIVE AGENT STATUS" in live_render
+        assert "LIVE TRACE · 2 turn(s)" in live_render
+        assert "AGENT TURN 1/2 · 0ms · 0 tool · 0 predict · LIVE" in live_render
+        assert "print('first')" in live_render
+        assert "short-second" in live_render
+
+        failed = dict(live)
+        failed.update({"status": "error", "error": "provider failed"})
+        node.agent_trace_json = json.dumps(failed)
+        failed_render = content.render().plain
+        assert "Status: error" in failed_render
+        assert "provider failed" in failed_render
+        assert "LIVE AGENT STATUS" in failed_render
+        assert "Code generated · turn 1" in failed_render
+        assert "Turn completed · turn 2" in failed_render
+        assert "iteration.recorded" not in failed_render
+
+        incomplete = json.loads(json.dumps(envelope))
+        incomplete["trace"]["evidence"]["complete"] = False
+        node.agent_trace_json = json.dumps(incomplete)
+        final_render = content.render().plain
+        assert "Live record: incomplete" in final_render
+        assert "STRUCTURED TRACE · 2 turn(s)" in final_render
+        assert "LIVE TRACE" not in final_render

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -2334,11 +2334,10 @@ class TestInteractions:
             # Shrink sidebar to force clipping
             sidebar.styles.width = 18
             app.store.sidebar_width = 18
-            await pilot.pause()
 
             rendered = sidebar.render()
             lines = rendered.plain.split("\n")
-            content_width = sidebar.content_size.width or 16
+            content_width = app.store.sidebar_width - 2
             for line in lines:
                 assert len(line) <= content_width, (
                     f"Line '{line}' ({len(line)} chars) exceeds "

--- a/test/tui_tmux_test.py
+++ b/test/tui_tmux_test.py
@@ -27,7 +27,9 @@ def tmux(*args: str, input: str | None = None) -> str:
     """Run a tmux command and return stdout."""
     result = subprocess.run(
         ["tmux", *args],
-        capture_output=True, text=True, timeout=10,
+        capture_output=True,
+        text=True,
+        timeout=10,
         input=input,
     )
     return result.stdout
@@ -48,12 +50,12 @@ def send_keys(*keys: str) -> None:
 
 def restart_tui(args: str = "", *, width: int = 100, height: int = 40) -> None:
     """Restart the tmux session with optional TUI CLI args."""
-    subprocess.run(["tmux", "kill-session", "-t", SESSION],
-                   capture_output=True, timeout=5)
+    subprocess.run(["tmux", "kill-session", "-t", SESSION], capture_output=True, timeout=5)
     cmd = f"{TUI_CMD} {args}; sleep 30" if args else f"{TUI_CMD}; sleep 30"
     subprocess.run(
         ["tmux", "new-session", "-d", "-s", SESSION, "-x", str(width), "-y", str(height), cmd],
-        check=True, timeout=10,
+        check=True,
+        timeout=10,
         cwd=os.path.dirname(os.path.dirname(__file__)),
     )
     assert wait_for("avalanche", timeout=8), "TUI did not start"
@@ -109,14 +111,24 @@ def tui_session():
         pytest.skip("tmux not installed")
 
     # Kill any leftover session
-    subprocess.run(["tmux", "kill-session", "-t", SESSION],
-                   capture_output=True, timeout=5)
+    subprocess.run(["tmux", "kill-session", "-t", SESSION], capture_output=True, timeout=5)
 
     # Start new session
     subprocess.run(
-        ["tmux", "new-session", "-d", "-s", SESSION, "-x", "100", "-y", "40",
-         f"{TUI_CMD}; sleep 30"],
-        check=True, timeout=10,
+        [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            SESSION,
+            "-x",
+            "100",
+            "-y",
+            "40",
+            f"{TUI_CMD}; sleep 30",
+        ],
+        check=True,
+        timeout=10,
         cwd=os.path.dirname(os.path.dirname(__file__)),
     )
     # Wait for the TUI to render
@@ -124,8 +136,7 @@ def tui_session():
 
     yield SESSION
 
-    subprocess.run(["tmux", "kill-session", "-t", SESSION],
-                   capture_output=True, timeout=5)
+    subprocess.run(["tmux", "kill-session", "-t", SESSION], capture_output=True, timeout=5)
 
 
 @pytest.mark.tmux
@@ -161,19 +172,29 @@ class TestTmuxRendering:
         # Status bar should show the selected node
         lines = capture()
         status_line = lines[-2] if len(lines) > 1 else ""
-        assert "validate" in status_line, (
-            f"Expected 'validate' in status bar, got: {status_line}"
-        )
+        assert (
+            "validate" in status_line
+        ), f"Expected 'validate' in status bar, got: {status_line}"
 
     def test_deep_link_workflow(self, tui_session):
         """Deep-link CLI arg should select the specified workflow."""
         # Kill current session and start with deep-link
-        subprocess.run(["tmux", "kill-session", "-t", SESSION],
-                       capture_output=True, timeout=5)
+        subprocess.run(["tmux", "kill-session", "-t", SESSION], capture_output=True, timeout=5)
         subprocess.run(
-            ["tmux", "new-session", "-d", "-s", SESSION, "-x", "100", "-y", "40",
-             f"{TUI_CMD} ml_workflow; sleep 30"],
-            check=True, timeout=10,
+            [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                SESSION,
+                "-x",
+                "100",
+                "-y",
+                "40",
+                f"{TUI_CMD} ml_workflow; sleep 30",
+            ],
+            check=True,
+            timeout=10,
             cwd=os.path.dirname(os.path.dirname(__file__)),
         )
         assert wait_for("ml_workflow", timeout=8)
@@ -182,9 +203,9 @@ class TestTmuxRendering:
         lines = capture()
         combined = "\n".join(lines)
         # DAG should show ml_workflow nodes, not order_workflow
-        assert "fetch_training" in combined or "preprocess" in combined, (
-            "Deep-link to ml_workflow should show its DAG"
-        )
+        assert (
+            "fetch_training" in combined or "preprocess" in combined
+        ), "Deep-link to ml_workflow should show its DAG"
 
     def test_deep_link_notify_slack(self, tui_session):
         """Deep-linking notify_slack in ml_workflow should select it."""
@@ -230,3 +251,61 @@ class TestTmuxRendering:
         send_keys("Left")
         time.sleep(0.5)
         assert_node_selected("deploy_staging")
+
+    def test_agent_trace_inspector_real_terminal_contract(self, tui_session):
+        """Structured agent turns remain scrollable and Escape restores the dashboard."""
+        restart_tui("agent_trace/inspect_agent", width=100, height=35)
+        assert wait_for("inspect_agent", timeout=8)
+        open_explorer()
+
+        send_keys("Escape", "Enter")
+        assert wait_for("STRUCTURED TRACE", timeout=5)
+        combined = "\n".join(capture())
+        assert "EXPLORER" in combined
+        assert "STRUCTURED TRACE" in combined
+        assert "AGENT TURN 1/4" in combined
+        assert "reasoning:" in combined
+        assert "code:" in combined
+        assert "inspect_agent" in combined
+
+        send_keys("m")
+        assert wait_for("AGENT METADATA", timeout=5)
+        combined = "\n".join(capture())
+        assert "InspectRecords" in combined
+        assert "records to inspect" in combined
+        assert "MODEL / RUNTIME SETTINGS" in combined
+        assert "audit" in combined
+        assert "RLM" not in combined
+
+        send_keys("PageDown")
+        assert wait_for("AGGREGATED STATIC INSTRUCTIONS", timeout=5)
+        combined = "\n".join(capture())
+        assert "pydantic" in combined
+        assert "record_helpers" in combined
+        assert "lookup_record" in combined
+
+        send_keys("m")
+        assert wait_for("STRUCTURED TRACE", timeout=5)
+
+        send_keys("o")
+        assert wait_for("FULL OUTPUT", timeout=5)
+        combined = "\n".join(capture())
+        assert "active_count" in combined
+        assert "Grace Hopper" in combined
+
+        send_keys("Enter")
+        time.sleep(0.5)
+        combined = "\n".join(capture())
+        assert "AGENT TURN 1/4" in combined
+        send_keys("Enter")
+        assert wait_for("output (full)", timeout=5)
+
+        send_keys("Escape")
+        assert wait_for("Logs", timeout=5)
+        send_keys("w", "PageDown")
+        assert wait_for("Agent code", timeout=5)
+        combined = "\n".join(capture())
+        assert "DAG" in combined
+        assert "Agent code" in combined
+        assert "EXPLORER" in combined
+        assert "inspect_agent" in combined

--- a/test/tui_tmux_test.py
+++ b/test/tui_tmux_test.py
@@ -253,7 +253,7 @@ class TestTmuxRendering:
         assert_node_selected("deploy_staging")
 
     def test_agent_trace_inspector_real_terminal_contract(self, tui_session):
-        """Structured agent turns remain scrollable and Escape restores the dashboard."""
+        """Agent output, trace controls, and metadata render in a real terminal."""
         restart_tui("agent_trace/inspect_agent", width=100, height=35)
         assert wait_for("inspect_agent", timeout=8)
         open_explorer()
@@ -268,7 +268,22 @@ class TestTmuxRendering:
         assert "code:" in combined
         assert "inspect_agent" in combined
 
-        send_keys("m")
+        send_keys("Right")
+        assert wait_for("AGENT OUTPUT", timeout=5)
+        combined = "\n".join(capture())
+        assert "summary" in combined
+        assert "InspectionSummary" in combined
+        assert "active_count" in combined
+        assert "reviewed" in combined
+        assert "SANDBOX_STDOUT_SENTINEL" not in combined
+        assert "Agent inspect_agent · Output" not in combined
+
+        send_keys("Left")
+        assert wait_for("STRUCTURED TRACE", timeout=5)
+        combined = "\n".join(capture())
+        assert "Enter collapse" in combined
+
+        send_keys("Left")
         assert wait_for("AGENT METADATA", timeout=5)
         combined = "\n".join(capture())
         assert "InspectRecords" in combined
@@ -284,7 +299,7 @@ class TestTmuxRendering:
         assert "record_helpers" in combined
         assert "lookup_record" in combined
 
-        send_keys("m")
+        send_keys("Right")
         assert wait_for("STRUCTURED TRACE", timeout=5)
 
         send_keys("o")

--- a/uv.lock
+++ b/uv.lock
@@ -280,8 +280,8 @@ requires-dist = [
     { name = "grpcio", marker = "extra == 'tui'", specifier = ">=1.75.1" },
     { name = "grpcio-tools", marker = "extra == 'all'", specifier = ">=1.75.1" },
     { name = "grpcio-tools", marker = "extra == 'runtime'", specifier = ">=1.75.1" },
-    { name = "predict-rlm", marker = "extra == 'agent'", specifier = ">=0.7.1" },
-    { name = "predict-rlm", marker = "extra == 'all'", specifier = ">=0.7.1" },
+    { name = "predict-rlm", marker = "extra == 'agent'", editable = "../predict-rlm" },
+    { name = "predict-rlm", marker = "extra == 'all'", editable = "../predict-rlm" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pyiceberg", extras = ["glue", "pandas", "pyarrow", "s3fs", "sql-sqlite"], specifier = ">=0.9,<0.11" },
     { name = "pylance", marker = "extra == 'all'", specifier = ">=0.24.0" },
@@ -304,7 +304,7 @@ dev = [
     { name = "grpcio", specifier = ">=1.75.1" },
     { name = "grpcio-tools", specifier = ">=1.75.1" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5,<6" },
-    { name = "predict-rlm", specifier = ">=0.7.1" },
+    { name = "predict-rlm", editable = "../predict-rlm" },
     { name = "pylance", specifier = ">=0.24.0" },
     { name = "pytest", specifier = ">=8.3.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.8,<0.24" },
@@ -2104,8 +2104,8 @@ wheels = [
 
 [[package]]
 name = "predict-rlm"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
+version = "0.8.0a0"
+source = { editable = "../predict-rlm" }
 dependencies = [
     { name = "deno" },
     { name = "dspy" },
@@ -2114,9 +2114,37 @@ dependencies = [
     { name = "pygments" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/a7/90a21a2f60592cf97bda51f2e235efdb6c60a2a8207157b6a9186180661c/predict_rlm-0.7.2.tar.gz", hash = "sha256:f509973f663e169ffbeae19e33dbd64fbc11457c851394c955039c51fad2c7c5", size = 253176, upload-time = "2026-07-09T17:18:47.876Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/20/304196374df34935d6b04af3e01370fd834bf18992bdc5079842c89a1c97/predict_rlm-0.7.2-py3-none-any.whl", hash = "sha256:439d2c08cd254dcde9cbaecf1af0cad657ac467123bae22931e8cd5ca0152205", size = 282476, upload-time = "2026-07-09T17:18:46.343Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "deno", specifier = ">=2" },
+    { name = "dspy", specifier = ">=3.2.1" },
+    { name = "formulas", marker = "extra == 'examples'", specifier = ">=1.2.0" },
+    { name = "gepa", marker = "extra == 'gepa'", specifier = ">=0.0.26" },
+    { name = "kaleido", marker = "extra == 'gepa-viz'", specifier = ">=0.2.0" },
+    { name = "litellm", marker = "extra == 'codex-lm'", specifier = ">=1.89.2" },
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "openai", marker = "extra == 'codex-lm'", specifier = ">=1.60" },
+    { name = "openpyxl", marker = "extra == 'examples'", specifier = ">=3.1.0" },
+    { name = "plotly", marker = "extra == 'gepa-viz'", specifier = ">=5.0.0" },
+    { name = "pydantic", specifier = ">=2.8.2,<3" },
+    { name = "pygments", specifier = ">=2.0.0" },
+    { name = "pymupdf", marker = "extra == 'examples'", specifier = ">=1.24.0" },
+    { name = "tenacity", specifier = ">=8.2.0" },
+    { name = "tenacity", marker = "extra == 'codex-lm'", specifier = ">=9.1.4" },
+    { name = "tqdm", marker = "extra == 'gepa'", specifier = ">=4.0.0" },
+    { name = "websockets", marker = "extra == 'sbx'", specifier = ">=15.0,<16" },
+]
+provides-extras = ["sbx", "gepa", "codex-lm", "gepa-viz", "examples"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipykernel", specifier = ">=6.29.0" },
+    { name = "pytest", specifier = ">=8.3.1,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.23.8,<0.24" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-testdox", specifier = ">=3.1.0,<4" },
+    { name = "ruff", specifier = ">=0.11.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Rationale

Avalanche can execute bodyful `@ava.agent_step` nodes, but the agent-specific information needed to understand those runs was not available end to end:

- PredictRLM evidence was produced inside the worker but did not cross the local/Ray execution boundary into operator state.
- Workflow discovery exposed ordinary DAG nodes, but not which nodes were agents or the resolved signature, skills, tools, instructions, and effective runtime configuration needed to inspect them before execution.
- After completion, the TUI had no authoritative view of the agent's final structured DSPy prediction. Sandbox stdout, the last turn's output, tool results, and the surrounding Python step's return value are all different data and cannot safely substitute for it.

The result was an opaque debugging experience: an agent could be running or completed while the operator exposed only ordinary node status and logs, finalized traces were lost, and a step that had not started could look like a malformed trace.

This PR adds the missing observability path from agent declaration and PredictRLM execution through worker transport, operator state, gRPC, and the TUI inspector. It preserves the bodyful-agent contract: the step still owns validation, composition, persistence, and its Python return value.

## What this PR changes

### Agent declaration metadata

- Serializes agent metadata during workflow discovery without constructing a predictor or making a model call.
- Captures the resolved signature name and instructions, ordered input/output fields, skills, packages, modules, tools, aggregated static instructions, and effective runtime settings.
- Removes secret-like keys and non-display runtime values such as callbacks, event sinks, output directories, and opaque objects before metadata leaves the defining process.
- Publishes agent node IDs and per-node metadata through `WorkflowDescriptor`, `WorkflowInfo`, and additive gRPC fields.

### Live and finalized evidence transport

- Adds a context-local, best-effort evidence bridge around agent execution.
- Projects PredictRLM events into transport-safe Avalanche evidence while preserving ordering and terminal outcome.
- Forwards evidence from both local and Ray workers through the coordinator protocol.
- Validates that evidence belongs to a published agent node, incrementally updates the run, and stores the finalized exportable trace envelope in `NodeState.agent_trace_json`.
- Keeps observability best effort: a display/transport failure does not replace the user step's actual result or error.

### RLM inspector

- Adds an inspector for agent nodes inside the existing workflow detail pane rather than introducing another global pane.
- Provides three tabs in a fixed order: **Trace · Output · Metadata**.
- Uses `←` / `→` to cycle tabs without moving to adjacent workflow nodes. Opening and closing the inspector resets to Trace.
- Preserves selected turn, collapsed turns, and full-sandbox-output state while moving between tabs.
- Keeps turn selection, collapse, and lowercase `o` full-output controls scoped to Trace; Output and Metadata remain scroll-only.
- Distinguishes pending, running, failed, malformed, and legacy states. A node absent from the current run is treated consistently with the DAG as not yet started rather than malformed.

### Authoritative structured output

The Output tab intentionally reads only the last mapping-valued `run.succeeded.data.outputs` event from `trace.evidence.events`.

- Fields render in declared signature order with their annotation and description.
- Nested objects, lists, empty values, `false`, `0`, and `null` are preserved.
- Declared-but-missing fields render as `Unavailable`.
- If declaration metadata is unavailable, transported output keys render in their existing order without inventing types.
- In-progress, failed, cancelled, malformed, and legacy traces do not fabricate output from workflow inputs, sandbox stdout, `steps[-1].output`, tool/predict subcalls, or the bodyful step's later Python return value.

## Protocol and compatibility

- Adds optional `agent_node_ids` and `agent_metadata_json` fields to workflow discovery messages.
- Adds optional `agent_trace_json` to node state messages.
- Existing providers and older serialized messages retain empty/`None` defaults.
- Runs without finalized agent evidence continue to work; the inspector reports the specific unavailable or pending state instead of deriving a misleading value.

## Verification

- `uv run pytest -q test/agent/agent_step_test.py test/operator_tests/test_grpc.py test/operator_tests/test_operator.py test/operator_tests/test_registry.py` — **121 passed**
- `uv run pytest -q test/tui_test.py test/tui_tmux_test.py` — **156 passed**
- `uv run ruff check src/tui/app.py src/tui/screens/workflow_detail.py test/operator_tests/test_grpc.py test/tui_test.py` — **passed**
