### PR TITLE
feat(tui): add provider integration hooks

### DIFF
--- a/src/avalanche/_agent_evidence.py
+++ b/src/avalanche/_agent_evidence.py
@@ -1,34 +1,95 @@
-"""Context-local bridge for best-effort agent evidence observation."""
+"""Context-local bridge for agent evidence observation."""
 
 from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, Literal, TypeAlias, TypedDict
 
-_AGENT_EVIDENCE_LISTENER: ContextVar[Callable[[dict[str, Any]], None] | None] = ContextVar(
-    "avalanche_agent_evidence_listener", default=None
+AgentInvocationId: TypeAlias = str
+
+
+class AgentEvidenceEvent(TypedDict):
+    """Incremental, sanitized evidence emitted during an agent run."""
+
+    kind: Literal["evidence"]
+    invocation_id: AgentInvocationId
+    sequence: int
+    event_kind: str
+    timestamp_ns: int
+    data: dict[str, Any]
+
+
+class AgentTraceFinishedEvent(TypedDict):
+    """Terminal exported trace for a completed, failed, or cancelled agent call."""
+
+    kind: Literal["trace_finished"]
+    invocation_id: AgentInvocationId
+    trace: dict[str, Any]
+
+
+class AgentTraceUnavailableEvent(TypedDict):
+    """Terminal notification emitted when no exportable trace is available."""
+
+    kind: Literal["trace_unavailable"]
+    invocation_id: AgentInvocationId
+    error: str
+
+
+AgentEvidenceObserverEvent: TypeAlias = (
+    AgentEvidenceEvent | AgentTraceFinishedEvent | AgentTraceUnavailableEvent
+)
+AgentEvidenceListener: TypeAlias = Callable[[AgentEvidenceObserverEvent], None]
+ListenerErrorPolicy: TypeAlias = Literal["raise", "ignore"]
+_Observer: TypeAlias = tuple[AgentEvidenceListener, ListenerErrorPolicy]
+
+_AGENT_EVIDENCE_OBSERVER: ContextVar[_Observer | None] = ContextVar(
+    "avalanche_agent_evidence_observer", default=None
 )
 
 
 @contextmanager
 def capture_agent_evidence(
-    listener: Callable[[dict[str, Any]], None],
+    listener: AgentEvidenceListener,
+    *,
+    errors: ListenerErrorPolicy = "ignore",
 ) -> Iterator[None]:
-    """Capture evidence emitted by agent calls in the current context."""
-    token = _AGENT_EVIDENCE_LISTENER.set(listener)
+    """Observe agent evidence in this context, restoring any outer observer.
+
+    ``errors="ignore"`` preserves standalone agent execution if a listener
+    fails. ``errors="raise"`` propagates listener failures to the emitter.
+    """
+    if errors not in {"raise", "ignore"}:
+        raise ValueError("errors must be 'raise' or 'ignore'")
+    token = _AGENT_EVIDENCE_OBSERVER.set((listener, errors))
     try:
         yield
     finally:
-        _AGENT_EVIDENCE_LISTENER.reset(token)
+        _AGENT_EVIDENCE_OBSERVER.reset(token)
 
 
-def emit_agent_evidence(event: dict[str, Any]) -> None:
-    """Notify the current observer without affecting agent execution."""
-    listener = _AGENT_EVIDENCE_LISTENER.get()
-    if listener is None:
+def emit_agent_evidence(event: AgentEvidenceObserverEvent) -> None:
+    """Notify the current observer according to its explicit error policy."""
+    observer = _AGENT_EVIDENCE_OBSERVER.get()
+    if observer is None:
+        return
+    listener, errors = observer
+    if errors == "raise":
+        listener(event)
         return
     try:
         listener(event)
-    except BaseException:
+    except Exception:
         pass
+
+
+__all__ = [
+    "AgentEvidenceEvent",
+    "AgentEvidenceListener",
+    "AgentEvidenceObserverEvent",
+    "AgentInvocationId",
+    "AgentTraceFinishedEvent",
+    "AgentTraceUnavailableEvent",
+    "ListenerErrorPolicy",
+    "capture_agent_evidence",
+]

--- a/src/avalanche/agent/__init__.py
+++ b/src/avalanche/agent/__init__.py
@@ -3,18 +3,36 @@
 from __future__ import annotations
 
 from .agent_step import Agent, AgentStepError, AgentStepExecutionError, agent_step, step
+from .evidence import (
+    AgentEvidenceEvent,
+    AgentEvidenceListener,
+    AgentEvidenceObserverEvent,
+    AgentInvocationId,
+    AgentTraceFinishedEvent,
+    AgentTraceUnavailableEvent,
+    ListenerErrorPolicy,
+    capture_agent_evidence,
+)
 from .signature import InputField, OutputField, Signature
 
 __all__ = [
     "Agent",
+    "AgentEvidenceEvent",
+    "AgentEvidenceListener",
+    "AgentEvidenceObserverEvent",
+    "AgentInvocationId",
     "AgentStepError",
     "AgentStepExecutionError",
+    "AgentTraceFinishedEvent",
+    "AgentTraceUnavailableEvent",
     "File",
     "InputField",
+    "ListenerErrorPolicy",
     "OutputField",
     "Signature",
     "Skill",
     "agent_step",
+    "capture_agent_evidence",
     "skills",
     "step",
 ]

--- a/src/avalanche/agent/agent_step.py
+++ b/src/avalanche/agent/agent_step.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import math
 import types
+import uuid
 from contextvars import ContextVar
 from enum import Enum
 from functools import update_wrapper
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence, Union, get_args, get_origin
 
-from .._agent_evidence import emit_agent_evidence
+from .._agent_evidence import AgentInvocationId, emit_agent_evidence
 from ..dag import Node, NodeType
 from .config import UNSET, validate_runtime_kwargs
 from .signature import resolve_signature
@@ -31,23 +33,70 @@ _WORKFLOW_AGENT_DEFAULTS: ContextVar[Mapping[str, Any]] = ContextVar(
 )
 
 
-class _AvalancheEvidenceSink:
-    """Best-effort projection of agent evidence into Avalanche."""
+class _AgentInvocationState:
+    """Task-local evidence state for one agent invocation."""
 
-    strict = False
+    def __init__(self, invocation_id: AgentInvocationId) -> None:
+        self.invocation_id = invocation_id
+        self.listener_base_exception: BaseException | None = None
+
+
+_AGENT_INVOCATION_STATE: ContextVar[_AgentInvocationState | None] = ContextVar(
+    "avalanche_agent_invocation_state", default=None
+)
+
+
+class _AvalancheEvidenceSink:
+    """Project PredictRLM evidence under the bridge's explicit error policy."""
+
+    strict = True
 
     async def emit(self, event: Any) -> None:
-        emit_agent_evidence(_project_evidence_event(event))
+        state = _current_invocation_state()
+        projected = _project_evidence_event(
+            event,
+            invocation_id=state.invocation_id,
+        )
+        _emit_sink_evidence(projected, state=state)
 
     async def flush(self, run_id: str) -> None:
         return None
 
     async def close(self, run_id: str, terminal_event: Any | None = None) -> None:
         if terminal_event is not None:
-            emit_agent_evidence(_project_evidence_event(terminal_event))
+            state = _current_invocation_state()
+            projected = _project_evidence_event(
+                terminal_event,
+                invocation_id=state.invocation_id,
+            )
+            _emit_sink_evidence(projected, state=state)
 
 
-def _project_evidence_event(event: Any) -> dict[str, Any]:
+def _current_invocation_state() -> _AgentInvocationState:
+    state = _AGENT_INVOCATION_STATE.get()
+    if state is None:
+        raise RuntimeError("agent evidence emitted outside an agent invocation")
+    return state
+
+
+def _emit_sink_evidence(
+    event: dict[str, Any],
+    *,
+    state: _AgentInvocationState,
+) -> None:
+    try:
+        emit_agent_evidence(event)
+    except BaseException as exc:
+        if not isinstance(exc, Exception) and state.listener_base_exception is None:
+            state.listener_base_exception = exc
+        raise
+
+
+def _project_evidence_event(
+    event: Any,
+    *,
+    invocation_id: AgentInvocationId,
+) -> dict[str, Any]:
     kind_value = getattr(getattr(event, "kind", None), "value", None)
     event_kind = kind_value if isinstance(kind_value, str) else str(getattr(event, "kind", ""))
     raw_data = getattr(event, "data", {})
@@ -104,6 +153,7 @@ def _project_evidence_event(event: Any) -> dict[str, Any]:
 
     return {
         "kind": "evidence",
+        "invocation_id": invocation_id,
         "sequence": int(getattr(event, "sequence", 0)),
         "event_kind": event_kind,
         "timestamp_ns": int(getattr(event, "timestamp_ns", 0)),
@@ -111,21 +161,41 @@ def _project_evidence_event(event: Any) -> dict[str, Any]:
     }
 
 
-def _emit_terminal_trace(trace: Any) -> bool:
+def _emit_terminal_trace(
+    trace: Any,
+    *,
+    invocation_id: AgentInvocationId,
+) -> bool:
     try:
         exported = trace.to_exportable_json()
         parsed = json.loads(exported)
         if not isinstance(parsed, dict):
             raise TypeError("exported trace is not a JSON object")
-    except BaseException as exc:
-        _emit_trace_unavailable(exc)
+    except Exception as exc:
+        _emit_trace_unavailable(exc, invocation_id=invocation_id)
         return False
-    emit_agent_evidence({"kind": "trace_finished", "trace": parsed})
+    emit_agent_evidence(
+        {
+            "kind": "trace_finished",
+            "invocation_id": invocation_id,
+            "trace": parsed,
+        }
+    )
     return True
 
 
-def _emit_trace_unavailable(error: Any) -> None:
-    emit_agent_evidence({"kind": "trace_unavailable", "error": str(error)})
+def _emit_trace_unavailable(
+    error: Any,
+    *,
+    invocation_id: AgentInvocationId,
+) -> None:
+    emit_agent_evidence(
+        {
+            "kind": "trace_unavailable",
+            "invocation_id": invocation_id,
+            "error": str(error),
+        }
+    )
 
 
 class Agent:
@@ -163,26 +233,50 @@ class Agent:
                 **self._runtime_kwargs,
             )
 
