### PR TITLE
fix(operator): preserve discovery imports and configure timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,10 @@ Avoid `--flows .`: operator discovery imports Python files recursively. Use a na
   duplicate labels in tests merely to locate UI.
 - Iterate with the smallest focused tests that cover the current feature or fix;
   never use the full regression suite as the iteration loop.
-- After all focused tests are green, run the full regression suite once as the
-  final verification gate. If that gate finds a regression, return to the
-  focused failing tests and iterate there until they are green, then use the
-  full suite only for the next final verification attempt.
+- `make test` is an exceptional validation gate, not a default final step. Do
+  not run it for ordinary bug fixes or new features; CI covers broad
+  regressions. Run it only for an explicitly requested or approved large-scale
+  refactor or migration.
 - TUI behavior normally needs both headless Textual coverage (`test/tui_test.py`) and tmux coverage (`test/tui_tmux_test.py`) when terminal rendering, sizing, or input behavior changes.
 - CI installs all extras, runs Ruff, then separates ordinary tests (`not tmux and not ray`), Ray tests, and tmux tests into distinct jobs.
 - Branch coverage is configured for `src/avalanche`; `make test-cov` reports missing lines. Do not treat a focused green test as proof for unrelated runtime, Ray, or tmux paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Operator discovery
+
+- Source discovery no longer unloads dependencies imported from excluded
+  directories such as a project-local `.venv`, avoiding duplicate native-module
+  load failures while scanning workflows.
+- `ava operator` and `ava dev` now accept `--discovery-timeout SECONDS` for one
+  discovery scan. The positive, finite limit defaults to 60 seconds, up from 15.
+- Discovery now logs a warning when its deadline expires and incomplete results
+  are discarded.
+
 ## 0.1.2
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ uv run ava dev --flows ./flow.py
 
 Otherwise, the scan defaults to the current working directory.
 
+Discovery allows 60 seconds per scan by default. Pass `--discovery-timeout SECONDS`
+to `ava operator` or `ava dev` to set a different positive, finite limit.
+
 > [!WARNING]
 > `ava dev` or `ava operator` without `--flows` scans every eligible Python file below the current
 > working directory. Run it only from a dedicated flow workspace; otherwise pass

--- a/src/ava_cli/app.py
+++ b/src/ava_cli/app.py
@@ -20,6 +20,8 @@ from importlib.resources import as_file, files
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
+from runtime.operator.discovery import DEFAULT_DISCOVERY_TIMEOUT, validate_discovery_timeout
+
 _RENAME_NOREPLACE = 1
 _RENAME_EXCL = 0x00000004
 _STAGED_OUTPUT_NAME = "result"
@@ -33,6 +35,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(list(argv) if argv is not None else None)
     if args.command == "dev" and args.port == args.web_port:
         parser.error("ava dev --port and --web-port must differ")
+    if args.command in {"dev", "operator"}:
+        try:
+            validate_discovery_timeout(args.discovery_timeout)
+        except ValueError as exc:
+            parser.error(str(exc))
     if not hasattr(args, "handler"):
         parser.print_help()
         return 2
@@ -89,6 +96,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="terminal log level (default: WARNING)",
     )
     operator.add_argument("--ray", action="store_true", help="use the Ray executor")
+    operator.add_argument(
+        "--discovery-timeout",
+        type=float,
+        default=DEFAULT_DISCOVERY_TIMEOUT,
+        metavar="SECONDS",
+        help=f"maximum seconds for one discovery scan (default: {DEFAULT_DISCOVERY_TIMEOUT:g})",
+    )
     operator.set_defaults(handler=_run_operator)
 
     webhooks = subcommands.add_parser("webhooks", help="inspect local webhook routes")
@@ -234,6 +248,13 @@ def _build_parser() -> argparse.ArgumentParser:
     dev.add_argument("--port", type=int, default=7433, help="operator gRPC port")
     dev.add_argument("--web-port", type=int, default=7435, help="browser UI HTTP port")
     dev.add_argument("--ray", action="store_true", help="use the Ray executor")
+    dev.add_argument(
+        "--discovery-timeout",
+        type=float,
+        default=DEFAULT_DISCOVERY_TIMEOUT,
+        metavar="SECONDS",
+        help=f"maximum seconds for one discovery scan (default: {DEFAULT_DISCOVERY_TIMEOUT:g})",
+    )
     dev.set_defaults(handler=_run_dev)
 
     return parser
