### PR TITLE
Add hack-night workflow workspace initializer

### DIFF
--- a/.agents/skills/avalanche-demo-init/SKILL.md
+++ b/.agents/skills/avalanche-demo-init/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: avalanche-demo-init
+description: >-
+  Initialize and verify an Avalanche workflow workspace with editable local
+  clones of Avalanche and PredictRLM under .trampoline-ai and the Avalanche
+  authoring skill installed at project scope. Use only when someone asks to set
+  up, bootstrap, or prepare a workspace; it does not design or create the
+  user's workflow.
+compatibility: >-
+  Requires Git, UV, a Node.js package runner such as npx, network access to
+  GitHub, and Python 3.11, 3.12, or 3.13.
+metadata:
+  author: Trampoline AI
+  version: "1.0"
+---
+
+# Initialize an Avalanche workflow workspace
+
+Create one standalone UV workspace containing a collection of Avalanche
+workflows. The result must work without publishing new Avalanche or PredictRLM
+releases.
+
+## Scope
+
+This skill performs workspace setup only. Do not design, propose, scaffold, or
+invoke an Avalanche workflow for the user. The bundled `binary_converter` is a
+fixed, operator-discoverable example flow, not the user's requested workflow.
+Stop after setup and static verification; creating or executing a workflow is a
+later, separate request.
+
+## Check for updates
+
+If this skill was installed through the Skills CLI, check for an update before
+initializing a workspace:
+
+```bash
+npx skills update avalanche-demo-init
+```
+
+Replace `npx` with `pnpx`, `bunx`, or the equivalent package runner in use.
+
+## Fixed outcome
+
+The initialized workspace has these properties:
+
+- it is one UV project at `./avalanche-workflows/`;
+- its workflows are direct children of `src/`, with no
+  `src/avalanche_workflows/` wrapper package;
+- it starts with the README's real `binary_converter` agent workflow;
+- `.trampoline-ai/avalanche` and `.trampoline-ai/predict-rlm` are ordinary,
+  independent Git clones;
+- UV resolves both `avalanche-ai[all]` and `predict-rlm` from those editable
+  local paths;
+- the `avalanche` authoring skill is installed from the local Avalanche clone
+  at project scope, never globally;
+- the starter contains only `flow.py` and is statically imported and checked
+  against the operator CLI without making a model call.
+
+Do not use Git submodules, Git subtree, published-package fallbacks, a separate
+`workflows/` directory, or a global skill installation. Do not initialize over
+an existing non-empty workspace or overwrite user files.
+
+## Workspace location
+
+Create `avalanche-workflows/` in the agent's current working directory. Users
+choose its placement by starting the agent in the desired parent directory. Use
+another location only when the user explicitly requests it.
+
+## Choose the starter model backend
+
+Before running the initializer, ask which model backend the user wants for the
+starter workflow. Offer these choices in this order:
+
+1. **CodexLM** — writes a DSPy `CodexLM` instance directly into the starter
+   flow, using the user's ChatGPT/Codex subscription rather than an OpenAI API
+   key. The initializer installs `predict-rlm[codex-lm]`; complete CodexLM
+   subscription authentication before a later operator execution.
+2. **OpenAI API (default)** — configures `openai/gpt-5.6-terra`. A later
+   operator execution requires `OPENAI_API_KEY`.
+3. **Other LiteLLM-compatible provider** — ask for the exact LiteLLM model
+   string and credential environment variable. The initializer writes that
+   model string into the starter flow. Provider support follows LiteLLM's
+   supported model and credential configuration.
+
+If the user does not choose, use OpenAI API. Missing credentials MUST NOT block
+workspace creation because initialization never executes a model call.
+
+## Initialize with the bundled script
+
+From the desired parent directory, invoke the command matching the selected
+backend:
+
+```bash
+# CodexLM
+python <skill-directory>/scripts/init_project.py --provider codex
+
+# OpenAI API (default)
+python <skill-directory>/scripts/init_project.py --provider openai
+
+# Other LiteLLM-compatible provider
+python <skill-directory>/scripts/init_project.py \
+  --provider other \
+  --model <provider/model> \
+  --credential-env <PROVIDER_API_KEY>
+```
+
+The script creates `./avalanche-workflows`, validates prerequisites, refuses a
+non-empty workspace, clones both framework repositories, configures editable
+sources, installs the project-scoped `avalanche` skill, writes the real
+`binary_converter` workflow and root `AGENTS.md`, synchronizes dependencies,
+and verifies every non-model boundary. Do not replace the script with manual
+setup steps or substitute PyPI dependencies.
+
+The script is intentionally non-destructive. If setup fails after it creates
+the workspace, inspect the reported failure and remove that generated directory
+only after confirming it contains no user work; then rerun the script.
+
+## Verification
+
+The script always verifies local editable imports, the project-scoped skill,
+the generated guidance, ignored nested checkouts, nested Git branches, static
+import of the sole starter `flow.py`, and availability of the `ava operator`
+and `ava run` commands. It never executes a workflow or makes a model call
+during initialization.
+
+## Handoff
+
+Report the workspace root, sole starter `flow.py` path, configured model
+backend, active branch of each nested repository, installed skill location, and
+that the operator and run commands were verified. Explain that future workflows
+are sibling directories under `src/`, while framework fixes are committed from
+the corresponding nested checkout.
+
+Tell the user to start the starter flow's local operator and TUI with:
+
+```bash
+uv run ava dev --flows src/binary_converter/
+```
+
+Stop there. Do not invoke the installed `avalanche` skill or begin a workflow
+outcome interview. On a later user request to create an Avalanche workflow, the
+workspace `AGENTS.md` directs the agent to use that installed skill.

