### PR TITLE
feat(operator): add declarative workflow webhooks

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -152,6 +152,61 @@ For UI-only exploration, use mock mode:
 uv run python -m avalanche.tui
 ```
 
+#### POST Body Intake
+
+Operator-managed workflows can declare a loopback HTTP webhook. Declare the
+workflow input as an `ava.BaseInput` model so Avalanche validates and injects the
+decoded request body as a typed value:
+
+```python
+import avalanche as ava
+
+
+class ReportRequest(ava.BaseInput):
+    message: str
+    priority: int = 0
+
+
+@ava.source
+def receive(payload: ReportRequest):
+    print(payload.message, payload.priority)
+
+
+@ava.workflow(input=ReportRequest, webhook=True)
+def report_webhook():
+    receive()
+```
+
+Start the operator with that flow file, then ask the operator for the generated
+loopback URL:
+
+```bash
+uv run ava operator --flows path/to/report_flow.py --webhook-port 7434
+uv run ava webhooks list --connect localhost:7433
+```
+
+Post a JSON object to the listed URL:
+
+```bash
+curl -i -X POST '<url-from-ava-webhooks-list>' \
+  -H 'Content-Type: application/json' \
+  --data '{"message":"daily report","priority":2}'
+```
+
+The endpoint accepts only `POST` requests with `Content-Type: application/json`,
+a valid `Content-Length`, and a top-level JSON object no larger than 1 MiB. It
+decodes the object and starts the discovered workflow with
+`input=<decoded-object>` and `triggered_by="webhook"`. Avalanche then constructs
+`ReportRequest` with Pydantic validation and injects it into matching node
+parameters such as `payload` above.
+
+A successfully started run returns `202` with `{"run_id": "..."}`. The HTTP
+boundary rejects an unknown route (`404`), unsupported method (`405`), malformed
+JSON or a non-object body (`400`), an oversized body (`413`), and a non-JSON
+content type (`415`). Typed input validation happens during workflow execution,
+after the run is accepted, so a schema mismatch is reported as a failed run
+rather than a synchronous HTTP validation response.
+
 ## Optional Components
 
 `uv sync` installs the development dependency group used by the test suite.

--- a/src/ava_cli/app.py
+++ b/src/ava_cli/app.py
@@ -66,8 +66,20 @@ def _build_parser() -> argparse.ArgumentParser:
             "external trusted and authenticated boundary"
         ),
     )
+    operator.add_argument(
+        "--webhook-port", type=int, default=7434, help="loopback webhook HTTP port"
+    )
     operator.add_argument("--ray", action="store_true", help="use the Ray executor")
     operator.set_defaults(handler=_run_operator)
+
+    webhooks = subcommands.add_parser("webhooks", help="inspect local webhook routes")
+    webhook_commands = webhooks.add_subparsers(dest="webhook_command", metavar="COMMAND")
+    for name, handler in (("list", _list_webhooks), ("get", _get_webhook)):
+        command = webhook_commands.add_parser(name, help=f"{name} local webhook routes")
+        if name == "get":
+            command.add_argument("selector", help="canonical workflow selector")
+        command.add_argument("--connect", default="localhost:7433", metavar="HOST:PORT")
+        command.set_defaults(handler=handler)
 
     run = subcommands.add_parser(
         "run",
@@ -194,10 +206,51 @@ def _run_operator(args: argparse.Namespace) -> int:
         args.host,
         "--port",
         str(args.port),
+        "--webhook-port",
+        str(args.webhook_port),
     ]
     if args.ray:
         runtime_args.append("--ray")
     return _operator_main(runtime_args)
+
+
+def _webhook_record(workflow) -> dict[str, object]:
+    return {
+        "selector": workflow.selector,
+        "method": "POST",
+        "path": workflow.webhook_path,
+        "url": workflow.webhook_url or workflow.webhook_path,
+        "active": workflow.webhook_active,
+    }
+
+
+def _list_webhooks(args: argparse.Namespace) -> int:
+    provider = _make_provider(args.connect)
+    try:
+        records = [
+            _webhook_record(item) for item in provider.list_workflows() if item.webhook_path
+        ]
+        print(json.dumps(records, sort_keys=True))
+        return 0
+    finally:
+        provider.close()
+
+
+def _get_webhook(args: argparse.Namespace) -> int:
+    provider = _make_provider(args.connect)
+    try:
+        matches = [
+            item
+            for item in provider.list_workflows()
+            if item.webhook_path and item.selector == args.selector
+        ]
+        if not matches:
+            print(f"Webhook not found: {args.selector}", file=sys.stderr)
+            return 1
+        print(json.dumps(_webhook_record(matches[0]), sort_keys=True))
+        return 0
+    finally:
+        provider.close()
 
 
 def _operator_main(argv: list[str]) -> int:

--- a/src/avalanche/__init__.py
+++ b/src/avalanche/__init__.py
@@ -60,6 +60,7 @@ from .storage import Namespace, NamespaceConfig, ScanResult, Table, TableGroup
 
 # Types
 from .types import AppendResult, SnapshotMetadata, SnapshotState
+from .webhook import Webhook
 
 __version__ = "0.1.0rc1"
 
@@ -96,6 +97,7 @@ __all__ = [
     # Workflow
     "Workflow",
     "Pipeline",
+    "Webhook",
     # Executors
     "Executor",
     "LocalExecutor",

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -61,6 +61,7 @@ from ulid import ULID
 
 from .input_ref import InputRef
 from .run_handle import RunHandle
+from .webhook import Webhook
 
 if TYPE_CHECKING:
     from .execution_services import ExecutionServicesSpec
@@ -2070,6 +2071,7 @@ class Workflow:
         name: str = "workflow",
         returns: Any = None,
         cron: str | None = None,
+        webhook: Webhook | bool | None = None,
         input_type: type | None = None,
         context_type: type | None = None,
         agent_defaults: dict[str, Any] | None = None,
@@ -2092,6 +2094,7 @@ class Workflow:
         self.name = name
         self.returns = returns
         self.cron = cron
+        self.webhook = _normalize_webhook(webhook)
         _validate_workflow_types(input_type, context_type)
         self.input_type = input_type
         self.context_type = context_type
@@ -2922,6 +2925,7 @@ def workflow(
     fn: Callable[[], None] | None = None,
     *,
     cron: str | None = None,
+    webhook: Webhook | bool | None = None,
     input: type | None = None,
     context: type | None = None,
     ctx: type | None = None,
@@ -2959,6 +2963,7 @@ def workflow(
     if context is not None and ctx is not None and context is not ctx:
         raise ValueError("Use either context= or ctx=, not both")
     context_type = context or ctx
+    webhook = _normalize_webhook(webhook)
     if agent_defaults is not None:
         from .agent.config import validate_runtime_kwargs
 
@@ -2982,6 +2987,7 @@ def workflow(
                     name=fn.__name__,
                     returns=result,
                     cron=cron,
+                    webhook=webhook,
                     input_type=input,
                     context_type=context_type,
                     agent_defaults=agent_defaults,
@@ -3001,3 +3007,13 @@ def workflow(
 
 
 pipeline = workflow
+
+
+def _normalize_webhook(value: Webhook | bool | None) -> Webhook | None:
+    if value is True:
+        return Webhook()
+    if value is False or value is None:
+        return None
+    if not isinstance(value, Webhook):
+        raise TypeError("webhook must be ava.Webhook, True, False, or None")
+    return value

--- a/src/avalanche/webhook.py
+++ b/src/avalanche/webhook.py
@@ -1,0 +1,31 @@
+"""Public configuration for HTTP-triggered workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Webhook:
+    """Enable a workflow's local POST webhook, optionally at ``path``."""
+
+    path: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.path is None:
+            return
+        if (
+            not isinstance(self.path, str)
+            or not self.path.startswith("/")
+            or self.path.startswith("//")
+            or len(self.path) > 1024
+            or not self.path.isprintable()
+            or "\\" in self.path
+        ):
+            raise ValueError("Webhook path must be a printable absolute URL path")
+        if "?" in self.path or "#" in self.path:
+            raise ValueError("Webhook path must not contain a query or fragment")
+        if self.path != "/" and any(
+            segment in {"", ".", ".."} for segment in self.path.removeprefix("/").split("/")
+        ):
+            raise ValueError("Webhook path must use non-empty, non-traversing segments")

--- a/src/runtime/operator/__init__.py
+++ b/src/runtime/operator/__init__.py
@@ -32,12 +32,13 @@ def serve(
     port: int = 7433,
     *,
     host: str = "127.0.0.1",
+    webhook_port: int = 7434,
     **kwargs,
 ) -> None:
     """Start the operator daemon with gRPC server."""
     from .server import serve as _serve
 
-    op = Operator(workflow_paths, **kwargs)
+    op = Operator(workflow_paths, webhook_port=webhook_port, **kwargs)
     try:
         _serve(op, port=port, block=True, host=host)
     finally:

--- a/src/runtime/operator/__main__.py
+++ b/src/runtime/operator/__main__.py
@@ -27,6 +27,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             "external trusted and authenticated boundary"
         ),
     )
+    parser.add_argument(
+        "--webhook-port", type=int, default=7434, help="loopback webhook HTTP port"
+    )
     parser.add_argument("--ray", action="store_true", help="use the Ray executor")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
@@ -43,6 +46,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.flows,
         port=args.port,
         host=args.host,
+        webhook_port=args.webhook_port,
         executor_backend="ray" if args.ray else "local",
     )
     return 0

--- a/src/runtime/operator/convert.py
+++ b/src/runtime/operator/convert.py
@@ -40,6 +40,9 @@ def workflow_info_to_proto(info: WorkflowInfo) -> pb.FlowInfoMsg:
         builder_symbol=info.builder_symbol,
         agent_node_ids=info.agent_node_ids,
         agent_metadata_json=info.agent_metadata_json,
+        webhook_path=info.webhook_path or "",
+        webhook_url=info.webhook_url or "",
+        webhook_active=info.webhook_active,
     )
 
 
@@ -64,6 +67,9 @@ def workflow_info_from_proto(msg: pb.FlowInfoMsg) -> WorkflowInfo:
         root_alias=msg.root_alias,
         relative_file=relative_file,
         builder_symbol=msg.builder_symbol,
+        webhook_path=msg.webhook_path or None,
+        webhook_url=msg.webhook_url or None,
+        webhook_active=msg.webhook_active,
     )
 
 

--- a/src/runtime/operator/discovery.py
+++ b/src/runtime/operator/discovery.py
@@ -419,6 +419,8 @@ def _descriptor_to_dict(
         "agent_node_ids": agent_node_ids,
         "agent_metadata_json": agent_metadata_json,
         "cron": workflow.cron,
+        "webhook_path": workflow.webhook.path if workflow.webhook else None,
+        "webhook_enabled": workflow.webhook is not None,
     }
 
 
@@ -436,6 +438,8 @@ def _descriptor_from_dict(item: dict[str, Any]) -> WorkflowDescriptor:
             (key, value) for key, value in item.get("agent_metadata_json", ())
         ),
         cron=item["cron"],
+        webhook_path=item.get("webhook_path"),
+        webhook_enabled=item.get("webhook_enabled", False),
     )
 
 

--- a/src/runtime/operator/models.py
+++ b/src/runtime/operator/models.py
@@ -100,6 +100,10 @@ class WorkflowInfo:
     builder_symbol: str = ""
     root_alias: str = ""
     relative_file: str = ""
+    webhook_path: str | None = None
+    webhook_enabled: bool = False
+    webhook_url: str | None = None
+    webhook_active: bool = False
 
     @property
     def selector(self) -> str:
@@ -147,6 +151,8 @@ class WorkflowDescriptor:
     agent_node_ids: tuple[str, ...] = ()
     agent_metadata_json: tuple[tuple[str, str], ...] = ()
     cron: str | None = None
+    webhook_path: str | None = None
+    webhook_enabled: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/runtime/operator/operator.py
+++ b/src/runtime/operator/operator.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 ExecutorBackend: TypeAlias = Literal["local", "ray"]
 STREAM_HISTORY_CAPACITY = 1024
 DEFAULT_RESULT_RETENTION_SECONDS = 24 * 60 * 60
+_PROCESS_GROUP_POLL_INTERVAL_SECONDS = 0.02
 DeprecatedExecutorFactory: TypeAlias = (
     type[LocalExecutor] | type[RayExecutor] | partial[RayExecutor]
 )
@@ -1460,22 +1461,41 @@ def _teardown_process_group(
             process.terminate()
     elif process.is_alive():
         process.terminate()
-    process.join(timeout=term_grace)
-    group_alive = os.name != "nt" and _coordinator_group_has_live_members(process.pid)
-    if process.is_alive() or group_alive:
+    quiesced = _wait_for_coordinator_group_quiescence(process, term_grace)
+    if not quiesced:
         if os.name != "nt":
             group_signalled = _signal_coordinator_group(process.pid, signal.SIGKILL)
             if not group_signalled and process.is_alive():
                 process.kill()
         elif hasattr(process, "kill"):
             process.kill()
-        process.join(timeout=kill_grace)
+        quiesced = _wait_for_coordinator_group_quiescence(process, kill_grace)
     close_job(windows_job)
-    group_alive = os.name != "nt" and _coordinator_group_has_live_members(process.pid)
-    return _ProcessGroupTeardown(
-        not process.is_alive() and not group_alive,
-        natural_exitcode,
-    )
+    return _ProcessGroupTeardown(quiesced, natural_exitcode)
+
+
+def _wait_for_coordinator_group_quiescence(
+    process: multiprocessing.Process,
+    timeout: float,
+) -> bool:
+    """Wait boundedly for both the coordinator and its descendants to stop."""
+    process_group = process.pid
+    if process_group is None:
+        return not process.is_alive()
+    deadline = time.monotonic() + max(0.0, timeout)
+    while True:
+        process_alive = process.is_alive()
+        group_alive = os.name != "nt" and _coordinator_group_has_live_members(process_group)
+        if not process_alive and not group_alive:
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        poll_interval = min(_PROCESS_GROUP_POLL_INTERVAL_SECONDS, remaining)
+        if process_alive:
+            process.join(timeout=poll_interval)
+        else:
+            time.sleep(poll_interval)
 
 
 def _signal_coordinator_group(process_group: int, signal_number: int) -> bool:
@@ -1486,20 +1506,23 @@ def _signal_coordinator_group(process_group: int, signal_number: int) -> bool:
     return True
 
 
-def _coordinator_group_exists(process_group: int) -> bool:
+def _coordinator_group_exists(process_group: int) -> bool | None:
     try:
         os.killpg(process_group, 0)
     except ProcessLookupError:
         return False
     except PermissionError:
-        return False
+        return None
     return True
 
 
 def _coordinator_group_has_live_members(process_group: int) -> bool:
     """Treat dead or irreversibly exiting groups as quiesced."""
-    if not _coordinator_group_exists(process_group):
+    group_exists = _coordinator_group_exists(process_group)
+    if group_exists is False:
         return False
+    if group_exists is None:
+        return True
     try:
         completed = subprocess.run(
             ["/bin/ps", "-axo", "pgid=,stat="],

--- a/src/runtime/operator/operator.py
+++ b/src/runtime/operator/operator.py
@@ -44,6 +44,7 @@ from .result_store import (
 from .results import EncodedWorkflowResult, decode_workflow_result
 from .run_worker import run_worker
 from .source import is_source_path_included, resolve_live_source, resolve_watch_roots
+from .webhooks import DEFAULT_WEBHOOK_PORT, WebhookServer, routes_for
 from .windows_job import WindowsJob, assign_process, close_job, create_kill_on_close_job
 
 _LEVEL_MAP = {
@@ -129,6 +130,7 @@ class Operator:
         stream_history_capacity: int = STREAM_HISTORY_CAPACITY,
         result_storage_directory: str | os.PathLike[str] | None = None,
         result_retention_seconds: float | None = DEFAULT_RESULT_RETENTION_SECONDS,
+        webhook_port: int = DEFAULT_WEBHOOK_PORT,
     ) -> None:
         """Create an operator with spawn-safe executor configuration.
 
@@ -143,12 +145,8 @@ class Operator:
             ray_init_kwargs=ray_init_kwargs,
             executor_factory=executor_factory,
         )
-        self._registry = WorkflowRegistry(discovery_timeout=discovery_timeout)
-        self._workflow_paths = workflow_paths or []
-        if self._workflow_paths:
-            self._registry.scan(self._workflow_paths)
-
-        self._prepare_timeout = prepare_timeout
+        if not 0 <= webhook_port <= 65535:
+            raise ValueError("Webhook port must be between 0 and 65535")
         if cancel_grace < 0:
             raise ValueError("Cancellation grace must be non-negative")
         if stream_history_capacity <= 0:
@@ -164,6 +162,14 @@ class Operator:
         self._result_retention_seconds = (
             None if result_retention_seconds is None else float(result_retention_seconds)
         )
+        self._prepare_timeout = prepare_timeout
+        self._registry = WorkflowRegistry(discovery_timeout=discovery_timeout)
+        self._workflow_paths = workflow_paths or []
+        self._webhooks = WebhookServer(self, webhook_port)
+        self._webhook_routes = {}
+        initial_view = None
+        if self._workflow_paths:
+            initial_view = self._registry.scan(self._workflow_paths, validate=routes_for)
         self._mp = multiprocessing.get_context("spawn")
         self._runs: dict[str, RunState] = {}
         self._stored_results: dict[str, StoredWorkflowResult] = {}
@@ -190,6 +196,8 @@ class Operator:
         self._scheduler = Scheduler(self)
         try:
             self._scheduler.reconcile(self._registry.descriptors())
+            if initial_view is not None:
+                self._reconcile_webhooks(initial_view.by_id.values())
             if watch and self._workflow_paths:
                 self._start_watcher()
             if schedule and self._workflow_paths:
@@ -205,6 +213,7 @@ class Operator:
             self._watcher_stop.set()
             self._result_cleanup_stop.set()
             self._scheduler.stop()
+            self._webhooks.close()
             if self._watcher_thread is not None:
                 self._watcher_thread.join(timeout=2.0)
             if self._result_cleanup_thread is not None:
@@ -215,6 +224,18 @@ class Operator:
     def list_workflows(self) -> list[WorkflowInfo]:
         workflows = self._registry.list_workflows()
         for info in workflows:
+            route = next(
+                (
+                    item
+                    for item in self._webhook_routes.values()
+                    if item.workflow_id == info.workflow_id
+                ),
+                None,
+            )
+            if route is not None:
+                info.webhook_path = route.path
+                info.webhook_url = self._webhooks.url_for(route.path)
+                info.webhook_active = self._webhooks.active
             if info.cron:
                 nxt = self._scheduler.next_run_time(info.cron)
                 info.next_run_at = nxt.timestamp() if nxt else None
@@ -470,6 +491,7 @@ class Operator:
             self._watcher_stop.set()
             self._result_cleanup_stop.set()
             self._scheduler.stop()
+            self._webhooks.close()
             if self._watcher_thread is not None:
                 self._watcher_thread.join(timeout=2.0)
             if self._result_cleanup_thread is not None:
@@ -563,8 +585,18 @@ class Operator:
         # Otherwise an old cron can resolve newly-published same-ID source in the
         # small window between these two operations.
         with self._scheduler.reconciliation_boundary():
-            view = self._registry.rescan()
+            try:
+                view = self._registry.rescan(validate=routes_for)
+            except ValueError as exc:
+                logging.getLogger(__name__).warning("Webhook catalog refresh rejected: %s", exc)
+                return
             self._scheduler.reconcile(view.by_id.values())
+            self._reconcile_webhooks(view.by_id.values())
+
+    def _reconcile_webhooks(self, descriptors) -> None:
+        routes = routes_for(tuple(descriptors))
+        self._webhooks.reconcile(routes)
+        self._webhook_routes = routes
 
     def _await_prepared(
         self, handle: _RunHandle

--- a/src/runtime/operator/proto/operator.proto
+++ b/src/runtime/operator/proto/operator.proto
@@ -79,6 +79,9 @@ message FlowInfoMsg {
   string builder_symbol = 14;
   repeated string agent_node_ids = 15;
   map<string, string> agent_metadata_json = 16;
+  string webhook_path = 17;
+  string webhook_url = 18;
+  bool webhook_active = 19;
 }
 
 message FlowList {

--- a/src/runtime/operator/proto/operator_pb2.py
+++ b/src/runtime/operator/proto/operator_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eoperator.proto\x12\x12\x61valanche.operator\"\x07\n\x05\x45mpty\"\xb2\x01\n\x0fStartRunRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x12\n\ninput_json\x18\x02 \x01(\t\x12\x14\n\x0c\x63ontext_json\x18\x03 \x01(\t\x12\x37\n\x0binput_files\x18\x04 \x03(\x0b\x32\".avalanche.operator.FileAttachment\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x19\n\x11workflow_selector\x18\x07 \x01(\t\"i\n\x0e\x46ileAttachment\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x14\n\x0c\x63ontent_type\x18\x04 \x01(\t\x12\x0e\n\x06sha256\x18\x05 \x01(\t\"\"\n\x10StartRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\"\n\x10\x43\x61ncelRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"?\n\x0fListRunsRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x19\n\x11workflow_selector\x18\x02 \x01(\t\"\x1f\n\rGetRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\'\n\rStreamRequest\x12\x16\n\x0esince_sequence\x18\x01 \x01(\x04\"\x1d\n\tNodeEdges\x12\x10\n\x08\x63hildren\x18\x01 \x03(\t\"\x8a\x06\n\x0b\x46lowInfoMsg\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\x10\n\x08node_ids\x18\x03 \x03(\t\x12\x39\n\x05graph\x18\x04 \x03(\x0b\x32*.avalanche.operator.FlowInfoMsg.GraphEntry\x12\x42\n\nnode_types\x18\x05 \x03(\x0b\x32..avalanche.operator.FlowInfoMsg.NodeTypesEntry\x12H\n\rdisplay_names\x18\x06 \x03(\x0b\x32\x31.avalanche.operator.FlowInfoMsg.DisplayNamesEntry\x12\x0c\n\x04\x63ron\x18\x07 \x01(\t\x12\x13\n\x0bnext_run_at\x18\x08 \x01(\x01\x12\x13\n\x0blast_run_at\x18\t \x01(\x01\x12\x13\n\x0bworkflow_id\x18\n \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x0b \x01(\t\x12\x12\n\nroot_alias\x18\x0c \x01(\t\x12\x15\n\rrelative_file\x18\r \x01(\t\x12\x16\n\x0e\x62uilder_symbol\x18\x0e \x01(\t\x12\x16\n\x0e\x61gent_node_ids\x18\x0f \x03(\t\x12S\n\x13\x61gent_metadata_json\x18\x10 \x03(\x0b\x32\x36.avalanche.operator.FlowInfoMsg.AgentMetadataJsonEntry\x1aK\n\nGraphEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.avalanche.operator.NodeEdges:\x02\x38\x01\x1a\x30\n\x0eNodeTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x33\n\x11\x44isplayNamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x38\n\x16\x41gentMetadataJsonEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"{\n\x08\x46lowList\x12.\n\x05\x66lows\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.FlowInfoMsg\x12?\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32*.avalanche.operator.DiscoveryDiagnosticMsg\"E\n\x16\x44iscoveryDiagnosticMsg\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\"\x90\x01\n\x0cNodeStateMsg\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tnode_type\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x12\n\nstarted_at\x18\x05 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x06 \x01(\x01\x12\x18\n\x10\x61gent_trace_json\x18\x07 \x01(\t\"Q\n\x0bLogEntryMsg\x12\x11\n\ttimestamp\x18\x01 \x01(\x01\x12\r\n\x05level\x18\x02 \x01(\t\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\x0f\n\x07message\x18\x04 \x01(\t\"\x90\x02\n\x0bRunStateMsg\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tflow_name\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12\x12\n\nstarted_at\x18\x04 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x05 \x01(\x01\x12/\n\x05nodes\x18\x06 \x03(\x0b\x32 .avalanche.operator.NodeStateMsg\x12-\n\x04logs\x18\x07 \x03(\x0b\x32\x1f.avalanche.operator.LogEntryMsg\x12\x14\n\x0ctriggered_by\x18\x08 \x01(\t\x12\x13\n\x0bworkflow_id\x18\t \x01(\t\x12\x1d\n\x15workflow_display_name\x18\n \x01(\t\"8\n\x07RunList\x12-\n\x04runs\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.RunStateMsg\"\x92\x01\n\x14ResultFileAttachment\x12\x15\n\rattachment_id\x18\x01 \x01(\t\x12\x11\n\x04name\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x17\n\nmedia_type\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x0e\n\x06sha256\x18\x05 \x01(\tB\x07\n\x05_nameB\r\n\x0b_media_type\"[\n\x0cRunResultMsg\x12\x12\n\nvalue_json\x18\x01 \x01(\t\x12\x37\n\x05\x66iles\x18\x02 \x03(\x0b\x32(.avalanche.operator.ResultFileAttachment\"K\n\tRunUpdate\x12\x10\n\x08sequence\x18\x01 \x01(\x04\x12,\n\x03run\x18\x02 \x01(\x0b\x32\x1f.avalanche.operator.RunStateMsg2\xc2\x04\n\x0fOperatorService\x12\x44\n\tListFlows\x12\x19.avalanche.operator.Empty\x1a\x1c.avalanche.operator.FlowList\x12U\n\x08StartRun\x12#.avalanche.operator.StartRunRequest\x1a$.avalanche.operator.StartRunResponse\x12L\n\tCancelRun\x12$.avalanche.operator.CancelRunRequest\x1a\x19.avalanche.operator.Empty\x12L\n\x08ListRuns\x12#.avalanche.operator.ListRunsRequest\x1a\x1b.avalanche.operator.RunList\x12L\n\x06GetRun\x12!.avalanche.operator.GetRunRequest\x1a\x1f.avalanche.operator.RunStateMsg\x12S\n\x0cGetRunResult\x12!.avalanche.operator.GetRunRequest\x1a .avalanche.operator.RunResultMsg\x12S\n\rStreamUpdates\x12!.avalanche.operator.StreamRequest\x1a\x1d.avalanche.operator.RunUpdate0\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eoperator.proto\x12\x12\x61valanche.operator\"\x07\n\x05\x45mpty\"\xb2\x01\n\x0fStartRunRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x12\n\ninput_json\x18\x02 \x01(\t\x12\x14\n\x0c\x63ontext_json\x18\x03 \x01(\t\x12\x37\n\x0binput_files\x18\x04 \x03(\x0b\x32\".avalanche.operator.FileAttachment\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x19\n\x11workflow_selector\x18\x07 \x01(\t\"i\n\x0e\x46ileAttachment\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x14\n\x0c\x63ontent_type\x18\x04 \x01(\t\x12\x0e\n\x06sha256\x18\x05 \x01(\t\"\"\n\x10StartRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\"\n\x10\x43\x61ncelRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"?\n\x0fListRunsRequest\x12\x11\n\tflow_name\x18\x01 \x01(\t\x12\x19\n\x11workflow_selector\x18\x02 \x01(\t\"\x1f\n\rGetRunRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\t\"\'\n\rStreamRequest\x12\x16\n\x0esince_sequence\x18\x01 \x01(\x04\"\x1d\n\tNodeEdges\x12\x10\n\x08\x63hildren\x18\x01 \x03(\t\"\xcd\x06\n\x0b\x46lowInfoMsg\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\x10\n\x08node_ids\x18\x03 \x03(\t\x12\x39\n\x05graph\x18\x04 \x03(\x0b\x32*.avalanche.operator.FlowInfoMsg.GraphEntry\x12\x42\n\nnode_types\x18\x05 \x03(\x0b\x32..avalanche.operator.FlowInfoMsg.NodeTypesEntry\x12H\n\rdisplay_names\x18\x06 \x03(\x0b\x32\x31.avalanche.operator.FlowInfoMsg.DisplayNamesEntry\x12\x0c\n\x04\x63ron\x18\x07 \x01(\t\x12\x13\n\x0bnext_run_at\x18\x08 \x01(\x01\x12\x13\n\x0blast_run_at\x18\t \x01(\x01\x12\x13\n\x0bworkflow_id\x18\n \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x0b \x01(\t\x12\x12\n\nroot_alias\x18\x0c \x01(\t\x12\x15\n\rrelative_file\x18\r \x01(\t\x12\x16\n\x0e\x62uilder_symbol\x18\x0e \x01(\t\x12\x16\n\x0e\x61gent_node_ids\x18\x0f \x03(\t\x12S\n\x13\x61gent_metadata_json\x18\x10 \x03(\x0b\x32\x36.avalanche.operator.FlowInfoMsg.AgentMetadataJsonEntry\x12\x14\n\x0cwebhook_path\x18\x11 \x01(\t\x12\x13\n\x0bwebhook_url\x18\x12 \x01(\t\x12\x16\n\x0ewebhook_active\x18\x13 \x01(\x08\x1aK\n\nGraphEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.avalanche.operator.NodeEdges:\x02\x38\x01\x1a\x30\n\x0eNodeTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x33\n\x11\x44isplayNamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x38\n\x16\x41gentMetadataJsonEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"{\n\x08\x46lowList\x12.\n\x05\x66lows\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.FlowInfoMsg\x12?\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32*.avalanche.operator.DiscoveryDiagnosticMsg\"E\n\x16\x44iscoveryDiagnosticMsg\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\"\x90\x01\n\x0cNodeStateMsg\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tnode_type\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x12\n\nstarted_at\x18\x05 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x06 \x01(\x01\x12\x18\n\x10\x61gent_trace_json\x18\x07 \x01(\t\"Q\n\x0bLogEntryMsg\x12\x11\n\ttimestamp\x18\x01 \x01(\x01\x12\r\n\x05level\x18\x02 \x01(\t\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\x0f\n\x07message\x18\x04 \x01(\t\"\x90\x02\n\x0bRunStateMsg\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tflow_name\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12\x12\n\nstarted_at\x18\x04 \x01(\x01\x12\x10\n\x08\x65nded_at\x18\x05 \x01(\x01\x12/\n\x05nodes\x18\x06 \x03(\x0b\x32 .avalanche.operator.NodeStateMsg\x12-\n\x04logs\x18\x07 \x03(\x0b\x32\x1f.avalanche.operator.LogEntryMsg\x12\x14\n\x0ctriggered_by\x18\x08 \x01(\t\x12\x13\n\x0bworkflow_id\x18\t \x01(\t\x12\x1d\n\x15workflow_display_name\x18\n \x01(\t\"8\n\x07RunList\x12-\n\x04runs\x18\x01 \x03(\x0b\x32\x1f.avalanche.operator.RunStateMsg\"\x92\x01\n\x14ResultFileAttachment\x12\x15\n\rattachment_id\x18\x01 \x01(\t\x12\x11\n\x04name\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\x0c\x12\x17\n\nmedia_type\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x0e\n\x06sha256\x18\x05 \x01(\tB\x07\n\x05_nameB\r\n\x0b_media_type\"[\n\x0cRunResultMsg\x12\x12\n\nvalue_json\x18\x01 \x01(\t\x12\x37\n\x05\x66iles\x18\x02 \x03(\x0b\x32(.avalanche.operator.ResultFileAttachment\"K\n\tRunUpdate\x12\x10\n\x08sequence\x18\x01 \x01(\x04\x12,\n\x03run\x18\x02 \x01(\x0b\x32\x1f.avalanche.operator.RunStateMsg2\xc2\x04\n\x0fOperatorService\x12\x44\n\tListFlows\x12\x19.avalanche.operator.Empty\x1a\x1c.avalanche.operator.FlowList\x12U\n\x08StartRun\x12#.avalanche.operator.StartRunRequest\x1a$.avalanche.operator.StartRunResponse\x12L\n\tCancelRun\x12$.avalanche.operator.CancelRunRequest\x1a\x19.avalanche.operator.Empty\x12L\n\x08ListRuns\x12#.avalanche.operator.ListRunsRequest\x1a\x1b.avalanche.operator.RunList\x12L\n\x06GetRun\x12!.avalanche.operator.GetRunRequest\x1a\x1f.avalanche.operator.RunStateMsg\x12S\n\x0cGetRunResult\x12!.avalanche.operator.GetRunRequest\x1a .avalanche.operator.RunResultMsg\x12S\n\rStreamUpdates\x12!.avalanche.operator.StreamRequest\x1a\x1d.avalanche.operator.RunUpdate0\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -58,33 +58,33 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_NODEEDGES']._serialized_start=546
   _globals['_NODEEDGES']._serialized_end=575
   _globals['_FLOWINFOMSG']._serialized_start=578
-  _globals['_FLOWINFOMSG']._serialized_end=1356
-  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_start=1120
-  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_end=1195
-  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_start=1197
-  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_end=1245
-  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_start=1247
-  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_end=1298
-  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._serialized_start=1300
-  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._serialized_end=1356
-  _globals['_FLOWLIST']._serialized_start=1358
-  _globals['_FLOWLIST']._serialized_end=1481
-  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_start=1483
-  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_end=1552
-  _globals['_NODESTATEMSG']._serialized_start=1555
-  _globals['_NODESTATEMSG']._serialized_end=1699
-  _globals['_LOGENTRYMSG']._serialized_start=1701
-  _globals['_LOGENTRYMSG']._serialized_end=1782
-  _globals['_RUNSTATEMSG']._serialized_start=1785
-  _globals['_RUNSTATEMSG']._serialized_end=2057
-  _globals['_RUNLIST']._serialized_start=2059
-  _globals['_RUNLIST']._serialized_end=2115
-  _globals['_RESULTFILEATTACHMENT']._serialized_start=2118
-  _globals['_RESULTFILEATTACHMENT']._serialized_end=2264
-  _globals['_RUNRESULTMSG']._serialized_start=2266
-  _globals['_RUNRESULTMSG']._serialized_end=2357
-  _globals['_RUNUPDATE']._serialized_start=2359
-  _globals['_RUNUPDATE']._serialized_end=2434
-  _globals['_OPERATORSERVICE']._serialized_start=2437
-  _globals['_OPERATORSERVICE']._serialized_end=3015
+  _globals['_FLOWINFOMSG']._serialized_end=1423
+  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_start=1187
+  _globals['_FLOWINFOMSG_GRAPHENTRY']._serialized_end=1262
+  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_start=1264
+  _globals['_FLOWINFOMSG_NODETYPESENTRY']._serialized_end=1312
+  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_start=1314
+  _globals['_FLOWINFOMSG_DISPLAYNAMESENTRY']._serialized_end=1365
+  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._serialized_start=1367
+  _globals['_FLOWINFOMSG_AGENTMETADATAJSONENTRY']._serialized_end=1423
+  _globals['_FLOWLIST']._serialized_start=1425
+  _globals['_FLOWLIST']._serialized_end=1548
+  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_start=1550
+  _globals['_DISCOVERYDIAGNOSTICMSG']._serialized_end=1619
+  _globals['_NODESTATEMSG']._serialized_start=1622
+  _globals['_NODESTATEMSG']._serialized_end=1766
+  _globals['_LOGENTRYMSG']._serialized_start=1768
+  _globals['_LOGENTRYMSG']._serialized_end=1849
+  _globals['_RUNSTATEMSG']._serialized_start=1852
+  _globals['_RUNSTATEMSG']._serialized_end=2124
+  _globals['_RUNLIST']._serialized_start=2126
+  _globals['_RUNLIST']._serialized_end=2182
+  _globals['_RESULTFILEATTACHMENT']._serialized_start=2185
+  _globals['_RESULTFILEATTACHMENT']._serialized_end=2331
+  _globals['_RUNRESULTMSG']._serialized_start=2333
+  _globals['_RUNRESULTMSG']._serialized_end=2424
+  _globals['_RUNUPDATE']._serialized_start=2426
+  _globals['_RUNUPDATE']._serialized_end=2501
+  _globals['_OPERATORSERVICE']._serialized_start=2504
+  _globals['_OPERATORSERVICE']._serialized_end=3082
 # @@protoc_insertion_point(module_scope)

--- a/src/runtime/operator/proto/operator_pb2.pyi
+++ b/src/runtime/operator/proto/operator_pb2.pyi
@@ -79,7 +79,7 @@ class NodeEdges(_message.Message):
     def __init__(self, children: _Optional[_Iterable[str]] = ...) -> None: ...
 
 class FlowInfoMsg(_message.Message):
-    __slots__ = ("name", "file_path", "node_ids", "graph", "node_types", "display_names", "cron", "next_run_at", "last_run_at", "workflow_id", "display_name", "root_alias", "relative_file", "builder_symbol", "agent_node_ids", "agent_metadata_json")
+    __slots__ = ("name", "file_path", "node_ids", "graph", "node_types", "display_names", "cron", "next_run_at", "last_run_at", "workflow_id", "display_name", "root_alias", "relative_file", "builder_symbol", "agent_node_ids", "agent_metadata_json", "webhook_path", "webhook_url", "webhook_active")
     class GraphEntry(_message.Message):
         __slots__ = ("key", "value")
         KEY_FIELD_NUMBER: _ClassVar[int]
@@ -124,6 +124,9 @@ class FlowInfoMsg(_message.Message):
     BUILDER_SYMBOL_FIELD_NUMBER: _ClassVar[int]
     AGENT_NODE_IDS_FIELD_NUMBER: _ClassVar[int]
     AGENT_METADATA_JSON_FIELD_NUMBER: _ClassVar[int]
+    WEBHOOK_PATH_FIELD_NUMBER: _ClassVar[int]
+    WEBHOOK_URL_FIELD_NUMBER: _ClassVar[int]
+    WEBHOOK_ACTIVE_FIELD_NUMBER: _ClassVar[int]
     name: str
     file_path: str
     node_ids: _containers.RepeatedScalarFieldContainer[str]
@@ -140,7 +143,10 @@ class FlowInfoMsg(_message.Message):
     builder_symbol: str
     agent_node_ids: _containers.RepeatedScalarFieldContainer[str]
     agent_metadata_json: _containers.ScalarMap[str, str]
-    def __init__(self, name: _Optional[str] = ..., file_path: _Optional[str] = ..., node_ids: _Optional[_Iterable[str]] = ..., graph: _Optional[_Mapping[str, NodeEdges]] = ..., node_types: _Optional[_Mapping[str, str]] = ..., display_names: _Optional[_Mapping[str, str]] = ..., cron: _Optional[str] = ..., next_run_at: _Optional[float] = ..., last_run_at: _Optional[float] = ..., workflow_id: _Optional[str] = ..., display_name: _Optional[str] = ..., root_alias: _Optional[str] = ..., relative_file: _Optional[str] = ..., builder_symbol: _Optional[str] = ..., agent_node_ids: _Optional[_Iterable[str]] = ..., agent_metadata_json: _Optional[_Mapping[str, str]] = ...) -> None: ...
+    webhook_path: str
+    webhook_url: str
+    webhook_active: bool
+    def __init__(self, name: _Optional[str] = ..., file_path: _Optional[str] = ..., node_ids: _Optional[_Iterable[str]] = ..., graph: _Optional[_Mapping[str, NodeEdges]] = ..., node_types: _Optional[_Mapping[str, str]] = ..., display_names: _Optional[_Mapping[str, str]] = ..., cron: _Optional[str] = ..., next_run_at: _Optional[float] = ..., last_run_at: _Optional[float] = ..., workflow_id: _Optional[str] = ..., display_name: _Optional[str] = ..., root_alias: _Optional[str] = ..., relative_file: _Optional[str] = ..., builder_symbol: _Optional[str] = ..., agent_node_ids: _Optional[_Iterable[str]] = ..., agent_metadata_json: _Optional[_Mapping[str, str]] = ..., webhook_path: _Optional[str] = ..., webhook_url: _Optional[str] = ..., webhook_active: bool = ...) -> None: ...
 
 class FlowList(_message.Message):
     __slots__ = ("flows", "diagnostics")

--- a/src/runtime/operator/registry.py
+++ b/src/runtime/operator/registry.py
@@ -74,6 +74,8 @@ def workflow_to_info(
         agent_node_ids=agent_node_ids,
         agent_metadata_json=agent_metadata_json,
         cron=workflow.cron,
+        webhook_path=workflow.webhook.path if workflow.webhook else None,
+        webhook_enabled=workflow.webhook is not None,
     )
 
 
@@ -94,6 +96,8 @@ def descriptor_to_info(descriptor: WorkflowDescriptor) -> WorkflowInfo:
         agent_node_ids=list(descriptor.agent_node_ids),
         agent_metadata_json=dict(descriptor.agent_metadata_json),
         cron=descriptor.cron,
+        webhook_path=descriptor.webhook_path,
+        webhook_enabled=descriptor.webhook_enabled,
     )
 
 
@@ -119,10 +123,17 @@ class WorkflowRegistry:
         with self._lock:
             return self._roots
 
-    def scan(self, paths: list[str]) -> CatalogView:
+    def scan(
+        self,
+        paths: list[str],
+        *,
+        validate: Callable[[tuple[WorkflowDescriptor, ...]], object] | None = None,
+    ) -> CatalogView:
         """Build a complete catalog off-lock, then atomically install it."""
         roots = configure_roots(paths)
         descriptors, diagnostics = discover(roots, timeout=self._discovery_timeout)
+        if validate is not None:
+            validate(descriptors)
 
         by_id: dict[str, WorkflowDescriptor] = {}
         for descriptor in descriptors:
@@ -148,13 +159,17 @@ class WorkflowRegistry:
             self._view = view
         return view
 
-    def rescan(self) -> CatalogView:
+    def rescan(
+        self,
+        *,
+        validate: Callable[[tuple[WorkflowDescriptor, ...]], object] | None = None,
+    ) -> CatalogView:
         """Refresh configured roots without retaining a last-good descriptor."""
         with self._lock:
             paths = list(self._scan_paths)
         if not paths:
             return self.view
-        return self.scan(paths)
+        return self.scan(paths, validate=validate)
 
     def resolve(self, selector: str) -> WorkflowDescriptor:
         descriptor, _ = self.resolve_source(selector)

--- a/src/runtime/operator/webhooks.py
+++ b/src/runtime/operator/webhooks.py
@@ -1,0 +1,191 @@
+"""Loopback HTTP ingress for locally discovered workflow webhooks."""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote, urlsplit
+
+from .models import WorkflowDescriptor
+
+if TYPE_CHECKING:
+    from .operator import Operator
+
+DEFAULT_WEBHOOK_PORT = 7434
+MAX_WEBHOOK_BODY_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class WebhookRoute:
+    workflow_id: str
+    path: str
+
+
+def routes_for(descriptors: tuple[WorkflowDescriptor, ...]) -> dict[str, WebhookRoute]:
+    """Build a complete route table or reject it before it can be published."""
+    routes: dict[str, WebhookRoute] = {}
+    for descriptor in descriptors:
+        if not descriptor.webhook_enabled:
+            continue
+        path = descriptor.webhook_path or default_path(descriptor)
+        if path in routes:
+            raise ValueError(
+                f"Webhook route collision for {path}: {routes[path].workflow_id} and "
+                f"{descriptor.workflow_id}"
+            )
+        routes[path] = WebhookRoute(descriptor.workflow_id, path)
+    return dict(sorted(routes.items()))
+
+
+def default_path(descriptor: WorkflowDescriptor) -> str:
+    relative_parts = descriptor.locator.relative_file.removesuffix(".py").split("/")
+    parts = [descriptor.locator.root_alias, *relative_parts, descriptor.locator.builder_symbol]
+    return "/webhooks/" + "/".join(quote(part, safe="") for part in parts)
+
+
+class WebhookServer:
+    """One small HTTP server whose route snapshot is owned by the Operator."""
+
+    def __init__(self, operator: Operator, port: int) -> None:
+        self._operator = operator
+        self._port = port
+        self._lock = threading.RLock()
+        self._routes: dict[str, WebhookRoute] = {}
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def active(self) -> bool:
+        with self._lock:
+            return self._server is not None
+
+    @property
+    def port(self) -> int | None:
+        with self._lock:
+            return self._server.server_address[1] if self._server is not None else None
+
+    def url_for(self, path: str) -> str | None:
+        port = self.port
+        return f"http://127.0.0.1:{port}{path}" if port is not None else None
+
+    def reconcile(self, routes: dict[str, WebhookRoute]) -> None:
+        with self._lock:
+            self._routes = dict(routes)
+            if routes and self._server is None:
+                self._start_locked()
+
+    def close(self) -> None:
+        with self._lock:
+            server, thread = self._server, self._thread
+            self._server = None
+            self._thread = None
+            self._routes = {}
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=2.0)
+
+    def _start_locked(self) -> None:
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                owner._handle(self)
+
+            def do_GET(self) -> None:  # noqa: N802
+                owner._method_not_allowed(self)
+
+            def do_PUT(self) -> None:  # noqa: N802
+                owner._method_not_allowed(self)
+
+            def do_PATCH(self) -> None:  # noqa: N802
+                owner._method_not_allowed(self)
+
+            def do_DELETE(self) -> None:  # noqa: N802
+                owner._method_not_allowed(self)
+
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", self._port), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="avalanche-webhooks",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _handle(self, handler: BaseHTTPRequestHandler) -> None:
+        request_path = urlsplit(handler.path).path
+        with self._lock:
+            route = self._routes.get(request_path)
+        if route is None:
+            self._reply(handler, HTTPStatus.NOT_FOUND, {"error": "unknown webhook route"})
+            return
+        content_type = handler.headers.get("Content-Type", "")
+        if content_type.split(";", 1)[0].strip().lower() != "application/json":
+            self._reply(
+                handler,
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                {"error": "Content-Type must be application/json"},
+            )
+            return
+        try:
+            length = int(handler.headers.get("Content-Length", ""))
+        except ValueError:
+            self._reply(handler, HTTPStatus.BAD_REQUEST, {"error": "invalid Content-Length"})
+            return
+        if length < 0 or length > MAX_WEBHOOK_BODY_BYTES:
+            self._reply(
+                handler,
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                {"error": "request body too large"},
+            )
+            return
+        try:
+            body: Any = json.loads(handler.rfile.read(length))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._reply(
+                handler,
+                HTTPStatus.BAD_REQUEST,
+                {"error": "request body must be valid JSON"},
+            )
+            return
+        if not isinstance(body, dict):
+            self._reply(
+                handler,
+                HTTPStatus.BAD_REQUEST,
+                {"error": "request body must be a JSON object"},
+            )
+            return
+        try:
+            run_id = self._operator.start_run(
+                route.workflow_id, input=body, triggered_by="webhook"
+            )
+        except Exception:
+            self._reply(
+                handler,
+                HTTPStatus.CONFLICT,
+                {"error": "workflow could not be started"},
+            )
+            return
+        self._reply(handler, HTTPStatus.ACCEPTED, {"run_id": run_id})
+
+    def _method_not_allowed(self, handler: BaseHTTPRequestHandler) -> None:
+        self._reply(handler, HTTPStatus.METHOD_NOT_ALLOWED, {"error": "POST is required"})
+
+    @staticmethod
+    def _reply(
+        handler: BaseHTTPRequestHandler, status: HTTPStatus, body: dict[str, str]
+    ) -> None:
+        encoded = json.dumps(body).encode()
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(encoded)))
+        handler.end_headers()
+        handler.wfile.write(encoded)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -67,6 +67,8 @@ def test_ava_operator_delegates_to_runtime_operator_with_flows(monkeypatch):
             "127.0.0.1",
             "--port",
             "17777",
+            "--webhook-port",
+            "7434",
             "--ray",
         ]
     ]

--- a/test/operator_tests/test_operator_dev_reload.py
+++ b/test/operator_tests/test_operator_dev_reload.py
@@ -1,10 +1,12 @@
 import os
 import queue
+import signal
 import sys
 import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -96,6 +98,114 @@ def test_process_group_quiescence_distinguishes_zombies_from_live_descendants(
     )
 
     assert operator_module._coordinator_group_has_live_members(4242) is expected
+
+
+class _ExitedProcess:
+    pid = 4242
+    exitcode = 0
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+def _install_fake_teardown_clock(monkeypatch):
+    now = [0.0]
+    sleeps = []
+
+    monkeypatch.setattr(operator_module.time, "monotonic", lambda: now[0])
+
+    def sleep(duration):
+        sleeps.append(duration)
+        now[0] += duration
+
+    monkeypatch.setattr(operator_module.time, "sleep", sleep)
+    return now, sleeps
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group behavior")
+def test_teardown_waits_for_descendants_to_disappear_after_sigkill(monkeypatch):
+    _, sleeps = _install_fake_teardown_clock(monkeypatch)
+    signals = []
+    kill_checks = 0
+
+    def signal_group(_process_group, signal_number):
+        signals.append(signal_number)
+        return True
+
+    def group_has_live_members(_process_group):
+        nonlocal kill_checks
+        if signals and signals[-1] == signal.SIGKILL:
+            kill_checks += 1
+            return kill_checks == 1
+        return True
+
+    monkeypatch.setattr(operator_module, "_signal_coordinator_group", signal_group)
+    monkeypatch.setattr(
+        operator_module,
+        "_coordinator_group_has_live_members",
+        group_has_live_members,
+    )
+    monkeypatch.setattr(operator_module, "close_job", lambda _job: None)
+
+    result = operator_module._teardown_process_group(
+        cast(Any, _ExitedProcess()),
+        None,
+        term_grace=0.0,
+        kill_grace=0.1,
+    )
+
+    assert result.quiesced
+    assert signals == [signal.SIGTERM, signal.SIGKILL]
+    assert sleeps
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group behavior")
+def test_teardown_fails_closed_when_descendants_outlive_deadline(monkeypatch):
+    now, _ = _install_fake_teardown_clock(monkeypatch)
+    monkeypatch.setattr(
+        operator_module,
+        "_signal_coordinator_group",
+        lambda _process_group, _signal_number: True,
+    )
+    monkeypatch.setattr(
+        operator_module,
+        "_coordinator_group_has_live_members",
+        lambda _process_group: True,
+    )
+    monkeypatch.setattr(operator_module, "close_job", lambda _job: None)
+
+    result = operator_module._teardown_process_group(
+        cast(Any, _ExitedProcess()),
+        None,
+        term_grace=0.0,
+        kill_grace=0.05,
+    )
+
+    assert not result.quiesced
+    assert now[0] == pytest.approx(0.05)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group behavior")
+def test_process_group_permission_error_is_not_quiescence(monkeypatch):
+    def deny_process_group_access(_process_group, _signal_number):
+        raise PermissionError
+
+    monkeypatch.setattr(
+        operator_module.os,
+        "killpg",
+        deny_process_group_access,
+    )
+    monkeypatch.setattr(
+        operator_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("process table must not be consulted"),
+    )
+
+    assert operator_module._coordinator_group_exists(4242) is None
+    assert operator_module._coordinator_group_has_live_members(4242)
 
 
 def _write_standalone(root: Path, *, deferred: bool = False, body: str | None = None) -> Path:

--- a/test/operator_tests/test_scheduler.py
+++ b/test/operator_tests/test_scheduler.py
@@ -1,9 +1,8 @@
 import threading
-from types import SimpleNamespace
 
 from croniter import croniter
 
-from avalanche.operator.models import WorkflowDescriptor, WorkflowLocator
+from avalanche.operator.models import CatalogView, WorkflowDescriptor, WorkflowLocator
 from avalanche.operator.scheduler import Scheduler
 from runtime.operator.operator import Operator
 
@@ -121,10 +120,13 @@ def test_operator_refresh_serializes_catalog_publication_with_schedule_replaceme
     finish_rescan = threading.Event()
     started: list[tuple[str, str]] = []
 
-    def rescan():
+    def rescan(*, validate=None):
         catalog_published.set()
         assert finish_rescan.wait(timeout=2.0)
-        return SimpleNamespace(by_id={})
+        descriptors = ()
+        if validate is not None:
+            validate(descriptors)
+        return CatalogView()
 
     operator._registry.rescan = rescan
     operator.start_run = lambda workflow_id, triggered_by: started.append(

--- a/test/operator_tests/test_webhooks.py
+++ b/test/operator_tests/test_webhooks.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import cast
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+from avalanche import Webhook, Workflow, workflow
+from runtime.operator.models import WorkflowDescriptor, WorkflowLocator
+from runtime.operator.webhooks import WebhookServer, routes_for
+
+
+def _descriptor(
+    *, workflow_id: str = "root/reports/daily.py::shared", path: str | None = None
+) -> WorkflowDescriptor:
+    return WorkflowDescriptor(
+        workflow_id=workflow_id,
+        display_name="shared",
+        locator=WorkflowLocator("root", "reports/daily.py", "shared"),
+        node_ids=(),
+        graph=(),
+        node_types=(),
+        display_names=(),
+        webhook_enabled=True,
+        webhook_path=path,
+    )
+
+
+def test_default_routes_are_hierarchical_and_collisions_reject_the_catalog():
+    route = routes_for((_descriptor(),))
+    assert list(route) == ["/webhooks/root/reports/daily/shared"]
+
+    with pytest.raises(ValueError, match="Webhook route collision"):
+        routes_for(
+            (
+                _descriptor(path="/same"),
+                _descriptor(workflow_id="other.py::flow", path="/same"),
+            )
+        )
+
+
+def test_declaration_normalizes_bool_and_validates_configured_paths():
+    explicit = Webhook(path="/stripe/events")
+
+    def declared(value: Webhook | bool | None) -> Workflow:
+        decorator = cast(
+            Callable[[Callable[[], None]], Callable[[], Workflow]],
+            workflow(webhook=value),
+        )
+
+        def definition() -> None:
+            return None
+
+        return decorator(definition)()
+
+    assert declared(True).webhook == Webhook()
+    assert declared(False).webhook is None
+    assert declared(explicit).webhook is explicit
+    for invalid in ("relative", "//double", "/trailing/", "/../escape", "/a//b"):
+        with pytest.raises(ValueError):
+            Webhook(path=invalid)
+
+
+def test_loopback_post_accepts_json_object_and_rejects_invalid_requests():
+    class FakeOperator:
+        calls = []
+
+        def start_run(self, selector, *, input, triggered_by):
+            self.calls.append((selector, input, triggered_by))
+            return "run_webhook"
+
+    operator = FakeOperator()
+    server = WebhookServer(operator, 0)
+    routes = routes_for((_descriptor(),))
+    server.reconcile(routes)
+    try:
+        url = server.url_for("/webhooks/root/reports/daily/shared")
+        assert url is not None and url.startswith("http://127.0.0.1:")
+        request = Request(
+            f"{url}?source=test",
+            data=json.dumps({"message": "hello"}).encode(),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(request) as response:  # noqa: S310 - loopback test server
+            assert response.status == 202
+            assert json.loads(response.read()) == {"run_id": "run_webhook"}
+        assert operator.calls == [
+            ("root/reports/daily.py::shared", {"message": "hello"}, "webhook")
+        ]
+
+        server.reconcile({})
+        with pytest.raises(HTTPError) as removed_error:
+            urlopen(request)  # noqa: S310 - loopback test server
+        assert removed_error.value.code == 404
+        server.reconcile(routes)
+
+        with pytest.raises(HTTPError) as error:
+            urlopen(url)  # noqa: S310 - loopback test server
+        assert error.value.code == 405
+    finally:
+        server.close()
+    assert not server.active


### PR DESCRIPTION
## Rationale

Workflows can declare scheduled execution, but webhook-triggered execution previously required a separate management lifecycle and had no catalog-driven local operator experience. Webhook intent should live with the workflow and remain tied to its canonical discovered identity.

## Summary

- Add `Webhook` declarations and normalize `webhook=True` into the default configuration on `@workflow`.
- Carry webhook metadata through discovery and validate route collisions before atomically publishing a refreshed catalog.
- Reconcile a bounded JSON HTTP endpoint from the watched operator catalog so each declared workflow receives its posted payload as workflow input.
- Expose active webhook URL/path metadata through the operator protocol and read-only `ava webhooks list/get` commands.
- Keep lifecycle operations declarative: changing or removing the workflow declaration changes the discovered webhook state; the CLI does not add, delete, or rotate webhooks.

## POST body intake

Declare the workflow input as an `ava.BaseInput` model and enable its webhook:

```python
import avalanche as ava


