### PR TITLE
ci(release): gate PyPI publish behind pypi environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/avalanche-ai
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Rationale
Follow-up to #40 (merged while this was in review). The in-workflow ancestry check verifies tags are on main, but the stronger, declarative control is platform-level: GitHub environment protection. This makes releases originate only from maintainer actions, enforced by GitHub before the publish job starts rather than by shell checks inside it.

## Summary
- The `publish` job now runs in the `pypi` environment (`environment: pypi`, with the PyPI project URL surfaced on the job).
- Repo settings configured to match (already applied, no code change needed):
  - `pypi` environment: required reviewers `magix022` and `glesperance` — a maintainer must approve every publish before it runs.
  - `pypi` deployment policy: only tag refs matching `v*` may deploy to the environment.
  - Pre-existing `protect release tags` ruleset: only org admins / repo admin+maintain roles can create, update, or delete `v*` tags.
- The PyPI trusted publisher is configured with environment "(Any)", so the `environment: pypi` OIDC claim matches without PyPI-side changes.
- The `validate` job's ancestry check stays as defense-in-depth: the environment policy restricts ref names, not commit ancestry.

## Test Plan
- [x] Verified via API: `pypi` environment exists with required reviewers `magix022`, `glesperance` and deployment policy `v*` (type: tag).
- [x] Verified via API: `protect release tags` ruleset active on `refs/tags/v*` with creation/update/deletion restricted to admin/maintain roles.
- [x] Workflow YAML parses; publish job carries `environment: pypi`; job graph `validate` → `build` → `publish` unchanged.
- [ ] First release: publish job shows "Waiting for approval" from a maintainer, then publishes after approval.