--- a/.agents/skills/avalanche-demo-init/assets/binary_converter/flow.py
+++ b/.agents/skills/avalanche-demo-init/assets/binary_converter/flow.py
@@ -1,0 +1,29 @@
+import random
+
+import avalanche as ava
+
+# __AGENT_LM_SETUP__
+
+@ava.source
+def generate_binary() -> str:
+    length = random.randint(128, 256)
+    return "1" + "".join(random.choice("01") for _ in range(length - 1))
+
+
+@ava.agent_step(
+    ava.Signature("binary: str -> decimal: str"),
+    lm="__AGENT_LM__",
+)
+async def convert_binary(binary: str, *, agent: ava.Agent) -> str:
+    return (await agent(binary=binary)).decimal
+
+
+@ava.dest
+def print_result(result: str) -> str:
+    print(result)
+    return result
+
+
+@ava.workflow
+def binary_converter():
+    return generate_binary() >> convert_binary() >> print_result()

--- a/.agents/skills/avalanche-demo-init/references/AGENTS.md
+++ b/.agents/skills/avalanche-demo-init/references/AGENTS.md
@@ -1,0 +1,136 @@
+# Avalanche workflow workshop
+
+## Purpose
+
+This repository is one UV workspace for a collection of Avalanche workflows.
+It was created by Avalanche's `avalanche-demo-init` skill. The starter
+`binary_converter` is a real agentic workflow copied from the Avalanche README
+and statically checked during setup. Whenever a user asks to create an Avalanche
+workflow, MUST invoke the installed `avalanche` skill before implementing it.
+
+```text
+src/
+├── binary_converter/       # starter flow
+│   └── flow.py
+├── research_assistant/     # future workflow
+└── document_reviewer/      # future workflow
+```
+
+Each direct child of `src/` is one workflow. Do not add a wrapper package such
+as `src/avalanche_workflows/`, and do not create a separate `pyproject.toml`,
+virtual environment, or framework checkout for each workflow.
+
+## Starter flow
+
+`src/binary_converter/flow.py` configures **__STARTER_PROVIDER__** with
+`__STARTER_MODEL__`. It generates a random binary value and asks the configured
+model to convert it to decimal when the operator executes the flow.
+
+The workspace is created whether or not __STARTER_CREDENTIAL__ is ready. Before
+operator execution, authenticate the selected backend or configure its
+credential. Do not change providers implicitly or reuse credentials from a
+different provider.
+
+## Execution boundary
+
+Flows execute through Avalanche's operator. This workspace contains flow
+declarations only. From the workspace root, start the starter flow's local
+operator and TUI with:
+
+```bash
+uv run ava dev --flows src/binary_converter/
+```
+
+To invoke a flow from the CLI instead, start an operator:
+
+```bash
+uv run ava operator --flows src/binary_converter/ --port 7433
+```
+
+Then, in another terminal:
+
+```bash
+uv run ava run binary_converter --connect localhost:7433
+```
+
+## Workflow boundaries
+
+- Put each workflow's decorated nodes and workflow declarations in its
+  `flow.py`; declarations are the final section of that file.
+- Keep workflow builders edge-only. Runtime work belongs in nodes.
+- Add each new workflow as a sibling under `src/`. Each starter workflow needs
+  only `flow.py`; add `schema.py` or `util.py` only when its actual contract or
+  helpers require them.
+
+## Editable framework checkouts
+
+The workspace intentionally uses local editable checkouts:
+
+```text
+.trampoline-ai/
+├── avalanche/       # Avalanche workflow runtime and authoring integration
+└── predict-rlm/     # PredictRLM agent runtime used by Avalanche agent steps
+```
+
+The outer workspace ignores `.trampoline-ai/`, but each child directory is an
+ordinary independent Git repository. The checkouts are not submodules. Their
+files are editable dependencies through `pyproject.toml`, so a change in either
+checkout is used by the next workspace Python invocation without publishing a
+package release.
+
+## Framework contribution policy
+
+When a problem belongs in the local Avalanche or PredictRLM checkout, classify
+it before changing framework code.
+
+### Bugs: direct fix and pull request
+
+A bug is reproducible behavior that violates an existing contract, documented
+behavior, or established expectation. Work on the relevant local checkout:
+
+1. Identify whether the behavior belongs to Avalanche or PredictRLM.
+2. Reproduce it with a focused test or minimal command in that repository.
+3. Make the smallest correct fix and add or update behavior-level regression
+   coverage there.
+4. Run the focused verification in that checkout, plus any directly relevant
+   lint or test command.
+5. Commit from the affected nested repository, not from this outer workspace.
+6. Open a pull request against the corresponding upstream repository.
+
+A bug PR does not require a prior issue, but its description MUST name the
+reproduction, violated behavior, root cause, fix, and exact verification.
+
+### Missing features: issue first
+
+A missing capability, new API, changed behavior, or feature a user asks to add
+is a feature request, not a bug. Do not open a feature PR by default. File an
+upstream issue with the `feature request` label that explains the user need,
+proposed behavior, alternatives or constraints, and acceptance criteria.
+
+Only create a feature PR when the feature request has a linked upstream issue
+and the user explicitly asks to proceed with implementation. The PR MUST link
+to that issue and state the issue number in its description. Do not disguise a
+feature as a bug to bypass this policy.
+
+### Remote ownership
+
+Use a branch in the nested checkout. If the upstream remote is not writable,
+create or use a fork as `origin`, retain the official repository as `upstream`,
+push the branch to the fork, and open the PR to `upstream/main`. Do not wait for
+a framework release before continuing to test the workspace: the editable
+checkout already contains the fix.
+
+When a bug cannot be fixed during the workshop, file an upstream issue with a
+minimal reproduction, expected and observed behavior, environment details, and
+the affected commit SHA. Link that issue from the workspace's own notes or pull
+request as applicable.
+
+## Git ownership
+
+- Commit workspace and workflow changes from this repository.
+- Commit Avalanche changes from `.trampoline-ai/avalanche`.
+- Commit PredictRLM changes from `.trampoline-ai/predict-rlm`.
+
+Never mix those histories or commit nested-repository files into the outer
+workspace. Before reporting a framework fix as complete, verify its Git status
+and branch inside the affected checkout.

