### PR TITLE
fix(operator): seal captured output before success

### DIFF
--- a/src/runtime/operator/run_worker.py
+++ b/src/runtime/operator/run_worker.py
@@ -100,6 +100,7 @@ def _run_worker(
     result_bundle_identity: tuple[int, int],
 ) -> None:
     """Import/build exactly once, prepare, wait for the parent, and execute."""
+    event_queue = _SealableEventQueue(event_queue)
     if os.name != "nt":
         try:
             os.setsid()
@@ -286,8 +287,14 @@ def _run_worker(
                     ray.shutdown()
             except Exception:
                 pass
+        # The terminal success event is a protocol boundary: the operator
+        # quiesces the coordinator and rejects every event observed after it.
+        # Flush partial captured output first so interpreter shutdown cannot
+        # turn pre-terminal output into a late protocol event.
+        stdout.flush()
+        stderr.flush()
         if terminal_event is not None:
-            _put_run_event(event_queue, terminal_event)
+            _put_terminal_run_event(event_queue, terminal_event)
 
 
 def _import_workflow_module(root: Path, relative_file: str):
@@ -328,6 +335,27 @@ def _workflow_metadata(workflow: Workflow) -> dict[str, Any]:
         },
         "display_names": {node_id: display_name_from_id(node_id) for node_id in node_ids},
     }
+
+
+class _SealableEventQueue:
+    """Serialize the terminal event and reject asynchronous writes after it."""
+
+    def __init__(self, event_queue: Any) -> None:
+        self._event_queue = event_queue
+        self._lock = threading.Lock()
+        self._sealed = False
+
+    def put(self, event: dict[str, Any]) -> None:
+        with self._lock:
+            if not self._sealed:
+                self._event_queue.put(event)
+
+    def put_terminal(self, event: dict[str, Any]) -> None:
+        with self._lock:
+            if self._sealed:
+                raise RuntimeError("coordinator event queue is already terminal")
+            self._event_queue.put(event)
+            self._sealed = True
 
 
 def _install_log_capture(event_queue: Any) -> None:
@@ -590,6 +618,16 @@ def _put_run_event(event_queue: Any, event: dict[str, Any]) -> None:
 
     _validate_run_event(event)
     event_queue.put(event)
+
+
+def _put_terminal_run_event(
+    event_queue: _SealableEventQueue,
+    event: dict[str, Any],
+) -> None:
+    from .operator import _validate_run_event
+
+    _validate_run_event(event)
+    event_queue.put_terminal(event)
 
 
 def _bounded_event_text(value: object, maximum_length: int) -> str:

--- a/test/operator_tests/test_workflow_results.py
+++ b/test/operator_tests/test_workflow_results.py
@@ -1657,6 +1657,98 @@ def test_valid_success_is_accepted_only_after_quiescence(monkeypatch):
         operator.close()
 
 
+def test_worker_flushes_partial_stream_output_before_provisional_success(tmp_path):
+    workflow_path = tmp_path / "partial_stream_output.py"
+    workflow_path.write_text(
+        """
+import avalanche as ava
+
+print("partial import output", end="")
+
+
+@ava.source
+def value():
+    return "complete"
+
+
+@ava.workflow
+def partial_stream_output():
+    return value()
+"""
+    )
+    operator = Operator([str(workflow_path)], watch=False, schedule=False)
+    try:
+        run_id = operator.start_run("partial_stream_output")
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            run = operator.get_run(run_id)
+            if run is not None and run.status in {
+                RunStatus.SUCCESS,
+                RunStatus.FAILED,
+                RunStatus.CANCELLED,
+            }:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("Run did not become terminal")
+
+        assert run.status == RunStatus.SUCCESS
+        assert operator.get_run_result(run_id) == "complete"
+        assert any(entry.message == "partial import output" for entry in run.logs)
+    finally:
+        operator.close()
+
+
+def test_worker_seals_asynchronous_output_after_provisional_success(tmp_path):
+    workflow_path = tmp_path / "asynchronous_stream_output.py"
+    workflow_path.write_text(
+        """
+import threading
+import time
+
+import avalanche as ava
+
+
+@ava.source
+def value():
+    def delayed_output():
+        time.sleep(0.2)
+        print("background output after result")
+
+    threading.Thread(target=delayed_output).start()
+    return "complete"
+
+
+@ava.workflow
+def asynchronous_stream_output():
+    return value()
+"""
+    )
+    operator = Operator([str(workflow_path)], watch=False, schedule=False)
+    try:
+        run_id = operator.start_run("asynchronous_stream_output")
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            run = operator.get_run(run_id)
+            if run is not None and run.status in {
+                RunStatus.SUCCESS,
+                RunStatus.FAILED,
+                RunStatus.CANCELLED,
+            }:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("Run did not become terminal")
+
+        assert run.status == RunStatus.SUCCESS
+        assert operator.get_run_result(run_id) == "complete"
+        assert all(
+            entry.message != "background output after result" for entry in run.logs
+        )
+    finally:
+        operator.close()
+
+
 def test_operator_and_grpc_roundtrip_existing_json_result(result_client):
     operator, client = result_client
     run_id = client.start_run("json_result")


### PR DESCRIPTION
## Rationale

An operator-executed 13-node agent workflow completed every node successfully, including its final destination, but the run was marked failed with `coordinator emitted an event after provisional success`.

The coordinator captures logs plus stdout and stderr on a multiprocessing queue. Partial output could remain buffered until interpreter shutdown, and background library threads could still log after the workflow result was ready. In both cases the worker published provisional success first, so a later observational event violated the terminal protocol even though workflow execution and result publication had succeeded.

## Summary

- Flush partial captured stdout and stderr before publishing the terminal event.
- Serialize event writes behind a thread-safe gate and atomically seal the worker-side event producer when the terminal event is queued.
- Drop asynchronous observational writes after terminal while retaining the operator's existing fail-closed check for any actual post-terminal event received from a faulty coordinator.
- Keep provisional-result quiescence and result-integrity verification unchanged.
- Add behavior-level regressions for both partial buffered output and a delayed background-thread write.

## Test Plan

- [x] `uv run pytest test/operator_tests/test_workflow_results.py -q -k 'provisional_success or valid_success or worker_flushes or worker_seals'`
- [x] `uv run pytest test/operator_tests/test_workflow_results.py -q` (96 passed)
- [x] `uv run ruff check src/runtime/operator/run_worker.py test/operator_tests/test_workflow_results.py`