@@ -263,6 +284,8 @@ def _run_operator(args: argparse.Namespace) -> int:
         str(args.webhook_port),
         "--log-level",
         args.log_level,
+        "--discovery-timeout",
+        str(args.discovery_timeout),
     ]
     if args.ray:
         runtime_args.append("--ray")
@@ -1362,7 +1385,9 @@ def _launch_tui(argv: Sequence[str]) -> None:
 def _run_dev(args: argparse.Namespace) -> int:
     port = args.port
     web_port = args.web_port
-    operator_process = _start_operator_process(args.flows, port, args.ray)
+    operator_process = _start_operator_process(
+        args.flows, port, args.ray, args.discovery_timeout
+    )
     web_process = None
     try:
         web_process = _start_web_process(f"127.0.0.1:{port}", web_port)
@@ -1377,6 +1402,7 @@ def _start_operator_process(
     flows: list[str],
     port: int,
     use_ray: bool,
+    discovery_timeout: float,
 ) -> subprocess.Popen:
     cmd = [
         sys.executable,
@@ -1386,6 +1412,8 @@ def _start_operator_process(
         *flows,
         "--port",
         str(port),
+        "--discovery-timeout",
+        str(discovery_timeout),
     ]
     if use_ray:
         cmd.append("--ray")

--- a/src/runtime/operator/__main__.py
+++ b/src/runtime/operator/__main__.py
@@ -6,6 +6,8 @@ import argparse
 import logging
 from collections.abc import Sequence
 
+from .discovery import DEFAULT_DISCOVERY_TIMEOUT, validate_discovery_timeout
+
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
@@ -34,6 +36,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument("--ray", action="store_true", help="use the Ray executor")
     parser.add_argument(
+        "--discovery-timeout",
+        type=float,
+        default=DEFAULT_DISCOVERY_TIMEOUT,
+        metavar="SECONDS",
+        help=f"maximum seconds for one discovery scan (default: {DEFAULT_DISCOVERY_TIMEOUT:g})",
+    )
+    parser.add_argument(
         "--log-level",
         type=str.upper,
         choices=("DEBUG", "INFO", "WARNING", "ERROR"),
@@ -41,6 +50,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="terminal log level (default: WARNING)",
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        validate_discovery_timeout(args.discovery_timeout)
+    except ValueError as exc:
+        parser.error(str(exc))
     logging.basicConfig(
         level=getattr(logging, args.log_level),
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
@@ -61,6 +74,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         port=args.port,
         host=args.host,
         webhook_port=args.webhook_port,
+        discovery_timeout=args.discovery_timeout,
         executor_backend="ray" if args.ray else "local",
     )
     return 0

--- a/src/runtime/operator/discovery.py
+++ b/src/runtime/operator/discovery.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib
 import importlib.util
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -29,6 +30,8 @@ from .models import (
 )
 from .source_policy import is_excluded_directory, is_path_in_excluded_directory
 from .windows_job import WindowsJob, assign_process, close_job, create_kill_on_close_job
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -146,6 +149,11 @@ def discover_files(
                 try:
                     process.wait(timeout=timeout)
                 except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "Workflow discovery timed out after %.1fs; "
+                        "incomplete scan results were discarded",
+                        timeout,
+                    )
                     return (), (_discovery_failure(f"Discovery exceeded {timeout:.1f}s"),)
                 finally:
                     _terminate_discovery_process(process, windows_job)

--- a/src/runtime/operator/discovery.py
+++ b/src/runtime/operator/discovery.py
@@ -27,7 +27,7 @@ from .models import (
     WorkflowLocator,
     display_name_from_id,
 )
-from .source_policy import is_excluded_directory
+from .source_policy import is_excluded_directory, is_path_in_excluded_directory
 from .windows_job import WindowsJob, assign_process, close_job, create_kill_on_close_job
 
 
@@ -341,7 +341,7 @@ def _purge_modules_under(root: Path) -> None:
         if module_file is None:
             continue
         path = _module_path_under(module_file, (root,))
-        if path is not None:
+        if path is not None and not is_path_in_excluded_directory(path.relative_to(root)):
             sys.modules.pop(module_name, None)
 
 

--- a/src/runtime/operator/discovery.py
+++ b/src/runtime/operator/discovery.py
@@ -7,6 +7,7 @@ import importlib
 import importlib.util
 import json
 import logging
+import math
 import os
 import subprocess
 import sys
@@ -52,8 +53,14 @@ class FileDiscoveryResult:
     dependencies: tuple[Path, ...]
 
 
-DEFAULT_DISCOVERY_TIMEOUT = 15.0
+DEFAULT_DISCOVERY_TIMEOUT = 60.0
 _DISCOVERY_TERMINATE_GRACE = 1.0
+
+
+def validate_discovery_timeout(timeout: float) -> None:
+    """Raise when a discovery timeout cannot bound one scan."""
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("Discovery timeout must be positive and finite")
 
 
 def configure_roots(paths: list[str]) -> tuple[ConfiguredRoot, ...]:
@@ -113,8 +120,7 @@ def discover_files(
             else None
         ),
     }
-    if timeout <= 0:
-        raise ValueError("Discovery timeout must be positive")
+    validate_discovery_timeout(timeout)
     with tempfile.TemporaryDirectory(prefix="avalanche-discovery-") as temp_dir:
         temp = Path(temp_dir)
         payload_path = temp / "request.json"

--- a/src/runtime/operator/operator.py
+++ b/src/runtime/operator/operator.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Literal, TypeAlias
 from uuid import uuid4
 
 from ..executor import LocalExecutor, RayExecutor
+from .discovery import DEFAULT_DISCOVERY_TIMEOUT
 from .models import (
     AgentEvent,
     AgentEventAppended,
@@ -245,7 +246,7 @@ class Operator:
         ray_runtime_env: Mapping[str, Any] | None = None,
         ray_init_kwargs: Mapping[str, Any] | None = None,
         prepare_timeout: float = 15.0,
-        discovery_timeout: float = 15.0,
+        discovery_timeout: float = DEFAULT_DISCOVERY_TIMEOUT,
         cancel_grace: float = 5.0,
         stream_history_capacity: int = STREAM_HISTORY_CAPACITY,
         result_storage_directory: str | os.PathLike[str] | None = None,

--- a/src/runtime/operator/registry.py
+++ b/src/runtime/operator/registry.py
@@ -15,12 +15,14 @@ from typing import Callable
 from avalanche.dag import Workflow
 
 from .discovery import (
+    DEFAULT_DISCOVERY_TIMEOUT,
     ConfiguredRoot,
     FileDiscoveryResult,
     candidate_files,
     configure_roots,
     discover_files,
     load_builder,
+    validate_discovery_timeout,
 )
 from .discovery_cache import DiscoveryCache
 from .models import (
@@ -164,9 +166,10 @@ class WorkflowRegistry:
     def __init__(
         self,
         *,
-        discovery_timeout: float = 15.0,
+        discovery_timeout: float = DEFAULT_DISCOVERY_TIMEOUT,
         cache_dir: Path | None = None,
     ) -> None:
+        validate_discovery_timeout(discovery_timeout)
         self._lock = threading.Lock()
         self._view = CatalogView()
         self._scan_paths: tuple[str, ...] = ()

--- a/src/runtime/operator/source.py
+++ b/src/runtime/operator/source.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from .discovery import ConfiguredRoot
 from .models import WorkflowLocator
-from .source_policy import is_excluded_directory
+from .source_policy import is_excluded_directory, is_path_in_excluded_directory
 
 _CREDENTIAL_NAMES = {
     ".npmrc",
@@ -140,7 +140,7 @@ def _included_source_path(
     if containing_root is None:
         return None
     relative = candidate.relative_to(containing_root)
-    if not relative.parts or any(is_excluded_directory(part) for part in relative.parts[:-1]):
+    if not relative.parts or is_path_in_excluded_directory(relative):
         return None
     if _exclude_file(relative.name):
         return None

--- a/src/runtime/operator/source_policy.py
+++ b/src/runtime/operator/source_policy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 _EXCLUDED_DIRECTORY_NAMES = frozenset(
     {
         "__pycache__",
@@ -16,3 +18,8 @@ _EXCLUDED_DIRECTORY_NAMES = frozenset(
 def is_excluded_directory(name: str) -> bool:
     """Return whether a directory is outside workflow source scope."""
     return name.startswith(".") or name.lower() in _EXCLUDED_DIRECTORY_NAMES
+
+
+def is_path_in_excluded_directory(relative_path: Path) -> bool:
+    """Return whether a relative file path lies under an excluded directory."""
+    return any(is_excluded_directory(part) for part in relative_path.parts[:-1])

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -150,7 +150,21 @@ def test_ava_operator_delegates_to_runtime_operator_with_flows(monkeypatch):
 
     monkeypatch.setattr(app, "_operator_main", fake_operator_main)
 
-    assert app.main(["operator", "--flows", "examples", "--port", "17777", "--ray"]) == 0
+    assert (
+        app.main(
+            [
+                "operator",
+                "--flows",
+                "examples",
+                "--port",
+                "17777",
+                "--discovery-timeout",
+                "45",
+                "--ray",
+            ]
+        )
+        == 0
+    )
     assert calls == [
         [
             "--flows",
@@ -163,6 +177,8 @@ def test_ava_operator_delegates_to_runtime_operator_with_flows(monkeypatch):
             "7434",
             "--log-level",
             "WARNING",
+            "--discovery-timeout",
+            "45.0",
             "--ray",
         ]
     ]
@@ -176,6 +192,7 @@ def test_ava_operator_defaults_flows_to_current_directory(monkeypatch):
 
     assert app.main(["operator"]) == 0
     assert calls[0][:2] == ["--flows", "."]
+    assert calls[0][-2:] == ["--discovery-timeout", "60.0"]
 
 
 def test_ava_operator_forwards_case_insensitive_log_level(monkeypatch):
@@ -185,7 +202,7 @@ def test_ava_operator_forwards_case_insensitive_log_level(monkeypatch):
     monkeypatch.setattr(app, "_operator_main", lambda argv: calls.append(argv) or 0)
 
     assert app.main(["operator", "--flows", "examples", "--log-level", "info"]) == 0
-    assert calls[0][-2:] == ["--log-level", "INFO"]
+    assert calls[0][-4:] == ["--log-level", "INFO", "--discovery-timeout", "60.0"]
 
 
 def test_runtime_operator_configures_logging_before_serve(monkeypatch):
@@ -204,7 +221,12 @@ def test_runtime_operator_configures_logging_before_serve(monkeypatch):
         lambda flows, **kwargs: lifecycle.append(("serve", (flows, kwargs))),
     )
 
-    assert operator_main.main(["--flows", "examples", "--log-level", "info"]) == 0
+    assert (
+        operator_main.main(
+            ["--flows", "examples", "--log-level", "info", "--discovery-timeout", "45"]
+        )
+        == 0
+    )
     assert lifecycle[0] == (
         "logging",
         {
@@ -214,6 +236,7 @@ def test_runtime_operator_configures_logging_before_serve(monkeypatch):
         },
     )
     assert lifecycle[1][0] == "serve"
+    assert lifecycle[1][1][1]["discovery_timeout"] == 45.0
 
 
 def test_runtime_operator_defaults_flows_to_current_directory(monkeypatch):
@@ -221,10 +244,26 @@ def test_runtime_operator_defaults_flows_to_current_directory(monkeypatch):
     from runtime.operator import __main__ as operator_main
 
     calls = []
-    monkeypatch.setattr(runtime_operator, "serve", lambda flows, **kwargs: calls.append(flows))
+    monkeypatch.setattr(
+        runtime_operator,
+        "serve",
+        lambda flows, **kwargs: calls.append((flows, kwargs)),
+    )
 
     assert operator_main.main([]) == 0
-    assert calls == [["."]]
+    assert calls[0][0] == ["."]
+    assert calls[0][1]["discovery_timeout"] == 60.0
+
+
+@pytest.mark.parametrize("timeout", ("0", "nan", "inf"))
+def test_runtime_operator_rejects_invalid_discovery_timeout(capsys, timeout):
+    from runtime.operator import __main__ as operator_main
+
+    with pytest.raises(SystemExit) as exc_info:
+        operator_main.main(["--discovery-timeout", timeout])
+
+    assert exc_info.value.code == 2
+    assert "Discovery timeout must be positive and finite" in capsys.readouterr().err
 
 
 def test_runtime_operator_reports_loaded_workflows(monkeypatch, capsys):
@@ -1621,8 +1660,8 @@ def test_ava_dev_starts_web_without_waiting_for_operator_readiness(monkeypatch):
         def kill(self):
             events.append("kill")
 
-    def fake_start_operator_process(flows, port, use_ray):
-        events.append(("start", flows, port, use_ray))
+    def fake_start_operator_process(flows, port, use_ray, discovery_timeout):
+        events.append(("start", flows, port, use_ray, discovery_timeout))
         return FakeProcess()
 
     def fake_start_web_process(address, port):
@@ -1634,12 +1673,23 @@ def test_ava_dev_starts_web_without_waiting_for_operator_readiness(monkeypatch):
 
     assert (
         app.main(
-            ["dev", "--flows", "examples", "--ray", "--port", "8443", "--web-port", "8444"]
+            [
+                "dev",
+                "--flows",
+                "examples",
+                "--ray",
+                "--port",
+                "8443",
+                "--web-port",
+                "8444",
+                "--discovery-timeout",
+                "45",
+            ]
         )
         == 0
     )
     assert events == [
-        ("start", ["examples"], 8443, True),
+        ("start", ["examples"], 8443, True, 45.0),
         ("web", "127.0.0.1:8443", 8444),
         ("wait", None),
         "terminate",
@@ -1665,10 +1715,14 @@ def test_ava_dev_defaults_flows_to_current_directory(monkeypatch):
     from ava_cli import app
 
     calls = []
-    monkeypatch.setattr(app, "_run_dev", lambda args: calls.append(args.flows) or 0)
+    monkeypatch.setattr(
+        app,
+        "_run_dev",
+        lambda args: calls.append((args.flows, args.discovery_timeout)) or 0,
+    )
 
     assert app.main(["dev"]) == 0
-    assert calls == [["."]]
+    assert calls == [(["."], 60.0)]
 
 
 def test_ava_dev_stops_operator_when_wait_is_interrupted(monkeypatch):
@@ -1692,7 +1746,7 @@ def test_ava_dev_stops_operator_when_wait_is_interrupted(monkeypatch):
     monkeypatch.setattr(
         app,
         "_start_operator_process",
-        lambda flows, port, use_ray: FakeProcess(),
+        lambda flows, port, use_ray, discovery_timeout: FakeProcess(),
     )
     monkeypatch.setattr(app, "_start_web_process", lambda address, port: FakeProcess())
 

--- a/test/operator_tests/test_registry.py
+++ b/test/operator_tests/test_registry.py
@@ -2,6 +2,7 @@
 
 import importlib
 import json
+import logging
 import os
 import signal
 import sys
@@ -357,7 +358,7 @@ class TestWorkflowRegistry:
         assert [item.workflow_id for item in registry.descriptors()] == ["flow.py::scheduled"]
         assert registry.list_diagnostics()[0].kind == "import_error"
 
-    def test_discovery_timeout_retains_current_view(self, tmp_path):
+    def test_discovery_timeout_retains_current_view(self, tmp_path, caplog):
         workflow_file = tmp_path / "flow.py"
         workflow_file.write_text(
             "import avalanche as ava\n"
@@ -369,6 +370,7 @@ class TestWorkflowRegistry:
         registry.scan([str(workflow_file)])
         assert registry.descriptors()
 
+        caplog.set_level(logging.WARNING, logger="runtime.operator.discovery")
         workflow_file.write_text("while True:\n    pass\n")
         registry._discovery_timeout = 0.2
         started = time.monotonic()
@@ -377,6 +379,15 @@ class TestWorkflowRegistry:
         assert time.monotonic() - started < 2.0
         assert [item.workflow_id for item in registry.descriptors()] == ["flow.py::scheduled"]
         assert "exceeded 0.2s" in registry.list_diagnostics()[0].message
+        timeout_warnings = [
+            record
+            for record in caplog.records
+            if (
+                record.name == "runtime.operator.discovery"
+                and record.levelno == logging.WARNING
+            )
+        ]
+        assert len(timeout_warnings) == 1
 
     def test_discovery_stdout_and_delayed_background_output_do_not_corrupt_result(
         self, tmp_path

--- a/test/operator_tests/test_registry.py
+++ b/test/operator_tests/test_registry.py
@@ -11,7 +11,7 @@ import pytest
 
 import avalanche as ava
 from avalanche.dag import Workflow
-from runtime.operator.discovery import FileDiscoveryResult, configure_roots
+from runtime.operator.discovery import FileDiscoveryResult, _worker, configure_roots
 from runtime.operator.discovery_cache import DiscoveryCache
 from runtime.operator.models import WorkflowDiscoveryDiagnostic
 from runtime.operator.registry import (
@@ -104,6 +104,52 @@ class TestWorkflowRegistry:
                 message="RuntimeError: broken import",
             )
         ]
+
+    def test_scan_preserves_virtualenv_modules(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        virtualenv = project / ".venv"
+        module_name = "_avalanche_virtualenv_reload_guard"
+        guard_name = "AVALANCHE_VIRTUALENV_RELOAD_GUARD"
+        virtualenv.mkdir(parents=True)
+        (virtualenv / f"{module_name}.py").write_text(
+            "import os\n"
+            f"if os.environ.get({guard_name!r}):\n"
+            "    raise ImportError('cannot load module more than once per process')\n"
+            f"os.environ[{guard_name!r}] = 'loaded'\n"
+        )
+        (project / "flow.py").write_text(
+            f"import {module_name}\n"
+            "import avalanche as ava\n"
+            "\n"
+            "@ava.workflow\n"
+            "def workflow():\n"
+            "    return None\n"
+        )
+
+        monkeypatch.delenv(guard_name, raising=False)
+        monkeypatch.syspath_prepend(str(virtualenv))
+        sys.modules.pop(module_name, None)
+        try:
+            importlib.import_module(module_name)
+            result = _worker(
+                {
+                    "roots": [
+                        {
+                            "alias": "project",
+                            "path": str(project),
+                            "target": str(project),
+                        }
+                    ],
+                    "targets": None,
+                }
+            )
+            file_result = result["files"][0]
+            assert file_result["diagnostics"] == []
+            assert [descriptor["workflow_id"] for descriptor in file_result["descriptors"]] == [
+                "flow.py::workflow"
+            ]
+        finally:
+            sys.modules.pop(module_name, None)
 
     def test_scan_discovers_workflow_in_package_with_relative_imports(self, tmp_path):
         pkg = tmp_path / "my_pkg" / "my_belt"


### PR DESCRIPTION
## Rationale

Scanning a project root that contains `.venv` incorrectly purges installed dependencies from Python's import cache. Reloading native dependencies during workflow import can fail with `ImportError: cannot load module more than once per process`, leaving the operator with an empty catalog. Discovery also needs a practical, configurable deadline: a short fixed global timeout can discard a complete catalog before large source trees finish scanning.

## Summary

- Centralize the existing excluded-directory path check in `source_policy` and use it when purging discovery imports, so dependencies under excluded directories remain loaded.
- Emit a `WARNING` when the global discovery deadline expires and incomplete results are discarded.
- Add `--discovery-timeout SECONDS` to `ava operator` and `ava dev`; validate that it is positive and finite, pass it through to the operator, and raise the shared default from 15 to 60 seconds.
- Document the timeout option and its release-note entry; add CLI regression coverage for forwarding, defaults, and invalid values.

## Test Plan

- [x] `make lint`
- [x] `uv run pytest test/operator_tests/test_registry.py test/operator_tests/test_source.py -q`
- [x] `uv run pytest test/cli_test.py::test_ava_operator_delegates_to_runtime_operator_with_flows test/cli_test.py::test_ava_operator_defaults_flows_to_current_directory test/cli_test.py::test_ava_operator_forwards_case_insensitive_log_level test/cli_test.py::test_runtime_operator_configures_logging_before_serve test/cli_test.py::test_runtime_operator_defaults_flows_to_current_directory test/cli_test.py::test_runtime_operator_rejects_invalid_discovery_timeout test/cli_test.py::test_ava_dev_starts_web_without_waiting_for_operator_readiness test/cli_test.py::test_ava_dev_defaults_flows_to_current_directory test/cli_test.py::test_ava_dev_stops_operator_when_wait_is_interrupted test/operator_tests/test_registry.py::TestWorkflowRegistry::test_discovery_timeout_retains_current_view -q`
- [x] `uv run ava operator --help && uv run ava dev --help`
- [x] Started `ava operator` against an intentionally non-terminating flow with `--discovery-timeout 0.2`; it emitted the timeout warning after 0.2 seconds and served the operator.
- [x] From `../test-init`, ran `PYTHONPATH=/home/emile_trampoline_ai/git/avalanche/src uv run ava dev`; catalog loaded `src/binary_converter/flow.py::binary_converter`.