--- a/.agents/skills/avalanche-demo-init/references/starter-project.md
+++ b/.agents/skills/avalanche-demo-init/references/starter-project.md
@@ -1,0 +1,54 @@
+# Starter workspace
+
+The initializer creates one UV workspace named `avalanche-workflows` in the
+current directory. It is the home for a collection of workflows, not one
+project per workflow.
+
+```text
+avalanche-workflows/
+├── pyproject.toml
+├── uv.lock
+├── AGENTS.md
+├── .trampoline-ai/
+│   ├── avalanche/
+│   └── predict-rlm/
+└── src/
+    └── binary_converter/
+        └── flow.py
+```
+
+The only starter asset is `assets/binary_converter/flow.py`. It is the README
+quick example:
+
+```text
+generate_binary → convert_binary → print_result
+```
+
+The initializer writes the selected CodexLM, OpenAI, or LiteLLM-compatible
+backend into `flow.py` without executing it. Workflows are run through the
+Avalanche operator, never through a per-workflow runner.
+
+
+## Adding another workflow
+
+Create each subsequent workflow directly under `src/`:
+
+```text
+src/
+├── binary_converter/
+├── research_assistant/
+└── document_reviewer/
+```
+
+Each workflow starts with only `flow.py`; add `schema.py`, `util.py`, or
+substantial agent-contract directories only when the workflow actually needs
+them. Do not create a `src/avalanche_workflows/` wrapper package, a nested
+`pyproject.toml`, per-workflow local framework clones, or embedded runners.
+
+The shared workspace installs `avalanche-ai[all]`. To start a flow from the
+CLI, first start an operator, then invoke the flow through it:
+
+```bash
+uv run ava operator --flows src/binary_converter/ --port 7433
+uv run ava run binary_converter --connect localhost:7433
+```

