### PR TITLE
ci: update Node 24 release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: Lint + tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv lock --check
       - run: uv sync --all-extras
       - run: uv run ruff check src/ test/
@@ -23,9 +23,12 @@ jobs:
     name: Browser UI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: astral-sh/setup-uv@v7
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.17.1
       - run: uv sync --all-extras
@@ -45,8 +48,8 @@ jobs:
     name: Ray tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --all-extras
       - run: uv run pytest -m ray
 
@@ -54,7 +57,7 @@ jobs:
     name: Tmux TUI tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --all-extras
       - run: uv run pytest -m tmux

--- a/.github/workflows/operator-ui-release.yml
+++ b/.github/workflows/operator-ui-release.yml
@@ -16,13 +16,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Verify tag is on main
         run: |
           TAG="${GITHUB_REF_NAME}"
           TAG_VERSION="${TAG#operator-ui-v}"
+
+          if [[ "$TAG_VERSION" == *"-"* ]] && [[ ! "$TAG_VERSION" =~ ^[0-9]+\.[0-9]+\.0- ]]; then
+            echo "::error::Prerelease tag '$TAG' is a hotfix version; only major and minor prereleases are allowed."
+            exit 1
+          fi
 
           if [[ "$TAG_VERSION" == *"-"* ]]; then
             echo "::notice title=Ancestry check skipped::Prerelease tag '$TAG', skipping main ancestry check."
@@ -54,11 +59,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v5
-      - uses: pnpm/action-setup@v4
+      - uses: astral-sh/setup-uv@v7
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.17.1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -130,7 +135,7 @@ jobs:
           }
           EOF
       - name: Upload package archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: operator-ui-package
           path: ${{ runner.temp }}/operator-ui/*.tgz
@@ -144,13 +149,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com
           scope: "@trampoline-ai"
       - name: Download package archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: operator-ui-package
           path: ${{ runner.temp }}/operator-ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
       - name: Verify tag is on main
         run: |
           TAG="${GITHUB_REF_NAME}"
 
-          # Skip ancestry check for prerelease tags (e.g., v1.2.3-rc.1)
+          # Skip ancestry check for prerelease tags (e.g., v1.2.0-rc.1)
           if [[ "$TAG" == *"-"* ]]; then
             echo "::notice title=Ancestry check skipped::Prerelease tag '$TAG', skipping main ancestry check."
             exit 0
@@ -44,10 +44,18 @@ jobs:
 
           tag = os.environ["TAG"].removeprefix("v")
           pkg = tomllib.load(open("pyproject.toml", "rb"))["project"]["version"]
-          if Version(tag) != Version(pkg):
+          tag_version = Version(tag)
+          package_version = Version(pkg)
+          if tag_version.is_prerelease and tag_version.micro != 0:
+              print(
+                  f"::error::Prerelease tag v{tag} is a hotfix version; "
+                  "only major and minor prereleases are allowed."
+              )
+              sys.exit(1)
+          if tag_version != package_version:
               print(f"::error::Tag v{tag} does not match pyproject version {pkg}")
               sys.exit(1)
-          kind = "pre-release" if Version(pkg).is_prerelease else "release"
+          kind = "pre-release" if package_version.is_prerelease else "release"
           print(f"Tag v{tag} matches pyproject version ({kind})")
           EOF
 
@@ -57,8 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: astral-sh/setup-uv@v7
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.17.1
       - name: Install browser dependencies
@@ -69,7 +80,7 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -86,7 +97,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -102,7 +113,7 @@ jobs:
       contents: write
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Continuous integration
+
+- CI actions and browser tooling now run on Node.js 24.
+- Release validation now rejects prerelease hotfix tags; only major and minor
+  prereleases are accepted.
+
 ### Documentation
 
 - Replaced the published Avalanche documentation source with a workflow-first Docsalot site covering onboarding, authoring, local operation, advanced data workflows, extensions, and complete public API and CLI reference.


### PR DESCRIPTION
## Rationale

GitHub Actions Node 20 runtimes are deprecated, and prerelease hotfix tags should not publish releases.

## Summary

- Upgrade CI and release action runtimes and browser tooling to Node.js 24.
- Reject prerelease tags with nonzero patch versions for Python and operator UI releases.

## Test Plan

- [x] Parsed all GitHub Actions workflow YAML files locally.
- [x] Exercised accepted major/minor prerelease tags and rejected hotfix prerelease tags.
- [ ] GitHub Actions run triggered by this pull request.
