### PR TITLE
test: speed up full local suite execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 .PHONY: test test-cov test-cov-html lint format precommit-check check smoke-test tui-bench proto brand install clean web-assets-check web-lint web-format web-format-check web-test web-bench
+PYTEST_WORKERS ?= 4
 
-# Run tests with every supported executor/storage extra installed.
+
+# Run ordinary tests concurrently; Ray and tmux own process-global resources.
 test:
-	uv run --all-extras pytest
+	uv run --all-extras pytest -n $(PYTEST_WORKERS) -m "not ray and not tmux"
+	uv run --all-extras pytest -m ray
+	uv run --all-extras pytest -m tmux
 
 # Run tests with coverage report
 test-cov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "predict-rlm>=0.8.0",
     "marimo>=0.23.9,<0.24",
     "pre-commit>=4,<5",
+    "pytest-xdist>=3.6,<4",
 ]
 examples = [
     "openpyxl>=3.1,<4",

--- a/test/rerun_test.py
+++ b/test/rerun_test.py
@@ -57,6 +57,30 @@ EXECUTOR_FACTORIES = [
     pytest.param(ava.RayExecutor, marks=pytest.mark.ray),
 ]
 
+@pytest.fixture(scope="module")
+def _shared_ray_runtime():
+    ray = pytest.importorskip("ray")
+    owns_runtime = not ray.is_initialized()
+    if owns_runtime:
+        ray.init(num_cpus=2, include_dashboard=False)
+    try:
+        yield ray
+    finally:
+        if owns_runtime and ray.is_initialized():
+            ray.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def _reuse_shared_ray_runtime_for_parametrized_contracts(request, monkeypatch):
+    if request.node.get_closest_marker("ray") is None:
+        return
+    ray = request.getfixturevalue("_shared_ray_runtime")
+
+    def defer_shutdown() -> None:
+        """Keep the module-owned runtime available to later contract cases."""
+
+    monkeypatch.setattr(ray, "shutdown", defer_shutdown)
+
 
 class RowSchema(dy.Schema):
     id = dy.Int64(nullable=False)

--- a/test/tui_test.py
+++ b/test/tui_test.py
@@ -4369,25 +4369,25 @@ class TestInteractions:
             dag_scroll._on_mouse_scroll_left(pointer_event(MouseScrollLeft))
             assert dag_scroll.scroll_target_x == 8
 
-            await pilot.pause(0.12)
+            await pilot.wait_for_animation()
             assert dag_scroll.scroll_x == pytest.approx(8)
 
             dag_scroll._on_mouse_scroll_down(pointer_event(MouseScrollDown))
             assert dag_scroll.scroll_target_y == 3
 
-            await pilot.pause(0.12)
+            await pilot.wait_for_animation()
             assert dag_scroll.scroll_y == pytest.approx(3)
 
             dag_scroll._on_mouse_scroll_down(pointer_event(MouseScrollDown, shift=True))
             assert dag_scroll.scroll_target_x == 16
 
-            await pilot.pause(0.12)
+            await pilot.wait_for_animation()
             assert dag_scroll.scroll_x == pytest.approx(16)
 
             dag_scroll._on_mouse_scroll_up(pointer_event(MouseScrollUp, ctrl=True))
             assert dag_scroll.scroll_target_x == 8
 
-            await pilot.pause(0.12)
+            await pilot.wait_for_animation()
             assert dag_scroll.scroll_x == pytest.approx(8)
 
             dag_scroll._scroll_to(x=0, y=0, animate=False)
@@ -5387,6 +5387,7 @@ async def test_trace_hydration_persistent_failure_uses_bounded_backoff():
     clock = [0.0]
     calls = []
     completed_attempts = []
+    completion_enqueued = threading.Event()
 
     def hydrate_trace(run_id, node_id):
         calls.append((run_id, node_id, clock[0]))
@@ -5399,41 +5400,47 @@ async def test_trace_hydration_persistent_failure_uses_bounded_backoff():
     app = AvalancheApp(provider=provider, workflow="agent_flow", node="agent")
     app._trace_hydration_now = lambda: clock[0]
     key = ("run-agent", "agent_1", 1)
+    enqueue_completion = app.store.enqueue_trace_hydration_completion
 
-    async def wait_for_retry(pilot, level, call_count, after_deadline):
-        for _ in range(40):
-            await pilot.pause()
-            retry = app._trace_hydration_retry.get(key)
-            if (
-                len(calls) == call_count
-                and len(completed_attempts) == call_count
-                and retry is not None
-                and retry[0] == level
-                and retry[1] > after_deadline
-            ):
-                return retry
-        raise AssertionError(f"retry level {level} was not observed")
+    def signal_completion(completion):
+        enqueue_completion(completion)
+        completion_enqueued.set()
+
+    app.store.enqueue_trace_hydration_completion = signal_completion
+
+    async def wait_for_retry(level, call_count, after_deadline):
+        assert await asyncio.to_thread(completion_enqueued.wait, 1)
+        completion_enqueued.clear()
+        app._tick()
+        retry = app._trace_hydration_retry.get(key)
+        assert (
+            len(calls) == call_count
+            and len(completed_attempts) == call_count
+            and retry is not None
+            and retry[0] == level
+            and retry[1] > after_deadline
+        ), f"retry level {level} was not observed"
+        return retry
 
     updates = _signal_background_updates(app.store)
     async with app.run_test(size=(100, 35)) as pilot:
         await pilot.pause()
         await _wait_for_current_run(app, updates)
         await pilot.press("enter")
-        retry = await wait_for_retry(pilot, 1, 1, clock[0])
+        retry = await wait_for_retry(1, 1, clock[0])
         assert retry == (1, 0.25)
 
-        for _ in range(20):
-            await pilot.pause()
+        app._tick()
         assert len(calls) == 1
 
         expected_levels = (2, 3, 4, 5, 5)
         for call_count, level in enumerate(expected_levels, start=2):
             clock[0] = app._trace_hydration_retry[key][1]
-            retry = await wait_for_retry(pilot, level, call_count, clock[0])
+            app._tick()
+            retry = await wait_for_retry(level, call_count, clock[0])
         assert retry[1] - clock[0] == 4.0
 
-        for _ in range(20):
-            await pilot.pause()
+        app._tick()
         assert len(calls) == 6
 
 
@@ -5581,18 +5588,10 @@ async def test_trace_hydration_tab_cycles_bound_blocked_worker_and_keep_backoff(
         await pilot.pause()
         await _wait_for_current_run(app, updates)
         await pilot.press("enter")
-        for _ in range(20):
-            if started.is_set():
-                break
-            await pilot.pause()
-        assert started.is_set()
+        assert await asyncio.to_thread(started.wait, 1)
 
         attempt = app._trace_hydration_attempts[key]
-        for _ in range(8):
-            await pilot.press("left")
-            await pilot.pause()
-            await pilot.press("right")
-            await pilot.pause()
+        await pilot.press(*(("left", "right") * 8))
 
         with lock:
             assert calls == 1
@@ -5604,22 +5603,14 @@ async def test_trace_hydration_tab_cycles_bound_blocked_worker_and_keep_backoff(
 
         release.set()
         await asyncio.to_thread(worker_done.wait)
-        retry = None
-        for _ in range(40):
-            await pilot.pause()
-            retry = app._trace_hydration_retry.get(key)
-            if retry is not None:
-                break
+        app._tick()
+        retry = app._trace_hydration_retry.get(key)
         assert retry == (1, 100.25)
         assert key not in app._trace_hydration_in_flight
         assert app._trace_hydration_attempts == {}
         assert attempt not in app._trace_hydration_superseded
 
-        await pilot.press("left")
-        await pilot.pause()
-        await pilot.press("right")
-        for _ in range(5):
-            await pilot.pause()
+        await pilot.press("left", "right")
         assert app._trace_hydration_retry[key] == retry
         assert calls == 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -247,6 +247,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-testdox" },
+    { name = "pytest-xdist" },
     { name = "ray", extra = ["default"] },
     { name = "ruff" },
     { name = "s3fs" },
@@ -289,6 +290,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.8,<0.24" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-testdox", specifier = ">=3.1.0,<4" },
+    { name = "pytest-xdist", specifier = ">=3.6,<4" },
     { name = "ray", extras = ["default"], specifier = ">=2.50.0" },
     { name = "ruff", specifier = ">=0.5.6,<0.6" },
     { name = "s3fs", specifier = ">=2023.12.2,<2024" },
@@ -783,6 +785,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -2918,6 +2929,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/32/d833d70c7b30994c593d721001ab218f02baee4f6d5be322e9ba3f7f77c0/pytest-testdox-3.1.0.tar.gz", hash = "sha256:f48c49c517f0fb926560b383062db4961112078ec6ca555f91692c661bb5c765", size = 8917, upload-time = "2023-07-22T03:42:47.476Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/8c/515ff4ab03b744b00f1283455ff189537082a16f62aa5ace6171f4cb5aea/pytest_testdox-3.1.0-py2.py3-none-any.whl", hash = "sha256:f3a8f0789d668ccfb60f15aab81fb927b75066cfd19209176166bd7cecae73e6", size = 9041, upload-time = "2023-07-22T03:42:46.069Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Rationale
The full suite had become slow to iterate on because ordinary tests ran serially and the rerun contract matrix repeatedly started local Ray runtimes.

## Summary
- Run ordinary tests across four pytest-xdist workers through `make test` (and `make precommit-check`) only. CI remains unchanged: its ordinary-test invocation stays serial.
- Keep Ray and tmux partitions serial in `make test` because they own process-global resources.
- Reuse one module-scoped Ray runtime for rerun contract variants.
- Replace polling and wall-clock waits in selected Textual tests with event and animation synchronization.

## Test Plan
- [x] `make lint`
- [x] `uv lock --check`
- [x] `make test`