--- a/.agents/skills/avalanche-demo-init/scripts/init_project.py
+++ b/.agents/skills/avalanche-demo-init/scripts/init_project.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Create a verified Avalanche workflow workspace from local editable checkouts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+AVALANCHE_REPOSITORY = "https://github.com/Trampoline-AI/avalanche.git"
+PREDICT_RLM_REPOSITORY = "https://github.com/Trampoline-AI/predict-rlm.git"
+WORKSPACE_NAME = "avalanche-workflows"
+STARTER_WORKFLOW_NAME = "binary_converter"
+DEFAULT_OPENAI_MODEL = "openai/gpt-5.6-terra"
+DEFAULT_CODEX_MODEL = "gpt-5.6-terra"
+ASSET_ROOT = Path(__file__).resolve().parent.parent / "assets" / STARTER_WORKFLOW_NAME
+REFERENCE_ROOT = Path(__file__).resolve().parent.parent / "references"
+
+
+@dataclass(frozen=True)
+class ProviderConfig:
+    name: str
+    model: str
+    credential_env: str | None
+    lm_setup: str
+    lm_expression: str
+    needs_codex_lm: bool
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create an Avalanche workflow workspace with editable framework checkouts."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd() / WORKSPACE_NAME,
+        help="Workspace directory. Defaults to ./avalanche-workflows.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=("codex", "openai", "other"),
+        default="openai",
+        help="Starter workflow model backend. Defaults to openai.",
+    )
+    parser.add_argument(
+        "--model",
+        help="Model slug. Required for --provider other.",
+    )
+    parser.add_argument(
+        "--credential-env",
+        help="Credential environment variable. Required for --provider other.",
+    )
+    return parser.parse_args()
+
+
+def resolve_provider(arguments: argparse.Namespace) -> ProviderConfig:
+    if arguments.provider == "codex":
+        if arguments.credential_env is not None:
+            raise ValueError("--credential-env is not used with --provider codex.")
+        model = arguments.model or DEFAULT_CODEX_MODEL
+        return ProviderConfig(
+            name="CodexLM via ChatGPT/Codex subscription",
+            model=model,
+            credential_env=None,
+            lm_setup=(
+                "from dspy_codex_lm import CodexLM\n\n"
+                f"CODEX_LM = CodexLM(model={json.dumps(model)})\n"
+            ),
+            lm_expression="CODEX_LM",
+            needs_codex_lm=True,
+        )
+
+    if arguments.provider == "openai":
+        if arguments.credential_env is not None:
+            raise ValueError("--credential-env is not used with --provider openai.")
+        model = arguments.model or DEFAULT_OPENAI_MODEL
+        return ProviderConfig(
+            name="OpenAI API",
+            model=model,
+            credential_env="OPENAI_API_KEY",
+            lm_setup="",
+            lm_expression=json.dumps(model),
+            needs_codex_lm=False,
+        )
+
+    if arguments.model is None:
+        raise ValueError("--model is required with --provider other.")
+    if arguments.credential_env is None:
+        raise ValueError("--credential-env is required with --provider other.")
+    return ProviderConfig(
+        name="LiteLLM-compatible provider",
+        model=arguments.model,
+        credential_env=arguments.credential_env,
+        lm_setup="",
+        lm_expression=json.dumps(arguments.model),
+        needs_codex_lm=False,
+    )
+
+
+def required_command(candidates: tuple[str, ...]) -> str:
+    for candidate in candidates:
+        if shutil.which(candidate) is not None:
+            return candidate
+    names = ", ".join(candidates)
+    raise RuntimeError(f"Missing required command. Install one of: {names}.")
+
+
+def run(command: list[str], *, cwd: Path, capture: bool = False) -> str:
+    print("+", " ".join(command))
+    if not capture:
+        subprocess.run(command, cwd=cwd, check=True)
+        return ""
+
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="", file=sys.stderr)
+    if completed.returncode != 0:
+        command_text = " ".join(command)
+        raise RuntimeError(
+            f"Command failed with exit status {completed.returncode}: {command_text}"
+        )
+    return completed.stdout + completed.stderr
+
+
+
+
+def ensure_empty_workspace(workspace_root: Path) -> Path:
+    resolved_root = workspace_root.expanduser().resolve()
+    if resolved_root.exists() and not resolved_root.is_dir():
+        raise ValueError(f"Workspace root is not a directory: {resolved_root}")
+    if resolved_root.exists() and any(resolved_root.iterdir()):
+        raise ValueError(f"Workspace root is not empty: {resolved_root}")
+    resolved_root.parent.mkdir(parents=True, exist_ok=True)
+    return resolved_root
+
+
+def update_python_constraint(workspace_root: Path) -> None:
+    pyproject_path = workspace_root / "pyproject.toml"
+    content = pyproject_path.read_text()
+    expected = 'requires-python = ">=3.11"'
+    if content.count(expected) != 1:
+        raise RuntimeError(f"Expected one Python requirement entry in {pyproject_path}.")
+    pyproject_path.write_text(content.replace(expected, 'requires-python = ">=3.11,<3.14"'))
+
+
+
+def add_gitignore_entry(workspace_root: Path) -> None:
+    gitignore_path = workspace_root / ".gitignore"
+    content = gitignore_path.read_text()
+    if ".trampoline-ai/" not in content.splitlines():
+        gitignore_path.write_text(f"{content.rstrip()}\n.trampoline-ai/\n")
+
+
+def write_starter_workflow(workspace_root: Path, provider: ProviderConfig) -> None:
+    workflow_root = workspace_root / "src" / STARTER_WORKFLOW_NAME
+    workflow_root.mkdir(parents=True)
+    asset_path = ASSET_ROOT / "flow.py"
+    if not asset_path.is_file():
+        raise RuntimeError(f"Starter flow asset is missing: {asset_path}")
+    content = asset_path.read_text()
+    content = content.replace("# __AGENT_LM_SETUP__\n", provider.lm_setup)
+    content = content.replace('"__AGENT_LM__"', provider.lm_expression)
+    workflow_root.joinpath("flow.py").write_text(content)
+
+
+def write_agents_guidance(workspace_root: Path, provider: ProviderConfig) -> None:
+    guidance = (REFERENCE_ROOT / "AGENTS.md").read_text()
+    guidance = guidance.replace("__STARTER_PROVIDER__", provider.name)
+    guidance = guidance.replace("__STARTER_MODEL__", provider.model)
+    guidance = guidance.replace(
+        "__STARTER_CREDENTIAL__",
+        provider.credential_env or "CodexLM subscription authentication",
+    )
+    workspace_root.joinpath("AGENTS.md").write_text(guidance)
+
+
+
+
+def verify_workspace(workspace_root: Path, package_runner: str, uv: str) -> None:
+    import_check = "\n".join(
+        [
+            "import avalanche",
+            "import predict_rlm",
+            "from pathlib import Path",
+            "checkouts = ((avalanche, '.trampoline-ai/avalanche'),",
+            "             (predict_rlm, '.trampoline-ai/predict-rlm'))",
+            "for module, relative_checkout in checkouts:",
+            "    module_path = Path(module.__file__).resolve()",
+            "    checkout_path = (Path.cwd() / relative_checkout).resolve()",
+            "    if checkout_path not in module_path.parents:",
+            "        raise RuntimeError(",
+            "            f'{module.__name__} resolved outside editable checkout: '",
+            "            f'{module_path}'",
+            "        )",
+            "    print(module_path)",
+        ]
+    )
+    run(["uv", "run", "python", "-B", "-c", import_check], cwd=workspace_root, capture=True)
+
+    flow_check = "\n".join(
+        [
+            "import importlib.util",
+            "from pathlib import Path",
+            f"flow_path = Path.cwd() / 'src/{STARTER_WORKFLOW_NAME}/flow.py'",
+            "spec = importlib.util.spec_from_file_location('starter_flow', flow_path)",
+            "if spec is None or spec.loader is None:",
+            "    raise RuntimeError(f'Cannot import starter flow: {flow_path}')",
+            "module = importlib.util.module_from_spec(spec)",
+            "spec.loader.exec_module(module)",
+            "print(flow_path)",
+        ]
+    )
+    run(["uv", "run", "python", "-B", "-c", flow_check], cwd=workspace_root, capture=True)
+    run([uv, "run", "ava", "operator", "--help"], cwd=workspace_root, capture=True)
+    run([uv, "run", "ava", "run", "--help"], cwd=workspace_root, capture=True)
+
+    run([package_runner, "--yes", "skills", "list"], cwd=workspace_root, capture=True)
+    skill_path = workspace_root / ".agents" / "skills" / "avalanche" / "SKILL.md"
+    if not skill_path.is_file():
+        raise RuntimeError("Project-scoped Avalanche skill is not installed.")
+
+    run(
+        ["git", "check-ignore", ".trampoline-ai/avalanche/pyproject.toml"],
+        cwd=workspace_root,
+    )
+    run(
+        ["git", "-C", ".trampoline-ai/avalanche", "status", "--short", "--branch"],
+        cwd=workspace_root,
+    )
+    run(
+        ["git", "-C", ".trampoline-ai/predict-rlm", "status", "--short", "--branch"],
+        cwd=workspace_root,
+    )
+
+    agents_path = workspace_root / "AGENTS.md"
+    if not agents_path.is_file():
+        raise RuntimeError("Workspace AGENTS.md is missing.")
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    provider = resolve_provider(arguments)
+    git = required_command(("git",))
+    uv = required_command(("uv",))
+    package_runner = required_command(("npx", "pnpx", "bunx"))
+    workspace_root = ensure_empty_workspace(arguments.root)
+
+    run(
+        [
+            uv,
+            "init",
+            "--bare",
+            "--name",
+            WORKSPACE_NAME,
+            "--python",
+            "3.11",
+            "--vcs",
+            "git",
+            "--no-workspace",
+            str(workspace_root),
+        ],
+        cwd=workspace_root.parent,
+    )
+    update_python_constraint(workspace_root)
+    run(
+        [git, "clone", AVALANCHE_REPOSITORY, ".trampoline-ai/avalanche"],
+        cwd=workspace_root,
+    )
+    run(
+        [git, "clone", PREDICT_RLM_REPOSITORY, ".trampoline-ai/predict-rlm"],
+        cwd=workspace_root,
+    )
+    add_gitignore_entry(workspace_root)
+    predict_rlm_add = [
+        uv,
+        "add",
+        "--editable",
+        ".trampoline-ai/predict-rlm",
+    ]
+    if provider.needs_codex_lm:
+        predict_rlm_add.extend(["--extra", "codex-lm"])
+    predict_rlm_add.append("--no-sync")
+    run(predict_rlm_add, cwd=workspace_root)
+    run(
+        [
+            uv,
+            "add",
+            "--editable",
+            ".trampoline-ai/avalanche",
+            "--extra",
+            "all",
+            "--no-sync",
+        ],
+        cwd=workspace_root,
+    )
+    run(
+        [
+            package_runner,
+            "--yes",
+            "skills",
+            "add",
+            "./.trampoline-ai/avalanche",
+            "--skill",
+            "avalanche",
+            "--yes",
+        ],
+        cwd=workspace_root,
+    )
+    write_starter_workflow(workspace_root, provider)
+    write_agents_guidance(workspace_root, provider)
+    run([uv, "sync"], cwd=workspace_root)
+    verify_workspace(workspace_root, package_runner, uv)
+    print(f"Initialized and verified {workspace_root} with {provider.name}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Give your coding agent Avalanche's workflow-authoring skill:
 npx skills add Trampoline-AI/avalanche
 ```
 
+### Workshop project setup
+
+Create a project with editable local checkouts of Avalanche and PredictRLM:
+
+```bash
+npx skills add https://github.com/Trampoline-AI/avalanche/tree/main/.agents/skills/avalanche-demo-init
+```
+
 
 
 ### Quick Example


### PR DESCRIPTION
## Rationale
Hack-night participants need a self-contained Avalanche workspace that uses editable local Avalanche and PredictRLM checkouts, supports framework contributions without package releases, and provides a consistent local operator/TUI startup path.

## Summary
- Add the project-scoped `avalanche-demo-init` skill and deterministic initializer.
- Create editable `.trampoline-ai` checkouts, install `avalanche-ai[all]`, and install the Avalanche authoring skill locally.
- Generate an operator-only starter flow with selectable CodexLM, OpenAI, or LiteLLM-compatible model configuration.
- Add workspace and contribution guidance for nested framework repositories.

## Test Plan
- [x] `env -u OPENAI_API_KEY python3 .agents/skills/avalanche-demo-init/scripts/init_project.py --root /tmp/avalanche-workflows-clean-test --provider openai`
- [x] `uv run ruff check .agents/skills/avalanche-demo-init/scripts/init_project.py .agents/skills/avalanche-demo-init/assets`
- [x] `make lint`