+        state = _AgentInvocationState(uuid.uuid4().hex)
+        invocation_token = _AGENT_INVOCATION_STATE.set(state)
         try:
-            prediction = await self._predictor.acall(**inputs)
+            try:
+                prediction = await self._predictor.acall(**inputs)
+            except asyncio.CancelledError as exc:
+                trace = getattr(exc, "trace", None)
+                try:
+                    if trace is None:
+                        _emit_trace_unavailable(exc, invocation_id=state.invocation_id)
+                    else:
+                        _emit_terminal_trace(trace, invocation_id=state.invocation_id)
+                except Exception as evidence_error:
+                    try:
+                        setattr(exc, "evidence_error", evidence_error)
+                    except Exception:
+                        pass
+                raise
+            except Exception as exc:
+                if state.listener_base_exception is not None:
+                    raise state.listener_base_exception
+                trace = getattr(exc, "trace", None)
+                if trace is None:
+                    _emit_trace_unavailable(exc, invocation_id=state.invocation_id)
+                else:
+                    _emit_terminal_trace(trace, invocation_id=state.invocation_id)
+                input_types = {name: type(value).__name__ for name, value in inputs.items()}
+                raise AgentStepExecutionError(
+                    f"agent step {self._step_name!r} failed calling "
+                    f"{_describe_signature(dspy_signature)}: {exc}. "
+                    f"input types: {input_types}."
+                ) from exc
+
             trace = getattr(prediction, "trace", None)
             if trace is None:
-                _emit_trace_unavailable("Agent trace unavailable")
+                _emit_trace_unavailable(
+                    "Agent trace unavailable",
+                    invocation_id=state.invocation_id,
+                )
             else:
-                _emit_terminal_trace(trace)
+                _emit_terminal_trace(trace, invocation_id=state.invocation_id)
             return prediction
-        except Exception as exc:
-            trace = getattr(exc, "trace", None)
-            if trace is None:
-                _emit_trace_unavailable(exc)
-            else:
-                _emit_terminal_trace(trace)
-            input_types = {name: type(value).__name__ for name, value in inputs.items()}
-            raise AgentStepExecutionError(
-                f"agent step {self._step_name!r} failed calling "
-                f"{_describe_signature(dspy_signature)}: {exc}. "
-                f"input types: {input_types}."
-            ) from exc
+        finally:
+            _AGENT_INVOCATION_STATE.reset(invocation_token)
 
     def _resolve_signature(self) -> Any:
         if self._dspy_signature is None:

--- a/src/avalanche/agent/evidence.py
+++ b/src/avalanche/agent/evidence.py
@@ -1,0 +1,25 @@
+"""Public agent evidence observer contracts."""
+
+from __future__ import annotations
+
+from .._agent_evidence import (
+    AgentEvidenceEvent,
+    AgentEvidenceListener,
+    AgentEvidenceObserverEvent,
+    AgentInvocationId,
+    AgentTraceFinishedEvent,
+    AgentTraceUnavailableEvent,
+    ListenerErrorPolicy,
+    capture_agent_evidence,
+)
+
+__all__ = [
+    "AgentEvidenceEvent",
+    "AgentEvidenceListener",
+    "AgentEvidenceObserverEvent",
+    "AgentInvocationId",
+    "AgentTraceFinishedEvent",
+    "AgentTraceUnavailableEvent",
+    "ListenerErrorPolicy",
+    "capture_agent_evidence",
+]

--- a/src/runtime/operator/client.py
+++ b/src/runtime/operator/client.py
@@ -97,6 +97,11 @@ class GrpcStateProvider:
         self.last_error: str = ""
         self.discovery_diagnostics: list[WorkflowDiscoveryDiagnostic] = []
 
+    @property
+    def connection_label(self) -> str:
+        """Human-readable remote endpoint for connection status displays."""
+        return self._address
+
     def _call(self, fn, *args, default=None, **kwargs):
         """Wrap a gRPC call with connection state tracking."""
         kwargs.setdefault("timeout", self._unary_timeout)

--- a/src/runtime/operator/operator.py
+++ b/src/runtime/operator/operator.py
@@ -866,6 +866,7 @@ class Operator:
                 else {
                     "schema_version": 1,
                     "status": "in_progress",
+                    "invocation_id": None,
                     "run_id": None,
                     "events": [],
                     "trace": None,
@@ -879,6 +880,9 @@ class Operator:
                 return None
 
             kind = event.get("kind")
+            invocation_id = event.get("invocation_id")
+            if not isinstance(invocation_id, str) or not invocation_id:
+                return None
             level = LogLevel.INFO
             if kind == "evidence":
                 sequence = event.get("sequence")
@@ -893,11 +897,19 @@ class Operator:
                     or not isinstance(data, dict)
                 ):
                     return None