class ReportRequest(ava.BaseInput):
    message: str
    priority: int = 0


@ava.source
def receive(payload: ReportRequest):
    print(payload.message, payload.priority)


@ava.workflow(input=ReportRequest, webhook=True)
def report_webhook():
    receive()
```

`ava webhooks list --connect localhost:7433` returns the generated loopback URL. A caller posts the body as JSON:

```bash
curl -i -X POST '<url-from-ava-webhooks-list>' \
  -H 'Content-Type: application/json' \
  --data '{"message":"daily report","priority":2}'
```

The endpoint accepts only `POST` requests with `Content-Type: application/json`, a valid `Content-Length`, and a top-level JSON object no larger than 1 MiB. It decodes the object and calls `Operator.start_run(..., input=body, triggered_by="webhook")`. Workflow execution constructs `ReportRequest` with Pydantic validation and injects the typed value into matching node parameters such as `payload` above.

A successfully started run returns `202` with `{"run_id": "..."}`. Malformed transport requests return `400`, `404`, `405`, `413`, or `415` as appropriate. Typed model validation occurs during workflow execution after acceptance, so a schema mismatch is reported as a failed run rather than a synchronous HTTP validation response.

The same contract and example are documented in `docs/getting-started.md`.

## Test Plan

- [x] GitHub CI run `30103098542` — lint + tests, Ray tests, and Tmux TUI tests passed
- [x] Focused post-rebase operator, webhook, gRPC, registry, scheduler, and CLI suite — 202 passed
- [x] Ruff changed-file checks
- [x] `git diff origin/main...HEAD --check`
