### PR TITLE
chore(web): upgrade nanoid to 3.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Dependencies
+
+- Updated the operator web workspace's transitive `nanoid` package to 3.3.18.
+
 ## 0.2.0
 
 ### Continuous integration

--- a/src/runtime/operator/operator.py
+++ b/src/runtime/operator/operator.py
@@ -2403,10 +2403,10 @@ class Operator:
                 f"(exit code {handle.process.exitcode})"
             ),
         )
+        self._result_store.discard(handle.result_bundle)
         with self._lock:
             run = self._runs.get(run_id)
             if run is None:
-                self._result_store.discard(handle.result_bundle)
                 return
             run.status = RunStatus.CANCELLED if cancelled else RunStatus.FAILED
             self._stored_results.pop(run_id, None)
@@ -2422,7 +2422,6 @@ class Operator:
                 status_node_ids=changed_node_ids,
                 log_entry=log_entry,
             )
-        self._result_store.discard(handle.result_bundle)
         self._wait_for_notifications(notifications)
 
     def _force_cancel_after_grace(self, run_id: str, handle: _RunHandle) -> None:

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: 3.3.18
+
 importers:
 
   .: {}
@@ -1732,8 +1735,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3865,7 +3868,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3920,7 +3923,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - operator
   - local
+
+overrides:
+  nanoid: 3.3.18


### PR DESCRIPTION
## Rationale

The operator web workspace resolved the transitive `nanoid` dependency to 3.3.16. The first CI run also exposed a race: an exited cancelled run could report its terminal state before its private result bundle was removed.

## Summary

- Added a workspace-wide pnpm override for `nanoid` 3.3.18.
- Regenerated the web lockfile so PostCSS and Vite resolve `nanoid` 3.3.18.
- Remove an exited run's pending result bundle before publishing its terminal state.
- Added an Unreleased changelog entry.

## Test Plan

- [x] `pnpm --dir web install --frozen-lockfile`
- [x] `make web-lint`
- [x] `uv run pytest test/operator_tests/test_workflow_results.py::test_failed_and_cancelled_runs_remove_their_pending_result_bundles -q` (10 runs)
- [x] `make lint`