-                last_sequence = events[-1].get("sequence", 0) if events else 0
+                last_sequence = max(
+                    (
+                        item.get("sequence", 0)
+                        for item in events
+                        if isinstance(item, dict) and item.get("invocation_id") == invocation_id
+                    ),
+                    default=0,
+                )
                 if sequence <= last_sequence:
                     return None
                 events.append(
                     {
+                        "invocation_id": invocation_id,
                         "sequence": sequence,
                         "event_kind": event_kind,
                         "timestamp_ns": timestamp_ns,
@@ -922,18 +934,32 @@ class Operator:
                 trace = event.get("trace")
                 if not isinstance(trace, dict):
                     return None
-                envelope["trace"] = trace
-                envelope["status"] = str(trace.get("status") or "unavailable")
+                status = str(trace.get("status") or "unavailable")
                 evidence = trace.get("evidence")
-                if isinstance(evidence, dict):
-                    envelope["run_id"] = evidence.get("run_id")
-                message = f"Agent trace {envelope['status']}"
-                if envelope["status"] == "error":
+                run_id = evidence.get("run_id") if isinstance(evidence, dict) else None
+                envelope.update(
+                    {
+                        "invocation_id": invocation_id,
+                        "trace": trace,
+                        "status": status,
+                        "run_id": run_id,
+                        "error": None,
+                    }
+                )
+                message = f"Agent trace {status}"
+                if status == "error":
                     level = LogLevel.ERROR
             elif kind == "trace_unavailable":
                 error = event.get("error")
-                envelope["status"] = "unavailable"
-                envelope["error"] = str(error or "Agent trace unavailable")
+                envelope.update(
+                    {
+                        "invocation_id": invocation_id,
+                        "status": "unavailable",
+                        "error": str(error or "Agent trace unavailable"),
+                        "trace": None,
+                        "run_id": None,
+                    }
+                )
                 message = f"Agent trace unavailable: {envelope['error']}"
                 level = LogLevel.WARN
             else:

--- a/src/runtime/operator/run_worker.py
+++ b/src/runtime/operator/run_worker.py
@@ -28,6 +28,16 @@ from .result_store import (
 from .results import encode_workflow_result
 
 
+def _import_isolated_ray() -> Any:
+    """Import Ray without inheriting the caller's ``uv run`` project."""
+    # The operator supplies a workflow-specific working_dir and owns the whole
+    # coordinator process group. Ray's automatic uv hook would instead launch
+    # workers through the caller's project environment, adding uv subprocesses
+    # that can outlive Ray shutdown and prevent verified success quiescence.
+    os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "0"
+    return importlib.import_module("ray")
+
+
 def run_worker(
     import_root: str,
     workflow_relative_module_file: str,
@@ -148,7 +158,7 @@ def _run_worker(
             def wrap_fn(node_id: str, fn: Callable[..., Any]) -> Callable[..., Any]:
                 return _with_local_node_observers(node_id, fn, stdout, stderr, event_queue)
         elif executor_mode == "ray":
-            import ray
+            ray = _import_isolated_ray()
 
             if ray.is_initialized():
                 raise RuntimeError(

--- a/src/tui/__init__.py
+++ b/src/tui/__init__.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+from .state import ConnectionAwareStateProvider, StateProvider
 
-def launch_tui(argv: list[str] | None = None) -> None:
+
+def launch_tui(
+    argv: list[str] | None = None,
+    *,
+    provider: StateProvider | None = None,
+) -> None:
     """Launch the Avalanche TUI.
 
     Usage: python -m avalanche.tui [--connect HOST:PORT] [flow[/node]]
@@ -11,6 +17,9 @@ def launch_tui(argv: list[str] | None = None) -> None:
         python -m avalanche.tui                          # mock mode
         python -m avalanche.tui --connect localhost:7433  # real operator
         python -m avalanche.tui ml_workflow
+
+    An injected ``provider`` is caller-owned and is not closed by this function.
+    It cannot be combined with ``--connect``.
     """
     import os
     import sys
@@ -28,6 +37,12 @@ def launch_tui(argv: list[str] | None = None) -> None:
         raise
 
     args = list(argv) if argv is not None else sys.argv[1:]
+    connect_options = [
+        arg for arg in args if arg == "--connect" or arg.startswith("--connect=")
+    ]
+    if provider is not None and connect_options:
+        raise ValueError("an injected provider cannot be combined with --connect")
+
     connect = None
     token = os.environ.get("AVALANCHE_TUI_GRPC_TOKEN") or None
     tls = os.environ.get("AVALANCHE_TUI_GRPC_TLS", "").lower() in {"1", "true", "yes"}
@@ -36,34 +51,44 @@ def launch_tui(argv: list[str] | None = None) -> None:
     node = None
 
     # Parse --connect flag
-    if "--connect" in args:
+    equals_connect = next(
+        (arg for arg in args if arg.startswith("--connect=")),
+        None,
+    )
+    if equals_connect is not None:
+        connect = equals_connect.partition("=")[2]
+        if not connect:
+            raise ValueError("--connect requires HOST:PORT")
+        args.remove(equals_connect)
+    elif "--connect" in args:
         idx = args.index("--connect")
-        if idx + 1 < len(args):
-            connect = args[idx + 1]
-            args = args[:idx] + args[idx + 2:]
+        if idx + 1 >= len(args) or args[idx + 1].startswith("--"):
+            raise ValueError("--connect requires HOST:PORT")
+        connect = args[idx + 1]
+        args = args[:idx] + args[idx + 2 :]
 
     if "--token" in args:
         idx = args.index("--token")
         if idx + 1 < len(args):
             token = args[idx + 1]
-            args = args[:idx] + args[idx + 2:]
+            args = args[:idx] + args[idx + 2 :]
 
     if "--tls" in args:
         idx = args.index("--tls")
         tls = True
-        args = args[:idx] + args[idx + 1:]
+        args = args[:idx] + args[idx + 1 :]
 
     if "--insecure" in args:
         idx = args.index("--insecure")
         tls = False
-        args = args[:idx] + args[idx + 1:]
+        args = args[:idx] + args[idx + 1 :]
 
     if "--tls-ca-cert" in args:
         idx = args.index("--tls-ca-cert")
         if idx + 1 < len(args):
             tls_ca_cert = args[idx + 1]
             tls = True
-            args = args[:idx] + args[idx + 2:]
+            args = args[:idx] + args[idx + 2 :]
 
     # Remaining positional arg is flow[/node]
     if args:
@@ -74,9 +99,9 @@ def launch_tui(argv: list[str] | None = None) -> None:
             flow = arg
 
     # Build provider
-    provider = None
     if connect:
         from avalanche.operator.client import GrpcStateProvider
+
         provider_kwargs = {}
         if token is not None:
             provider_kwargs["token"] = token
@@ -88,3 +113,6 @@ def launch_tui(argv: list[str] | None = None) -> None:
 
     app = AvalancheApp(provider=provider, workflow=flow, node=node)
     app.run()
+
+
+__all__ = ["ConnectionAwareStateProvider", "StateProvider", "launch_tui"]

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -11,7 +11,7 @@ from .dag_layout import DagNode
 from .mock import MockStateProvider
 from .models import RunState, WorkflowInfo
 from .screens.workflow_detail import WorkflowDetailScreen
-from .state import StateProvider
+from .state import ConnectionAwareStateProvider, StateProvider
 from .theme import AVALANCHE_THEME
 from .ui_store import UIStore
 from .widgets.agent_trace import (
@@ -377,7 +377,7 @@ class AvalancheApp(App):
     def _check_connection(self) -> None:
         """Show/hide disconnect overlay based on provider connection state."""
         provider = self.store.provider
-        if not hasattr(provider, "ping"):
+        if not isinstance(provider, ConnectionAwareStateProvider):
             return  # MockStateProvider — no connection tracking
 
         # Ping every ~2s (30 ticks at 15fps), non-blocking
@@ -388,8 +388,10 @@ class AvalancheApp(App):
             self._ping_in_flight = True
 
             def _do_ping():
-                provider.ping()
-                self._ping_in_flight = False
+                try:
+                    provider.ping()
+                finally:
+                    self._ping_in_flight = False
 
             threading.Thread(target=_do_ping, daemon=True).start()
 
@@ -412,8 +414,10 @@ class AvalancheApp(App):
 
             msg = Text()
             msg.append("CONNECTION LOST\n\n", Style(color="#f06080", bold=True))
-            msg.append(f"{provider._address}\n", Style(color="#e0f8ff"))
+            msg.append(f"{provider.connection_label}\n", Style(color="#e0f8ff"))
             msg.append("is not reachable.\n\n", Style(color="#7ab0c8"))
+            if provider.last_error:
+                msg.append(f"{provider.last_error}\n\n", Style(color="#f0a080"))
             msg.append(f"Reconnecting{dots:<3}", Style(color="#7ab0c8"))
             box.update(msg)
             wrapper.add_class("visible")

--- a/src/tui/state.py
+++ b/src/tui/state.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol
+from typing import Any, Callable, Protocol, runtime_checkable
 
 from .models import LogEntry, RunState, WorkflowInfo
 
 
 class StateProvider(Protocol):
+    """State and action contract consumed by the Avalanche TUI."""
+
     def list_workflows(self) -> list[WorkflowInfo]: ...
 
     def list_runs(self, workflow_selector: str) -> list[RunState]: ...
@@ -23,3 +25,22 @@ class StateProvider(Protocol):
     def on_run_update(self, callback: Callable[[RunState], None]) -> None: ...
 
     def on_log(self, callback: Callable[[LogEntry], None]) -> None: ...
+
+
+@runtime_checkable
+class ConnectionAwareStateProvider(StateProvider, Protocol):
+    """Optional connection state exposed by remote providers."""
+
+    @property
+    def connected(self) -> bool: ...
+
+    @property
+    def connection_label(self) -> str: ...
+
+    @property
+    def last_error(self) -> str: ...
+
+    def ping(self) -> bool: ...
+
+
+__all__ = ["ConnectionAwareStateProvider", "StateProvider"]

--- a/src/tui/widgets/status_bar.py
+++ b/src/tui/widgets/status_bar.py
@@ -85,10 +85,10 @@ class StatusBar(Static):
             if icon:
                 text.append(f" {icon}", _STATUS_STYLES.get(run.status, Style()))
 
-            node = store.selected_node
-            if node:
-                text.append(_SEP, _SEP_STYLE)
-                text.append(node.display_name, Style(color=ICE_FROST, bold=True))
+        node = store.selected_node
+        if node:
+            text.append(_SEP, _SEP_STYLE)
+            text.append(node.display_name, Style(color=ICE_FROST, bold=True))
 
         # Residual search info
         if store.search_query and not store.searching:

--- a/test/agent/agent_step_test.py
+++ b/test/agent/agent_step_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
 from types import SimpleNamespace
@@ -11,11 +12,152 @@ import pytest
 from pydantic import BaseModel
 
 import avalanche as ava
-from avalanche._agent_evidence import capture_agent_evidence
-from avalanche.agent import AgentStepError, AgentStepExecutionError
+from avalanche._agent_evidence import emit_agent_evidence
+from avalanche.agent import (
+    AgentStepError,
+    AgentStepExecutionError,
+    capture_agent_evidence,
+)
 from avalanche.executor import LocalExecutor
 
 agent_step_module = importlib.import_module("avalanche.agent.agent_step")
+
+
+def test_agent_evidence_contracts_are_public_and_typed():
+    from avalanche.agent import (
+        AgentEvidenceEvent,
+        AgentEvidenceListener,
+        AgentEvidenceObserverEvent,
+        AgentInvocationId,
+        AgentTraceFinishedEvent,
+        AgentTraceUnavailableEvent,
+        ListenerErrorPolicy,
+    )
+    from avalanche.agent.evidence import capture_agent_evidence as module_capture
+
+    assert module_capture is capture_agent_evidence
+    assert AgentEvidenceEvent.__required_keys__ == {
+        "kind",
+        "invocation_id",
+        "sequence",
+        "event_kind",
+        "timestamp_ns",
+        "data",
+    }
+    assert AgentTraceFinishedEvent.__required_keys__ == {
+        "kind",
+        "invocation_id",
+        "trace",
+    }
+    assert AgentTraceUnavailableEvent.__required_keys__ == {
+        "kind",
+        "invocation_id",
+        "error",
+    }
+    assert AgentEvidenceListener is not None
+    assert AgentEvidenceObserverEvent is not None
+    assert AgentInvocationId is str
+    assert ListenerErrorPolicy is not None
+
+
+def test_agent_evidence_observer_nesting_and_error_policy():
+    outer = []
+    inner = []
+
+    with capture_agent_evidence(outer.append):
+        emit_agent_evidence(
+            {
+                "kind": "trace_unavailable",
+                "invocation_id": "outer-before",
+                "error": "before",
+            }
+        )
+        with capture_agent_evidence(inner.append):
+            emit_agent_evidence(
+                {
+                    "kind": "trace_unavailable",
+                    "invocation_id": "inner",
+                    "error": "inside",
+                }
+            )
+        emit_agent_evidence(
+            {
+                "kind": "trace_unavailable",
+                "invocation_id": "outer-after",
+                "error": "after",
+            }
+        )
+
+    assert [event["error"] for event in outer] == ["before", "after"]
+    assert [event["error"] for event in inner] == ["inside"]
+
+    def broken_listener(_event):
+        raise RuntimeError("persistence failed")
+
+    with capture_agent_evidence(broken_listener, errors="ignore"):
+        emit_agent_evidence(
+            {
+                "kind": "trace_unavailable",
+                "invocation_id": "ignored",
+                "error": "ignored",
+            }
+        )
+
+    with capture_agent_evidence(broken_listener, errors="raise"):
+        with pytest.raises(RuntimeError, match="persistence failed"):
+            emit_agent_evidence(
+                {
+                    "kind": "trace_unavailable",
+                    "invocation_id": "raised",
+                    "error": "raised",
+                }
+            )
+
+    def interrupted_listener(_event):
+        raise KeyboardInterrupt
+
+    with capture_agent_evidence(interrupted_listener, errors="ignore"):
+        with pytest.raises(KeyboardInterrupt):
+            emit_agent_evidence(
+                {
+                    "kind": "trace_unavailable",
+                    "invocation_id": "interrupted",
+                    "error": "interrupted",
+                }
+            )
+
+    with pytest.raises(ValueError, match="errors must be 'raise' or 'ignore'"):
+        with capture_agent_evidence(outer.append, errors="invalid"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_agent_evidence_observers_are_isolated_across_async_contexts():
+    ready = asyncio.Event()
+    arrivals = 0
+
+    async def observe(name):
+        nonlocal arrivals
+        events = []
+        with capture_agent_evidence(events.append, errors="raise"):
+            arrivals += 1
+            if arrivals == 2:
+                ready.set()
+            await ready.wait()
+            await asyncio.sleep(0)
+            emit_agent_evidence(
+                {
+                    "kind": "trace_unavailable",
+                    "invocation_id": name,
+                    "error": name,
+                }
+            )
+        return events
+
+    left, right = await asyncio.gather(observe("left"), observe("right"))
+
+    assert [event["error"] for event in left] == ["left"]
+    assert [event["error"] for event in right] == ["right"]
 
 
 class Person(BaseModel):
@@ -67,6 +209,132 @@ def install_fake(monkeypatch, respond):
 
     monkeypatch.setattr(agent_step_module, "_build_predictor", fake_build)
     return captured
+
+
+def test_build_predictor_uses_declared_predict_rlm_event_contract():
+    predictor = agent_step_module._build_predictor(
+        "question -> answer",
+        skills=(),
+        tools=(),
+    )
+
+    assert len(predictor.runtime_spec.events) == 1
+    assert isinstance(
+        predictor.runtime_spec.events[0], agent_step_module._AvalancheEvidenceSink
+    )
+
+
+@pytest.mark.asyncio
+async def test_predict_rlm_recorder_honors_observer_error_policy():
+    """The real recorder must not swallow a strict bridge persistence failure."""
+    from predict_rlm import (
+        EvidenceIncompleteError,
+        EvidenceRecorder,
+        RunContext,
+        RunEventKind,
+    )
+
+    class AnswerSignature(ava.Signature):
+        question: str = ava.InputField()
+        answer: str = ava.OutputField()
+
+    predictor = agent_step_module._build_predictor(
+        AnswerSignature,
+        skills=(),
+        tools=(),
+    )
+
+    class RecorderPredictor:
+        async def acall(self, **inputs):
+            recorder = EvidenceRecorder(
+                RunContext(predictor.runtime_spec, inputs),
+                predictor.runtime_spec.events,
+            )
+            await recorder.emit(RunEventKind.RUN_STARTED, inputs=inputs)
+            return SimpleNamespace(answer="ok")
+
+    class ListenerPersistenceError(RuntimeError):
+        pass
+
+    def broken_incremental_listener(event):
+        if event["kind"] == "evidence":
+            raise ListenerPersistenceError("persistence failed")
+
+    ignored_agent = agent_step_module.Agent(
+        signature=AnswerSignature,
+        step_name="answer",
+        runtime_kwargs={},
+    )
+    ignored_agent._predictor = RecorderPredictor()
+    with capture_agent_evidence(broken_incremental_listener, errors="ignore"):
+        prediction = await ignored_agent(question="ignored")
+    assert prediction.answer == "ok"
+
+    strict_agent = agent_step_module.Agent(
+        signature=AnswerSignature,
+        step_name="answer",
+        runtime_kwargs={},
+    )
+    strict_agent._predictor = RecorderPredictor()
+    with capture_agent_evidence(broken_incremental_listener, errors="raise"):
+        with pytest.raises(AgentStepExecutionError) as raised:
+            await strict_agent(question="strict")
+
+    recorder_error = raised.value.__cause__
+    assert isinstance(recorder_error, EvidenceIncompleteError)
+    assert isinstance(recorder_error.__cause__, ListenerPersistenceError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "listener_failure",
+    [
+        KeyboardInterrupt("listener interrupted"),
+        SystemExit("listener requested exit"),
+    ],
+)
+async def test_predict_rlm_recorder_reraises_exact_listener_base_exception(
+    listener_failure,
+):
+    """PredictRLM wrapping must not replace a listener control-flow exception."""
+    from predict_rlm import EvidenceRecorder, RunContext, RunEventKind
+
+    class AnswerSignature(ava.Signature):
+        question: str = ava.InputField()
+        answer: str = ava.OutputField()
+
+    predictor = agent_step_module._build_predictor(
+        AnswerSignature,
+        skills=(),
+        tools=(),
+    )
+
+    class RecorderPredictor:
+        async def acall(self, **inputs):
+            recorder = EvidenceRecorder(
+                RunContext(predictor.runtime_spec, inputs),
+                predictor.runtime_spec.events,
+            )
+            await recorder.emit(RunEventKind.RUN_STARTED, inputs=inputs)
+            return SimpleNamespace(answer="ok")
+
+    def interrupted_incremental_listener(event):
+        if event["kind"] == "evidence":
+            raise listener_failure
+
+    agent = agent_step_module.Agent(
+        signature=AnswerSignature,
+        step_name="answer",
+        runtime_kwargs={},
+    )
+    agent._predictor = RecorderPredictor()
+
+    with capture_agent_evidence(interrupted_incremental_listener, errors="raise"):
+        with pytest.raises(type(listener_failure)) as raised:
+            await agent(question="strict")
+
+    assert raised.value is listener_failure
+    assert not isinstance(raised.value, AgentStepExecutionError)
 
 
 class TestBodyfulAgentSteps:
@@ -536,6 +804,188 @@ async def test_agent_streams_sanitized_evidence_and_exported_trace(monkeypatch):
     assert terminal["trace"]["evidence"]["complete"] is True
     assert "IMAGE_BASE_64_ENCODED" in json.dumps(terminal)
     assert trace.called is True
+
+
+@pytest.mark.asyncio
+async def test_successful_terminal_listener_failure_is_not_reclassified():
+    prediction = SimpleNamespace(trace=_ExportableTrace())
+
+    class SuccessfulPredictor:
+        async def acall(self, **inputs):
+            return prediction
+
+    agent = agent_step_module.Agent(
+        signature=SummarySignature,
+        step_name="summarize",
+        runtime_kwargs={},
+    )
+    agent._predictor = SuccessfulPredictor()
+    observed = []
+    listener_error = RuntimeError("terminal persistence failed")
+
+    def persist_then_fail(event):
+        observed.append(event)
+        if event["kind"] == "trace_finished":
+            raise listener_error
+
+    with capture_agent_evidence(persist_then_fail, errors="raise"):
+        with pytest.raises(RuntimeError) as raised:
+            await agent(person=Person(id=1, name="Ada"))
+
+    assert raised.value is listener_error
+    terminal_events = [
+        event for event in observed if event["kind"] in {"trace_finished", "trace_unavailable"}
+    ]
+    assert len(terminal_events) == 1
+    assert terminal_events[0]["kind"] == "trace_finished"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_agent_calls_have_stable_generated_invocation_ids(monkeypatch):
+    """One outer observer can deterministically correlate interleaved calls."""
+    from predict_rlm import RunEvent, RunEventKind
+
+    generated_ids = iter(("generated-left", "generated-right"))
+    monkeypatch.setattr(
+        agent_step_module.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex=next(generated_ids)),
+    )
+
+    class CorrelationSignature(ava.Signature):
+        request_id: str = ava.InputField()
+        answer: str = ava.OutputField()
+
+    class CorrelatedTrace:
+        def __init__(self, request_id):
+            self.request_id = request_id
+
+        def to_exportable_json(self):
+            return json.dumps(
+                {
+                    "status": "completed",
+                    "evidence": {
+                        "run_id": self.request_id,
+                        "complete": True,
+                        "terminal_outcome": "completed",
+                        "events": [],
+                    },
+                    "steps": [],
+                }
+            )
+
+    class ConcurrentPredictor:
+        def __init__(self):
+            self.sink = agent_step_module._AvalancheEvidenceSink()
+            self.ready = asyncio.Event()
+            self.arrivals = 0
+
+        async def acall(self, **inputs):
+            request_id = inputs["request_id"]
+            await self.sink.emit(
+                RunEvent(
+                    request_id,
+                    1,
+                    RunEventKind.PREDICT_STARTED,
+                    1,
+                    {
+                        "call_id": request_id,
+                        "invocation_id": f"caller-{request_id}",
+                    },
+                )
+            )
+            self.arrivals += 1
+            if self.arrivals == 2:
+                self.ready.set()
+            await self.ready.wait()
+            await asyncio.sleep(0)
+            await self.sink.close(
+                request_id,
+                RunEvent(
+                    request_id,
+                    2,
+                    RunEventKind.RUN_SUCCEEDED,
+                    2,
+                    {},
+                ),
+            )
+            return SimpleNamespace(
+                answer=request_id,
+                trace=CorrelatedTrace(request_id),
+            )
+
+    agent = agent_step_module.Agent(
+        signature=CorrelationSignature,
+        step_name="correlate",
+        runtime_kwargs={},
+    )
+    agent._predictor = ConcurrentPredictor()
+    observed = []
+
+    with capture_agent_evidence(observed.append, errors="raise"):
+        left, right = await asyncio.gather(
+            agent(request_id="left"),
+            agent(request_id="right"),
+        )
+
+    assert (left.answer, right.answer) == ("left", "right")
+    grouped = {}
+    for event in observed:
+        grouped.setdefault(event["invocation_id"], []).append(event)
+
+    assert set(grouped) == {"generated-left", "generated-right"}
+    assert not set(grouped) & {"left", "right", "caller-left", "caller-right"}
+    correlations = {}
+    for invocation_id, events in grouped.items():
+        assert [event["kind"] for event in events] == [
+            "evidence",
+            "evidence",
+            "trace_finished",
+        ]
+        call_id = events[0]["data"]["call_id"]
+        assert events[0]["data"].get("invocation_id") is None
+        assert events[-1]["trace"]["evidence"]["run_id"] == call_id
+        correlations[call_id] = invocation_id
+    assert set(correlations) == {"left", "right"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exportable_trace", [False, True])
+async def test_agent_cancellation_emits_one_typed_terminal_and_reraises_exactly(
+    exportable_trace,
+):
+    cancellation = asyncio.CancelledError("cancelled by caller")
+    if exportable_trace:
+        cancellation.trace = _ExportableTrace(status="cancelled")
+
+    class CancelledPredictor:
+        async def acall(self, **inputs):
+            raise cancellation
+
+    agent = agent_step_module.Agent(
+        signature=SummarySignature,
+        step_name="summarize",
+        runtime_kwargs={},
+    )
+    agent._predictor = CancelledPredictor()
+    observed = []
+
+    with capture_agent_evidence(observed.append, errors="raise"):
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await agent(person=Person(id=1, name="Ada"))
+
+    assert raised.value is cancellation
+    assert len(observed) == 1
+    assert observed[0]["invocation_id"]
+    if exportable_trace:
+        assert observed[0]["kind"] == "trace_finished"
+        assert observed[0]["trace"]["status"] == "cancelled"
+    else:
+        assert observed[0] == {
+            "kind": "trace_unavailable",
+            "invocation_id": observed[0]["invocation_id"],
+            "error": "cancelled by caller",
+        }
 
 
 @pytest.mark.asyncio

--- a/test/operator_tests/test_grpc_client_auth_tls.py
+++ b/test/operator_tests/test_grpc_client_auth_tls.py
@@ -5,6 +5,7 @@ from concurrent import futures
 import grpc
 
 from avalanche.operator.client import GrpcStateProvider
+from avalanche.tui import ConnectionAwareStateProvider
 from runtime.operator import client as client_module
 from runtime.operator._grpc import MAX_GRPC_MESSAGE_BYTES
 from runtime.operator.proto import operator_pb2 as pb
@@ -49,10 +50,12 @@ def test_grpc_state_provider_uses_secure_channel_when_tls_enabled(monkeypatch) -
     monkeypatch.setattr(client_module.grpc, "secure_channel", fake_secure_channel)
     monkeypatch.setattr(client_module.pb_grpc, "OperatorServiceStub", lambda channel: object())
 
-    provider = GrpcStateProvider("delta.example:443", tls=True, root_certificates=b"ca")
+    provider = GrpcStateProvider("operator.example:443", tls=True, root_certificates=b"ca")
+    assert isinstance(provider, ConnectionAwareStateProvider)
+    assert provider.connection_label == "operator.example:443"
     provider.close()
 
-    assert calls["address"] == "delta.example:443"
+    assert calls["address"] == "operator.example:443"
     assert calls["credentials"] == "credentials"
     assert calls["root_certificates"] == b"ca"
     assert dict(calls["options"]) == {

--- a/test/operator_tests/test_operator.py
+++ b/test/operator_tests/test_operator.py
@@ -18,6 +18,7 @@ from avalanche.operator.models import NodeState, NodeStatus, RunState, RunStatus
 from avalanche.operator.operator import RunAlreadyExistsError
 from avalanche.operator.scheduler import Scheduler
 from runtime.operator.run_worker import (
+    _import_isolated_ray,
     _QueueStream,
     _with_local_node_observers,
     _with_ray_node_observers,
@@ -336,6 +337,21 @@ class TestOperatorLifecycle:
         with pytest.raises(ValueError, match="require executor_backend='ray'"):
             Operator([], watch=False, schedule=False, **ray_config)
 
+    def test_isolated_ray_import_disables_uv_runtime_env_hook(self, monkeypatch):
+        imported = SimpleNamespace()
+
+        def import_module(name):
+            assert name == "ray"
+            assert os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] == "0"
+            return imported
+
+        monkeypatch.setenv("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "1")
+        monkeypatch.setattr(
+            "runtime.operator.run_worker.importlib.import_module", import_module
+        )
+
+        assert _import_isolated_ray() is imported
+
     @pytest.mark.parametrize(
         "explicit_config",
         [
@@ -556,6 +572,7 @@ class TestAgentEvidenceTransport:
             emit_agent_evidence(
                 {
                     "kind": "evidence",
+                    "invocation_id": "agent-invocation",
                     "sequence": 1,
                     "event_kind": "run.started",
                     "timestamp_ns": 1,
@@ -584,6 +601,7 @@ class TestAgentEvidenceTransport:
                 "node_id": "agent_1",
                 "event": {
                     "kind": "evidence",
+                    "invocation_id": "agent-invocation",
                     "sequence": 1,
                     "event_kind": "run.started",
                     "timestamp_ns": 1,
@@ -608,6 +626,7 @@ class TestAgentEvidenceTransport:
             "node_id": "agent_1",
             "event": {
                 "kind": "evidence",
+                "invocation_id": "agent-invocation",
                 "sequence": 1,
                 "event_kind": "code.generated",
                 "timestamp_ns": 10,
@@ -625,6 +644,7 @@ class TestAgentEvidenceTransport:
                     "node_id": "agent_1",
                     "event": {
                         "kind": "trace_finished",
+                        "invocation_id": "agent-invocation",
                         "trace": {
                             "status": "completed",
                             "evidence": {
@@ -643,6 +663,98 @@ class TestAgentEvidenceTransport:
         envelope = json.loads(run.nodes["agent_1"].agent_trace_json)
         assert envelope["status"] == "completed"
         assert envelope["run_id"] == "agent-run"
+        assert envelope["invocation_id"] == "agent-invocation"
         assert [item["sequence"] for item in envelope["events"]] == [1]
+        assert [item["invocation_id"] for item in envelope["events"]] == ["agent-invocation"]
         assert [entry.node_id for entry in run.logs] == ["agent_1", "agent_1"]
+        operator.close()
+
+    def test_operator_terminal_snapshots_are_coherent_across_invocations(self):
+        operator = Operator([], watch=False, schedule=False)
+        run = self._state()
+
+        def record(event):
+            return operator._record_agent_evidence_event(
+                run,
+                "agent_1",
+                event,
+                notify=False,
+            )
+
+        def evidence(invocation_id):
+            return {
+                "kind": "evidence",
+                "invocation_id": invocation_id,
+                "sequence": 1,
+                "event_kind": "run.started",
+                "timestamp_ns": 1,
+                "data": {},
+            }
+
+        def finished(invocation_id, run_id):
+            return {
+                "kind": "trace_finished",
+                "invocation_id": invocation_id,
+                "trace": {
+                    "status": "completed",
+                    "evidence": {"run_id": run_id, "events": []},
+                    "steps": [],
+                },
+            }
+
+        assert record(evidence("invocation-a")) is not None
+        assert record(finished("invocation-a", "run-a")) is not None
+        snapshot_a = json.loads(run.nodes["agent_1"].agent_trace_json)
+        assert {
+            key: snapshot_a[key] for key in ("invocation_id", "status", "run_id", "error")
+        } == {
+            "invocation_id": "invocation-a",
+            "status": "completed",
+            "run_id": "run-a",
+            "error": None,
+        }
+        assert snapshot_a["trace"]["evidence"]["run_id"] == "run-a"
+
+        assert record(evidence("invocation-b")) is not None
+        assert (
+            record(
+                {
+                    "kind": "trace_unavailable",
+                    "invocation_id": "invocation-b",
+                    "error": "trace export failed",
+                }
+            )
+            is not None
+        )
+        snapshot_b = json.loads(run.nodes["agent_1"].agent_trace_json)
+        assert {
+            key: snapshot_b[key]
+            for key in ("invocation_id", "status", "run_id", "trace", "error")
+        } == {
+            "invocation_id": "invocation-b",
+            "status": "unavailable",
+            "run_id": None,
+            "trace": None,
+            "error": "trace export failed",
+        }
+
+        assert record(evidence("invocation-c")) is not None
+        assert record(finished("invocation-c", "run-c")) is not None
+        snapshot_c = json.loads(run.nodes["agent_1"].agent_trace_json)
+        assert {
+            key: snapshot_c[key] for key in ("invocation_id", "status", "run_id", "error")
+        } == {
+            "invocation_id": "invocation-c",
+            "status": "completed",
+            "run_id": "run-c",
+            "error": None,
+        }
+        assert snapshot_c["trace"]["evidence"]["run_id"] == "run-c"
+        assert [
+            (event["invocation_id"], event["sequence"]) for event in snapshot_c["events"]
+        ] == [
+            ("invocation-a", 1),
+            ("invocation-b", 1),
+            ("invocation-c", 1),
+        ]
         operator.close()

--- a/test/tui_package_layout_test.py
+++ b/test/tui_package_layout_test.py
@@ -24,6 +24,54 @@ def test_avalanche_dot_tui_import_delegates_to_tui_source_package():
     source_package = importlib.import_module("tui")
 
     assert compat.launch_tui is source_package.launch_tui
+    assert compat.StateProvider is source_package.StateProvider
+    assert compat.ConnectionAwareStateProvider is source_package.ConnectionAwareStateProvider
+
+
+def test_public_provider_contract_keeps_connection_state_optional():
+    from avalanche.tui import ConnectionAwareStateProvider, StateProvider
+
+    assert {
+        "list_workflows",
+        "list_runs",
+        "get_run",
+        "start_run",
+        "cancel_run",
+        "on_run_update",
+        "on_log",
+    } <= StateProvider.__dict__.keys()
+    assert "ping" not in StateProvider.__dict__
+
+    class ConnectedProvider:
+        connected = False
+        connection_label = "operator.example:7433"
+        last_error = "unavailable"
+
+        def list_workflows(self):
+            return []
+
+        def list_runs(self, workflow_selector):
+            return []
+
+        def get_run(self, run_id):
+            return None
+
+        def start_run(self, workflow_selector, **kwargs):
+            return ""
+
+        def cancel_run(self, run_id):
+            return None
+
+        def on_run_update(self, callback):
+            return None
+
+        def on_log(self, callback):
+            return None
+
+        def ping(self):
+            return False
+
+    assert isinstance(ConnectedProvider(), ConnectionAwareStateProvider)
 
 
 def test_avalanche_dot_tui_shim_reports_extra_when_impl_is_missing(monkeypatch):
@@ -104,7 +152,7 @@ def test_tui_launch_passes_grpc_auth_and_tls_options(monkeypatch, tmp_path):
         [
             "avalanche.tui",
             "--connect",
-            "delta.example:443",
+            "operator.example:443",
             "--token",
             "secret",
             "--tls",
@@ -117,10 +165,113 @@ def test_tui_launch_passes_grpc_auth_and_tls_options(monkeypatch, tmp_path):
 
     assert providers == [
         (
-            ("delta.example:443",),
+            ("operator.example:443",),
             {"token": "secret", "tls": True, "root_certificates": b"ca"},
         )
     ]
+
+
+def test_tui_launch_accepts_caller_owned_provider(monkeypatch):
+    tui = importlib.import_module("tui")
+    launched = []
+
+    class InjectedProvider:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    class FakeApp:
+        def __init__(self, **kwargs):
+            launched.append(kwargs)
+
+        def run(self):
+            return None
+
+    fake_app_module = ModuleType("tui.app")
+    fake_app_module.AvalancheApp = FakeApp
+    monkeypatch.setitem(sys.modules, "tui.app", fake_app_module)
+    provider = InjectedProvider()
+
+    tui.launch_tui(["orders/prepare"], provider=provider)
+
+    assert launched == [{"provider": provider, "workflow": "orders", "node": "prepare"}]
+    assert provider.closed is False
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--connect", "operator.example:7433"],
+        ["--connect=operator.example:7433"],
+    ],
+)
+def test_tui_launch_rejects_injected_provider_with_connect(monkeypatch, argv):
+    tui = importlib.import_module("tui")
+    fake_app_module = ModuleType("tui.app")
+    fake_app_module.AvalancheApp = object
+    monkeypatch.setitem(sys.modules, "tui.app", fake_app_module)
+
+    with pytest.raises(
+        ValueError, match="an injected provider cannot be combined with --connect"
+    ):
+        tui.launch_tui(argv, provider=object())
+
+
+def test_tui_launch_accepts_connect_equals_syntax(monkeypatch):
+    tui = importlib.import_module("tui")
+    providers = []
+    launched = []
+
+    class FakeProvider:
+        def __init__(self, address, **kwargs):
+            providers.append((self, address, kwargs))
+
+    class FakeApp:
+        def __init__(self, **kwargs):
+            launched.append(kwargs)
+
+        def run(self):
+            return None
+
+    fake_app_module = ModuleType("tui.app")
+    fake_app_module.AvalancheApp = FakeApp
+    monkeypatch.setitem(sys.modules, "tui.app", fake_app_module)
+    operator_client = importlib.import_module("avalanche.operator.client")
+    monkeypatch.setattr(operator_client, "GrpcStateProvider", FakeProvider)
+
+    tui.launch_tui(["--connect=operator.example:7433", "orders/prepare"])
+
+    assert [(address, kwargs) for _, address, kwargs in providers] == [
+        ("operator.example:7433", {})
+    ]
+    assert launched == [
+        {
+            "provider": providers[0][0],
+            "workflow": "orders",
+            "node": "prepare",
+        }
+    ]
+
+
+def test_tui_launch_without_provider_preserves_mock_path(monkeypatch):
+    tui = importlib.import_module("tui")
+    launched = []
+
+    class FakeApp:
+        def __init__(self, **kwargs):
+            launched.append(kwargs)
+
+        def run(self):
+            return None
+
+    fake_app_module = ModuleType("tui.app")
+    fake_app_module.AvalancheApp = FakeApp
+    monkeypatch.setitem(sys.modules, "tui.app", fake_app_module)
+
+    tui.launch_tui(["orders"])
+
+    assert launched == [{"provider": None, "workflow": "orders", "node": None}]
 
 
 def test_core_operator_models_do_not_depend_on_optional_tui_package():

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -6,6 +6,7 @@ import threading
 import time
 from dataclasses import replace
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -76,6 +77,81 @@ def _signal_background_updates(store: UIStore) -> _SignalingQueue:
     queue = _SignalingQueue(store._background_updates)
     store._background_updates = queue
     return queue
+
+
+def test_connection_overlay_uses_public_label_and_error_state():
+    from avalanche.tui.app import AvalancheApp
+    from avalanche.tui.state import ConnectionAwareStateProvider
+
+    delegate = MockStateProvider()
+
+    class DisconnectedProvider:
+        connected = False
+        connection_label = "operator.example:7433"
+        last_error = "UNAVAILABLE: maintenance"
+
+        def list_workflows(self):
+            return delegate.list_workflows()
+
+        def list_runs(self, workflow_selector):
+            return delegate.list_runs(workflow_selector)
+
+        def get_run(self, run_id):
+            return delegate.get_run(run_id)
+
+        def start_run(self, workflow_selector, **kwargs):
+            return delegate.start_run(workflow_selector, **kwargs)
+
+        def cancel_run(self, run_id):
+            return delegate.cancel_run(run_id)
+
+        def on_run_update(self, callback):
+            return delegate.on_run_update(callback)
+
+        def on_log(self, callback):
+            return delegate.on_log(callback)
+
+        def ping(self):
+            return False
+
+    class Wrapper:
+        visible = False
+
+        def has_class(self, name):
+            return name == "visible" and self.visible
+
+        def add_class(self, name):
+            assert name == "visible"
+            self.visible = True
+
+    class Box:
+        rendered = None
+
+        def update(self, value):
+            self.rendered = value
+
+    provider = DisconnectedProvider()
+    assert isinstance(provider, ConnectionAwareStateProvider)
+    wrapper = Wrapper()
+    box = Box()
+    screen = SimpleNamespace(
+        query_one=lambda selector: {
+            "#disconnect-wrapper": wrapper,
+            "#disconnect-box": box,
+        }[selector]
+    )
+    app = SimpleNamespace(
+        store=SimpleNamespace(provider=provider, frame=0),
+        _screen=screen,
+        _ping_counter=0,
+        _ping_in_flight=False,
+    )
+
+    AvalancheApp._check_connection(app)
+
+    assert wrapper.visible
+    assert "operator.example:7433" in str(box.rendered)
+    assert "UNAVAILABLE: maintenance" in str(box.rendered)
 
 
 # ── Models ─────────────────────────────────────────────────────────────────
@@ -1862,9 +1938,7 @@ class TestVirtualizedLogs:
             assert rebuilds == 0
             assert all(
                 rendered is initial
-                for rendered, initial in zip(
-                    log_view.lines, initial_prefix, strict=True
-                )
+                for rendered, initial in zip(log_view.lines, initial_prefix, strict=True)
             )
 
             app.store.current_run = replace(
@@ -2587,6 +2661,69 @@ class TestInteractions:
             assert app.store.selected_node is not None
             assert app.store.selected_node.name == "export_onnx_1"
             assert app.store.selected_node.display_name == "export_onnx"
+
+    async def test_deep_link_node_renders_while_runs_are_still_loading(self):
+        """Deep-link selection must not be hidden behind asynchronous run loading."""
+        from avalanche.tui.app import AvalancheApp
+
+        delegate = MockStateProvider()
+        catalog_entered = threading.Event()
+        catalog_release = threading.Event()
+        runs_release = threading.Event()
+
+        class BlockingRunsProvider:
+            def list_workflows(self):
+                catalog_entered.set()
+                catalog_release.wait()
+                return delegate.list_workflows()
+
+            def list_runs(self, workflow_selector):
+                runs_release.wait()
+                return delegate.list_runs(workflow_selector)
+
+            def get_run(self, run_id):
+                return delegate.get_run(run_id)
+
+            def start_run(self, workflow_selector, **kwargs):
+                return delegate.start_run(workflow_selector, **kwargs)
+
+            def cancel_run(self, run_id):
+                return delegate.cancel_run(run_id)
+
+            def on_run_update(self, callback):
+                return delegate.on_run_update(callback)
+
+            def on_log(self, callback):
+                return delegate.on_log(callback)
+
+        app = AvalancheApp(
+            provider=BlockingRunsProvider(),
+            workflow="order_workflow",
+            node="validate",
+        )
+        updates = _signal_background_updates(app.store)
+        assert catalog_entered.wait(1.0)
+        catalog_release.set()
+        assert updates.put_event.wait(1.0)
+        app.store._apply_background_updates()
+        app._apply_deep_link()
+
+        try:
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app._timer.pause()
+                app._refresh_widgets()
+
+                assert app.store.current_run is None
+                assert app.store.selected_node is not None
+                assert app.store.selected_node.display_name == "validate"
+                assert "validate" in app._screen.query_one("#dag-panel").render().plain
+                assert "validate" in str(app._screen.query_one("#log-panel").border_title)
+                assert (
+                    "validate" in app._screen.query_one("#status-bar", StatusBar).render().plain
+                )
+        finally:
+            runs_release.set()
 
     async def test_dag_arrows_move_nodes_not_scroll(self):
         """Arrow keys in DAG pane should move node selection, not scroll the container."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -280,8 +280,8 @@ requires-dist = [
     { name = "grpcio", marker = "extra == 'tui'", specifier = ">=1.75.1" },
     { name = "grpcio-tools", marker = "extra == 'all'", specifier = ">=1.75.1" },
     { name = "grpcio-tools", marker = "extra == 'runtime'", specifier = ">=1.75.1" },
-    { name = "predict-rlm", marker = "extra == 'agent'", editable = "../predict-rlm" },
-    { name = "predict-rlm", marker = "extra == 'all'", editable = "../predict-rlm" },
+    { name = "predict-rlm", marker = "extra == 'agent'", specifier = ">=0.7.1" },
+    { name = "predict-rlm", marker = "extra == 'all'", specifier = ">=0.7.1" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pyiceberg", extras = ["glue", "pandas", "pyarrow", "s3fs", "sql-sqlite"], specifier = ">=0.9,<0.11" },
     { name = "pylance", marker = "extra == 'all'", specifier = ">=0.24.0" },
@@ -304,7 +304,7 @@ dev = [
     { name = "grpcio", specifier = ">=1.75.1" },
     { name = "grpcio-tools", specifier = ">=1.75.1" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5,<6" },
-    { name = "predict-rlm", editable = "../predict-rlm" },
+    { name = "predict-rlm", specifier = ">=0.7.1" },
     { name = "pylance", specifier = ">=0.24.0" },
     { name = "pytest", specifier = ">=8.3.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.8,<0.24" },
@@ -988,7 +988,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/62/1c2665558618553c42922ed47a4e6d6527e2fa3516a8256c2f431c5d0441/greenlet-3.1.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e4d333e558953648ca09d64f13e6d8f0523fa705f51cae3f03b5983489958c70", size = 272479, upload-time = "2024-09-20T17:07:22.332Z" },
     { url = "https://files.pythonhosted.org/packages/76/9d/421e2d5f07285b6e4e3a676b016ca781f63cfe4a0cd8eaecf3fd6f7a71ae/greenlet-3.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09fc016b73c94e98e29af67ab7b9a879c307c6731a2c9da0db5a7d9b7edd1159", size = 640404, upload-time = "2024-09-20T17:36:45.588Z" },
     { url = "https://files.pythonhosted.org/packages/e5/de/6e05f5c59262a584e502dd3d261bbdd2c97ab5416cc9c0b91ea38932a901/greenlet-3.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d5e975ca70269d66d17dd995dafc06f1b06e8cb1ec1e9ed54c1d1e4a7c4cf26e", size = 652813, upload-time = "2024-09-20T17:39:19.052Z" },
-    { url = "https://files.pythonhosted.org/packages/49/93/d5f93c84241acdea15a8fd329362c2c71c79e1a507c3f142a5d67ea435ae/greenlet-3.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b2813dc3de8c1ee3f924e4d4227999285fd335d1bcc0d2be6dc3f1f6a318ec1", size = 648517, upload-time = "2024-09-20T17:44:24.101Z" },
     { url = "https://files.pythonhosted.org/packages/15/85/72f77fc02d00470c86a5c982b8daafdf65d38aefbbe441cebff3bf7037fc/greenlet-3.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e347b3bfcf985a05e8c0b7d462ba6f15b1ee1c909e2dcad795e49e91b152c383", size = 647831, upload-time = "2024-09-20T17:08:40.577Z" },
     { url = "https://files.pythonhosted.org/packages/f7/4b/1c9695aa24f808e156c8f4813f685d975ca73c000c2a5056c514c64980f6/greenlet-3.1.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e8f8c9cb53cdac7ba9793c276acd90168f416b9ce36799b9b885790f8ad6c0a", size = 602413, upload-time = "2024-09-20T17:08:31.728Z" },
     { url = "https://files.pythonhosted.org/packages/76/70/ad6e5b31ef330f03b12559d19fda2606a522d3849cde46b24f223d6d1619/greenlet-3.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:62ee94988d6b4722ce0028644418d93a52429e977d742ca2ccbe1c4f4a792511", size = 1129619, upload-time = "2024-09-20T17:44:14.222Z" },
@@ -997,7 +996,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ec/bad1ac26764d26aa1353216fcbfa4670050f66d445448aafa227f8b16e80/greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d", size = 274260, upload-time = "2024-09-20T17:08:07.301Z" },
     { url = "https://files.pythonhosted.org/packages/66/d4/c8c04958870f482459ab5956c2942c4ec35cac7fe245527f1039837c17a9/greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79", size = 649064, upload-time = "2024-09-20T17:36:47.628Z" },
     { url = "https://files.pythonhosted.org/packages/51/41/467b12a8c7c1303d20abcca145db2be4e6cd50a951fa30af48b6ec607581/greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa", size = 663420, upload-time = "2024-09-20T17:39:21.258Z" },
-    { url = "https://files.pythonhosted.org/packages/27/8f/2a93cd9b1e7107d5c7b3b7816eeadcac2ebcaf6d6513df9abaf0334777f6/greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441", size = 658035, upload-time = "2024-09-20T17:44:26.501Z" },
     { url = "https://files.pythonhosted.org/packages/57/5c/7c6f50cb12be092e1dccb2599be5a942c3416dbcfb76efcf54b3f8be4d8d/greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36", size = 660105, upload-time = "2024-09-20T17:08:42.048Z" },
     { url = "https://files.pythonhosted.org/packages/f1/66/033e58a50fd9ec9df00a8671c74f1f3a320564c6415a4ed82a1c651654ba/greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9", size = 613077, upload-time = "2024-09-20T17:08:33.707Z" },
     { url = "https://files.pythonhosted.org/packages/19/c5/36384a06f748044d06bdd8776e231fadf92fc896bd12cb1c9f5a1bda9578/greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0", size = 1135975, upload-time = "2024-09-20T17:44:15.989Z" },
@@ -1006,7 +1004,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/57/0db4940cd7bb461365ca8d6fd53e68254c9dbbcc2b452e69d0d41f10a85e/greenlet-3.1.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:05175c27cb459dcfc05d026c4232f9de8913ed006d42713cb8a5137bd49375f1", size = 272990, upload-time = "2024-09-20T17:08:26.312Z" },
     { url = "https://files.pythonhosted.org/packages/1c/ec/423d113c9f74e5e402e175b157203e9102feeb7088cee844d735b28ef963/greenlet-3.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:935e943ec47c4afab8965954bf49bfa639c05d4ccf9ef6e924188f762145c0ff", size = 649175, upload-time = "2024-09-20T17:36:48.983Z" },
     { url = "https://files.pythonhosted.org/packages/a9/46/ddbd2db9ff209186b7b7c621d1432e2f21714adc988703dbdd0e65155c77/greenlet-3.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:667a9706c970cb552ede35aee17339a18e8f2a87a51fba2ed39ceeeb1004798a", size = 663425, upload-time = "2024-09-20T17:39:22.705Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/f9/9c82d6b2b04aa37e38e74f0c429aece5eeb02bab6e3b98e7db89b23d94c6/greenlet-3.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8a678974d1f3aa55f6cc34dc480169d58f2e6d8958895d68845fa4ab566509e", size = 657736, upload-time = "2024-09-20T17:44:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/d9/42/b87bc2a81e3a62c3de2b0d550bf91a86939442b7ff85abb94eec3fc0e6aa/greenlet-3.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efc0f674aa41b92da8c49e0346318c6075d734994c3c4e4430b1c3f853e498e4", size = 660347, upload-time = "2024-09-20T17:08:45.56Z" },
     { url = "https://files.pythonhosted.org/packages/37/fa/71599c3fd06336cdc3eac52e6871cfebab4d9d70674a9a9e7a482c318e99/greenlet-3.1.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e", size = 615583, upload-time = "2024-09-20T17:08:36.85Z" },
     { url = "https://files.pythonhosted.org/packages/4e/96/e9ef85de031703ee7a4483489b40cf307f93c1824a02e903106f2ea315fe/greenlet-3.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:275f72decf9932639c1c6dd1013a1bc266438eb32710016a1c742df5da6e60a1", size = 1133039, upload-time = "2024-09-20T17:44:18.287Z" },
@@ -1014,7 +1011,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/1b/54336d876186920e185066d8c3024ad55f21d7cc3683c856127ddb7b13ce/greenlet-3.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:b42703b1cf69f2aa1df7d1030b9d77d3e584a70755674d60e710f0af570f3761", size = 299490, upload-time = "2024-09-20T17:17:09.501Z" },
     { url = "https://files.pythonhosted.org/packages/5f/17/bea55bf36990e1638a2af5ba10c1640273ef20f627962cf97107f1e5d637/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1695e76146579f8c06c1509c7ce4dfe0706f49c6831a817ac04eebb2fd02011", size = 643731, upload-time = "2024-09-20T17:36:50.376Z" },
     { url = "https://files.pythonhosted.org/packages/78/d2/aa3d2157f9ab742a08e0fd8f77d4699f37c22adfbfeb0c610a186b5f75e0/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7876452af029456b3f3549b696bb36a06db7c90747740c5302f74a9e9fa14b13", size = 649304, upload-time = "2024-09-20T17:39:24.55Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/8e/d0aeffe69e53ccff5a28fa86f07ad1d2d2d6537a9506229431a2a02e2f15/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4ead44c85f8ab905852d3de8d86f6f8baf77109f9da589cb4fa142bd3b57b475", size = 646537, upload-time = "2024-09-20T17:44:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/05/79/e15408220bbb989469c8871062c97c6c9136770657ba779711b90870d867/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8320f64b777d00dd7ccdade271eaf0cad6636343293a25074cc5566160e4de7b", size = 642506, upload-time = "2024-09-20T17:08:47.852Z" },
     { url = "https://files.pythonhosted.org/packages/18/87/470e01a940307796f1d25f8167b551a968540fbe0551c0ebb853cb527dd6/greenlet-3.1.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822", size = 602753, upload-time = "2024-09-20T17:08:38.079Z" },
     { url = "https://files.pythonhosted.org/packages/e2/72/576815ba674eddc3c25028238f74d7b8068902b3968cbe456771b166455e/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01", size = 1122731, upload-time = "2024-09-20T17:44:20.556Z" },
@@ -2105,7 +2101,7 @@ wheels = [
 [[package]]
 name = "predict-rlm"
 version = "0.8.0a0"
-source = { editable = "../predict-rlm" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deno" },
     { name = "dspy" },
@@ -2114,37 +2110,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tenacity" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "deno", specifier = ">=2" },
-    { name = "dspy", specifier = ">=3.2.1" },
-    { name = "formulas", marker = "extra == 'examples'", specifier = ">=1.2.0" },
-    { name = "gepa", marker = "extra == 'gepa'", specifier = ">=0.0.26" },
-    { name = "kaleido", marker = "extra == 'gepa-viz'", specifier = ">=0.2.0" },
-    { name = "litellm", marker = "extra == 'codex-lm'", specifier = ">=1.89.2" },
-    { name = "nest-asyncio", specifier = ">=1.6.0" },
-    { name = "openai", marker = "extra == 'codex-lm'", specifier = ">=1.60" },
-    { name = "openpyxl", marker = "extra == 'examples'", specifier = ">=3.1.0" },
-    { name = "plotly", marker = "extra == 'gepa-viz'", specifier = ">=5.0.0" },
-    { name = "pydantic", specifier = ">=2.8.2,<3" },
-    { name = "pygments", specifier = ">=2.0.0" },
-    { name = "pymupdf", marker = "extra == 'examples'", specifier = ">=1.24.0" },
-    { name = "tenacity", specifier = ">=8.2.0" },
-    { name = "tenacity", marker = "extra == 'codex-lm'", specifier = ">=9.1.4" },
-    { name = "tqdm", marker = "extra == 'gepa'", specifier = ">=4.0.0" },
-    { name = "websockets", marker = "extra == 'sbx'", specifier = ">=15.0,<16" },
-]
-provides-extras = ["sbx", "gepa", "codex-lm", "gepa-viz", "examples"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "ipykernel", specifier = ">=6.29.0" },
-    { name = "pytest", specifier = ">=8.3.1,<9" },
-    { name = "pytest-asyncio", specifier = ">=0.23.8,<0.24" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-testdox", specifier = ">=3.1.0,<4" },
-    { name = "ruff", specifier = ">=0.11.5" },
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a6/e31ccbf66b592a7548b0a415e78c678ee788de5700307fde6833695c48a9/predict_rlm-0.8.0a0.tar.gz", hash = "sha256:3dee35d4a88ae0e9c8bd7ed0cbc50dfdcc3273148b02ce949048a8e93e13a9c5", size = 300544, upload-time = "2026-07-17T19:05:45.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/cd/ea12cf2911a36538d53551f7aa6063de64139dd01fc02e4c545a5843554b/predict_rlm-0.8.0a0-py3-none-any.whl", hash = "sha256:ec28c72a088d9b72e46e639ac668163c05344f8c65cdee8fd3ef1ad88bebc1f9", size = 335064, upload-time = "2026-07-17T19:05:43.596Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Rationale

Avalanche's TUI currently obtains workflow state through its built-in runtime client. Embedded operators and alternate execution environments need to reuse the same UI without copying widgets, mutating global connection state, or translating their data into a second transport.

This change makes workflow state and agent evidence explicit extension points while preserving the existing CLI and remote-runtime behavior.

This PR is stacked on #23, which provides the native agent trace model and inspector used by the evidence hooks.

## Summary

- Adds a public `StateProvider` contract for workflows, runs, logs, cancellation, and lifecycle ownership.
- Adds `ConnectionAwareStateProvider` so connection status remains explicit without coupling custom providers to the built-in runtime client.
- Extends `launch_tui(...)` and the Textual application constructor to accept a provider while preserving the default provider path.
- Adds bounded, best-effort agent evidence listeners that receive structured events without replacing step results or failures.
- Threads optional evidence callbacks through local and operator execution without exposing transport-specific implementation details.
- Normalizes the lock to the published PredictRLM `0.8.0a0` package so the branch does not require a sibling checkout.

## Compatibility

- Existing `ava tui` and remote operator workflows continue to use the built-in provider by default.
- Provider and evidence hooks are additive.
- Listener failures are isolated as ordinary exceptions; process-level `BaseException` signals still propagate.
- Isolated operator Ray coordinators disable automatic `uv run` environment inheritance before importing Ray so verified process-group quiescence remains intact.
- Deep-linked node breadcrumbs render independently of asynchronous run availability, keeping DAG, log inspector, and status-bar selection coherent.
- Public exports and package-layout tests cover the new extension surface.

## Verification

- `uv run pytest -q test/tui_test.py test/tui_package_layout_test.py test/cli_test.py test/agent/agent_step_test.py test/operator_tests/test_grpc_client_auth_tls.py test/operator_tests/test_operator.py test/operator_tests/test_workflow_results.py test/workflow_file_output_test.py` — **348 passed**
- Exact unchanged Ray operator regression — **1 passed**
- Adjacent operator/evidence/TUI regression selection — **311 passed**
- Tmux TUI suite — **13 passed, 2 skipped**
- Focused TUI/package/CLI suite, including blocked-run deep-link regression — **199 passed**
- Ruff format check on all 16 changed Python files — **passed**
- Ruff lint on all 16 changed Python files — **passed**
- `uv lock --check` — **passed**
- `git diff --check origin/native-rlm-support...HEAD` — **passed**
