### PR TITLE
chore(release): prepare v0.1.5-rc.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - run: uv lock --check
       - run: uv sync --all-extras
       - run: uv run ruff check src/ test/
       - run: uv run pytest -m "not tmux and not ray"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.1.5rc1
+
+This prerelease carries the V2 server, converter, and generated bindings used by Delta.
+
 ### Operator transport
 
 - Added an additive V2 project-summary cursor for consistent run-summary page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "avalanche-ai"
-version = "0.1.4"
+version = "0.1.5rc1"
 description = "Python toolkit for local data-flow experiments with Iceberg and Lance"
 authors = [{ name = "Gabriel Lesperance", email = "611342+glesperance@users.noreply.github.com" }]
 requires-python = "<3.14,>=3.11"

--- a/src/avalanche/__init__.py
+++ b/src/avalanche/__init__.py
@@ -63,7 +63,7 @@ from .storage import Namespace, NamespaceConfig, ScanResult, Table, TableGroup
 from .types import AppendResult, SnapshotMetadata, SnapshotState
 from .webhook import Webhook
 
-__version__ = "0.1.4"
+__version__ = "0.1.5rc1"
 
 
 def __getattr__(name: str):

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "avalanche-ai"
-version = "0.1.4"
+version = "0.1.5rc1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Release prep: `v0.1.5-rc.1`

Publishes the already-accepted V2 operator/provider surface as a prerelease registry
artifact for Delta’s V2-only lifecycle cutover.

- Sets package and runtime version to `0.1.5rc1`.
- Moves current V2 transport notes into the RC changelog section.
- Regenerates the lock metadata and makes `uv lock --check` an early CI gate.
- Leaves V2 source, generated bindings, browser assets, and runtime behavior unchanged.

## Verification

- `uv lock --check`
- locked all-extras sync, Ruff, web-assets check, and `uv build`
- V2 gRPC module: 26 passed
- Independent frozen-candidate review accepted the exact five-file diff

After exact-head CI passes, merge this PR, verify `e01119f` is on main, then create the
annotated prerelease tag `v0.1.5-rc.1`. Do not publish a stable `v0.1.5`.
