### PR TITLE
ci(release): publish avalanche-ai to PyPI on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,37 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
 
 permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build distributions
+  validate:
+    name: Validate tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
+      - name: Verify tag is on main
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+
+          # Skip ancestry check for prerelease tags (e.g., v1.2.3-rc.1)
+          if [[ "$TAG" == *"-"* ]]; then
+            echo "::notice title=Ancestry check skipped::Prerelease tag '$TAG', skipping main ancestry check."
+            exit 0
+          fi
+
+          git fetch origin main
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag '$TAG' is a valid commit on main"
+          else
+            echo "::error::Tag '$TAG' is not on main. Ensure the tagged commit is on the main branch."
+            exit 1
+          fi
       - name: Verify tag matches package version
         env:
           TAG: ${{ github.ref_name }}
@@ -31,6 +50,14 @@ jobs:
           kind = "pre-release" if Version(pkg).is_prerelease else "release"
           print(f"Tag v{tag} matches pyproject version ({kind})")
           EOF
+
+  build:
+    name: Build distributions
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v5
       - name: Build sdist and wheel
         run: uv build
       - name: Upload distributions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Verify tag matches package version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          uv run --no-project --with packaging python - <<'EOF'
+          import os, sys, tomllib
+          from packaging.version import Version
+
+          tag = os.environ["TAG"].removeprefix("v")
+          pkg = tomllib.load(open("pyproject.toml", "rb"))["project"]["version"]
+          if Version(tag) != Version(pkg):
+              print(f"::error::Tag v{tag} does not match pyproject version {pkg}")
+              sys.exit(1)
+          kind = "pre-release" if Version(pkg).is_prerelease else "release"
+          print(f"Tag v{tag} matches pyproject version ({kind})")
+          EOF
+      - name: Build sdist and wheel
+        run: uv build
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Rationale
Releasing `avalanche-ai` to PyPI is currently a manual, unversioned process. This adds a tag-triggered release workflow so every published artifact is built from the exact tagged commit, and uses PyPI trusted publishing (OIDC) so no long-lived API token is stored in repo secrets.

## Summary
- Adds `.github/workflows/release.yml`, triggered on `v*.*.*` tags, with three jobs: `validate` → `build` → `publish`.
- Validate job: verifies the tagged commit is an ancestor of `origin/main` (skipped for hyphenated prerelease tags, e.g. `v1.2.3-rc.1`), then checks the tag version matches `pyproject.toml` using PEP 440-aware comparison (`packaging.version`), so pre-release tags like `v0.1.0rc2` are supported; fails closed on version mismatch or invalid version strings.
- Build job: builds sdist + wheel with `uv build` and uploads them as an artifact.
- Publish job: downloads the artifact and publishes with `pypa/gh-action-pypi-publish` via OIDC trusted publishing (`id-token: write`, no stored token). No GitHub environment required — the PyPI trusted publisher is configured with environment "(Any)" for repo `Trampoline-AI/avalanche`, workflow `release.yml`.

## Test Plan
- [x] YAML parses; job graph `validate` → `build` → `publish` correct.
- [x] Executed the embedded ancestry check against real refs: prerelease tag skips with notice, tag on main passes, tag off main fails closed.
- [x] Executed the embedded version-check script: rc tag match (pass, reports "pre-release"), final tag match (pass, reports "release"), tag/version mismatch (fails closed), invalid version string (fails closed via `InvalidVersion`).
- [ ] End-to-end publish: after merge, tag `v0.1.0rc3` (or next version) and confirm the workflow publishes to PyPI.