### PR TITLE
fix(web): add operator UI package README

### DIFF
--- a/.github/workflows/operator-ui-release.yml
+++ b/.github/workflows/operator-ui-release.yml
@@ -101,6 +101,7 @@ jobs:
           test -f "$PACKAGE_ROOT/dist/index.d.ts"
           test -f "$PACKAGE_ROOT/dist/styles.css"
           test -f "$PACKAGE_ROOT/dist/ui/OperatorUi.d.ts"
+          test -f "$PACKAGE_ROOT/README.md"
           node --input-type=module <<'EOF'
           import { readFile } from "node:fs/promises";
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   typed host and workflow-workspace APIs for local and hosted shells.
 - Prepared `@trampoline-ai/operator-ui` for independent GitHub Packages releases with archive
   verification and a versioned release workflow.
+- Added a package-specific README so GitHub Packages displays operator UI installation and
+  embedding guidance.
 
 ## 0.1.5rc1
 

--- a/web/operator/README.md
+++ b/web/operator/README.md
@@ -1,0 +1,52 @@
+# @trampoline-ai/operator-ui
+
+Embeddable React UI for inspecting and controlling Avalanche workflows. The package provides the
+workflow graph, run list, run controls, logs, node details, and agent details; the embedding host
+owns navigation, the operator connection, and presentation.
+
+## Install
+
+The package is published through GitHub Packages. Configure the scope and an authenticated token
+outside source control:
+
+```ini
+@trampoline-ai:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+Then install the package with its React peer dependencies:
+
+```bash
+pnpm add @trampoline-ai/operator-ui react react-dom
+```
+
+## Embed
+
+Import the package stylesheet once, then render `OperatorUi` with a typed host:
+
+```tsx
+import "@trampoline-ai/operator-ui/styles.css";
+import { OperatorUi } from "@trampoline-ai/operator-ui";
+import type { OperatorUiHost } from "@trampoline-ai/operator-ui";
+
+const host: OperatorUiHost = {
+  api: operatorApi,
+  presentation: {
+    rootLabel: "Example project",
+    brandImageUrl: "/brand.svg",
+    unavailableDescription: "The operator is unavailable.",
+    workflowReloadDescription: "Workflow changes are being loaded.",
+  },
+};
+
+export function WorkflowPage() {
+  return <OperatorUi host={host} />;
+}
+```
+
+Use `GrpcWebOperatorApi` when the host has a compatible gRPC-Web endpoint, or implement the
+`OperatorApi` interface for another transport. `WorkflowWorkspace` is also available when the
+host supplies its own surrounding navigation and layout.
+
+This package does not run an operator server, create an authentication boundary, or provide
+multi-tenant behavior. Those concerns stay with the embedding host.

--- a/web/operator/package.json
+++ b/web/operator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trampoline-ai/operator-ui",
-  "version": "0.1.0-rc1",
+  "version": "0.1.0-rc2",
   "description": "Embeddable React UI for Avalanche operators",
   "license": "Apache-2.0",
   "repository": {
@@ -15,7 +15,8 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "sideEffects": [
     "./dist/styles.css"


### PR DESCRIPTION
## Rationale

GitHub Packages displays the README contained in the published package archive. The first operator UI prerelease had no package-local README, so its package page showed Avalanche's repository README instead of package installation and embedding guidance.

## Summary

- Added `web/operator/README.md` with package-specific installation, styling, host-boundary, and embedding guidance.
- Explicitly includes that README in the published package files and verifies it in the release archive.
- Bumped `@trampoline-ai/operator-ui` from `0.1.0-rc1` to `0.1.0-rc2`.
- Preserved prerelease publication through the npm `next` tag; this workflow still creates no GitHub Release.

## Test Plan

- [x] `pnpm pack --pack-destination /tmp --json` from `web/operator`
- [x] Verified `README.md` in `trampoline-ai-operator-ui-0.1.0-rc2.tgz`
- [x] `make web-format-check`
- [x] `npm publish /tmp/trampoline-ai-operator-ui-0.1.0-rc2.tgz --tag next --dry-run`
- [x] Strict release-workflow YAML and contract validation
