### PR TITLE
Run independent local workflow nodes concurrently

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,20 +143,23 @@ and tools stay step-local capabilities.
 
 ### Executors
 
-`LocalExecutor` executes submitted node functions in the local coordinator
-process. `RayExecutor` submits work to Ray when selected. The DAG runtime, not
-the UI or operator parent, controls dependency order and binding. Ray object
-references remain distributed until a consumer needs materialization; the
-operator parent receives lifecycle events and encoded terminal results rather
-than live task objects.
+`LocalExecutor` runs dependency-ready nodes concurrently in a per-run thread
+pool inside the local coordinator process. Its worker bound is configurable;
+one worker provides serial execution. Node arguments and fan-in receipts retain
+DAG declaration order even when sibling completion order differs. `RayExecutor`
+submits work to Ray when selected. The DAG runtime, not the UI or operator
+parent, controls dependency order and binding. Ray object references remain
+distributed until a consumer needs materialization; the operator parent
+receives lifecycle events and encoded terminal results rather than live task
+objects.
 
 For an operator run, executor construction happens in the spawned coordinator:
 
 ```text
 Operator parent
   └── coordinator imports one workflow module and builds one Workflow
-        ├── LocalExecutor: local node execution with queue-backed observers
-        └── RayExecutor: Ray runtime environment + Ray log queue
+        ├── LocalExecutor: dependency-ready thread-pool nodes + queue observers
+        └── RayExecutor: Ray tasks + Ray log queue
 ```
 
 The coordinator tears down its executor after a terminal outcome. The parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@
 - `LocalExecutor` now runs independent, dependency-ready workflow nodes
   concurrently in a bounded thread pool while preserving fan-in argument,
   receipt, hook, and node-log behavior.
+- Concurrent `Table.append()` calls now preserve every append for Iceberg and Lance
+  tables; commit ordering is unspecified.
 - The cursor example keeps per-model embedding work parallel and commits both
-  results through one fan-in transaction, avoiding concurrent writes to the
-  shared Iceberg table.
+  results through one fan-in transaction.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@
 - `LocalExecutor` now runs independent, dependency-ready workflow nodes
   concurrently in a bounded thread pool while preserving fan-in argument,
   receipt, hook, and node-log behavior.
-- Concurrent `Table.append()` calls now preserve every append for Iceberg and Lance
-  tables; commit ordering is unspecified.
+- Concurrent `Table.append()` calls now preserve successful Iceberg and Lance
+  appends; commit ordering is unspecified. Iceberg catalog conflicts retry with
+  jitter for up to 30 seconds before surfacing `CommitFailedException`.
 - The cursor example keeps per-model embedding work parallel and commits both
   results through one fan-in transaction.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@
 - `ava init` now configures its starter workspace to scan `src/`, so
   `uv run ava dev` discovers newly added starter workflows without a local wrapper.
 
+### Workflow execution
+
+- `LocalExecutor` now runs independent, dependency-ready workflow nodes
+  concurrently in a bounded thread pool while preserving fan-in argument,
+  receipt, hook, and node-log behavior.
+- The cursor example keeps per-model embedding work parallel and commits both
+  results through one fan-in transaction, avoiding concurrent writes to the
+  shared Iceberg table.
+
 ## 0.2.0
 
 ### Continuous integration

--- a/docs/dag-api.md
+++ b/docs/dag-api.md
@@ -98,6 +98,28 @@ def fanout_flow():
     )
 ```
 
+`&` records fan-out and fan-in dependencies. During local execution, every node
+whose parents have completed is eligible to run in the `LocalExecutor` thread
+pool, so independent branches overlap. The downstream node starts only after
+both branches complete, and receives their values in declaration order.
+
+`LocalExecutor(max_workers=...)` can bound local concurrency. Its default uses
+Python's standard thread-pool worker count. Threads are effective for I/O-bound
+nodes and native libraries that release the GIL; use `RayExecutor` for
+distributed or CPU-bound Python execution. Concurrent nodes that share external
+state must provide their own synchronization.
+
+When parallel branches produce data for the same transactional table, keep the
+computation parallel but use one downstream writer. Each branch returns its
+prepared data; the fan-in node combines the values and commits them in one
+transaction. Two sibling transactions against the same table may conflict even
+though the DAG nodes are otherwise independent.
+
+```python
+prepared = source() >> (prepare_left() & prepare_right())
+return prepared >> persist_both()
+```
+
 ## Multiple outputs
 
 Set `num_returns` when downstream nodes need individual values from a tuple-like
@@ -261,8 +283,12 @@ result = run.result()
 result = await document_flow().run(executor=ava.LocalExecutor())
 ```
 
-Use `ava.LocalExecutor` for local execution. `ava.RayExecutor` is available when
-Ray support is installed. Call `run.cancel()` to request cooperative cancellation.
+Use `ava.LocalExecutor` for concurrent in-process execution. Pass
+`max_workers=1` when a workflow must run serially, or a larger value to bound
+the number of local node threads. `ava.RayExecutor` is available when Ray
+support is installed. Call `run.cancel()` to request cooperative cancellation;
+already-submitted local nodes are allowed to finish, while their unscheduled
+descendants do not start.
 
 For task-scoped platform resources, pass `ava.ExecutionServicesSpec`; see
 [Execution services](execution-services.md).

--- a/docs/dag-api.md
+++ b/docs/dag-api.md
@@ -106,19 +106,12 @@ both branches complete, and receives their values in declaration order.
 `LocalExecutor(max_workers=...)` can bound local concurrency. Its default uses
 Python's standard thread-pool worker count. Threads are effective for I/O-bound
 nodes and native libraries that release the GIL; use `RayExecutor` for
-distributed or CPU-bound Python execution. Concurrent nodes that share external
-state must provide their own synchronization.
+distributed or CPU-bound Python execution.
 
-When parallel branches produce data for the same transactional table, keep the
-computation parallel but use one downstream writer. Each branch returns its
-prepared data; the fan-in node combines the values and commits them in one
-transaction. Two sibling transactions against the same table may conflict even
-though the DAG nodes are otherwise independent.
-
-```python
-prepared = source() >> (prepare_left() & prepare_right())
-return prepared >> persist_both()
-```
+Parallel nodes have no ordering guarantee. Independent nodes can append to the
+same Avalanche table; both appends are retained, but commit order is unspecified.
+If a node must observe another node's output or otherwise follow it, express that
+dependency with `>>`. Other shared external state still needs user synchronization.
 
 ## Multiple outputs
 

--- a/docs/execution-services.md
+++ b/docs/execution-services.md
@@ -162,7 +162,10 @@ methods. Sessions never cross from one task attempt to another.
 
 ### Local and Ray execution
 
-`LocalExecutor` invokes the lifecycle synchronously and carries values directly.
+`LocalExecutor` runs each node's lifecycle synchronously within that node's
+worker thread and carries values directly. Independent node lifecycles may
+overlap, while a dependent lifecycle receives completed parent receipts in DAG
+order.
 
 `RayExecutor` runs the complete lifecycle inside one Ray task. The task returns three
 separate channels: user payloads, one small receipt, and one status marker. The driver

--- a/examples/cursor_pattern.py
+++ b/examples/cursor_pattern.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import dataframely as dy
@@ -47,6 +48,13 @@ class EmbeddingSchema(dy.Schema):
     chunk_id = dy.String(nullable=False)
     model = dy.String(nullable=False)
     vector = dy.Binary(nullable=False)
+
+
+@dataclass(frozen=True)
+class PendingEmbeddings:
+    data: pl.DataFrame | None
+    chunk_count: int
+    source_snapshot_id: int
 
 
 class ExampleNamespace(ava.IcebergNs):
@@ -113,31 +121,44 @@ def embed_chunks_per_model(
     *,
     model: str = "local_demo",
     source=ns.chunk,
-    dest=ns.embedding,
+    checkpoint=ava.Cursor(ns.embedding, key="embedding_models"),
+) -> PendingEmbeddings:
+    """Compute one model's embeddings without committing shared table state."""
+    last_snapshot = checkpoint.get()
+    chunk_df = source.append_scan(start_snapshot_id=last_snapshot).to_polars()
+    current_snapshot = source.current_snapshot().snapshot_id
+    embeddings = None if chunk_df.is_empty() else generate_embeddings(chunk_df, model=model)
+    return PendingEmbeddings(
+        data=embeddings,
+        chunk_count=len(chunk_df),
+        source_snapshot_id=current_snapshot,
+    )
+
+
+@ava.step
+def persist_embeddings(
+    local_batch: PendingEmbeddings,
+    backup_batch: PendingEmbeddings,
+    *,
+    cursor=ava.Cursor(ns.embedding, key="embedding_models"),
 ) -> str:
-    """Embed newly chunked documents for one model."""
-    key = f"embed_{model.replace('-', '_')}"
-    cursor = ava.Cursor(dest, key=key)
+    """Commit parallel embedding results and their shared checkpoint once."""
+    if local_batch.source_snapshot_id != backup_batch.source_snapshot_id:
+        raise ValueError("Embedding branches read different chunk snapshots")
 
+    frames = [batch.data for batch in (local_batch, backup_batch) if batch.data is not None]
     with cursor.tx() as tx:
-        last_snapshot = cursor.get()
-        chunk_df = source.append_scan(start_snapshot_id=last_snapshot).to_polars()
-        current_snapshot = source.current_snapshot().snapshot_id
+        if frames:
+            tx.append(pl.concat(frames).to_arrow())
+        cursor.set(local_batch.source_snapshot_id)
 
-        if chunk_df.is_empty():
-            cursor.set(current_snapshot)
-            return f"no chunks for {model}"
-
-        embeddings = generate_embeddings(chunk_df, model=model)
-        tx.append(embeddings.to_arrow())
-        cursor.set(current_snapshot)
-        return f"embedded {len(chunk_df)} chunks with {model}"
+    total_embeddings = sum(batch.chunk_count for batch in (local_batch, backup_batch))
+    return f"persisted {total_embeddings} embeddings"
 
 
 @ava.dest
 def sync_to_vector_db(
-    _local_embeddings: object = None,
-    _backup_embeddings: object = None,
+    _persisted_embeddings: object = None,
     *,
     cursor=ava.Cursor(ns.embedding, key="vector_db_sync"),
     chunks=ns.chunk,
@@ -162,16 +183,11 @@ def sync_to_vector_db(
 
 @ava.workflow
 def cursor_workflow():
-    # Equivalent NodeFuture argument form, less visual:
-    # load = load_documents()
-    # chunk = chunk_documents(load)
-    # embed_local = embed_chunks_per_model(chunk)
-    # embed_backup = embed_chunks_per_model(chunk, model="backup_demo")
-    # sync = sync_to_vector_db(embed_local, embed_backup)
     return (
         load_documents()
         >> chunk_documents()
         >> (embed_chunks_per_model() & embed_chunks_per_model(model="backup_demo"))
+        >> persist_embeddings()
         >> sync_to_vector_db()
     )
 

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -2911,9 +2911,6 @@ class Workflow:
                         else:
                             completed_nodes.add(node_id)
 
-                    if cancel_requested and cancel_requested():
-                        cancelled = True
-
             if primary_failure is not None:
                 raise primary_failure
             if cancelled:

--- a/src/avalanche/dag.py
+++ b/src/avalanche/dag.py
@@ -49,12 +49,13 @@ When a workflow runs:
 from __future__ import annotations
 
 from collections import defaultdict
-from concurrent.futures import CancelledError
+from concurrent.futures import FIRST_COMPLETED, CancelledError, Future, ThreadPoolExecutor, wait
 from contextvars import ContextVar
 from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import update_wrapper, wraps
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable, DefaultDict, TypeVar, get_type_hints
 
 from ulid import ULID
@@ -2291,6 +2292,7 @@ class Workflow:
         # Service receipts are a separate control channel. They are never
         # stored in result_refs or exposed to workflow arguments/context.
         receipt_refs: dict[str, Any] = {}
+        receipt_refs_lock = Lock()
 
         # Build reverse dependency map (child -> parents) for execution.
         # Keep the original map so rerun stream providers can still identify
@@ -2322,10 +2324,14 @@ class Workflow:
             )
         )
 
-        def submit_node(node_id: str) -> tuple[NodeFuture, Any]:
+        def submit_node(
+            node_id: str,
+            *,
+            emit_hooks: bool = True,
+        ) -> tuple[NodeFuture, Any]:
             node_ref = self.nodes[node_id]
 
-            if hooks and hooks.on_node_start:
+            if emit_hooks and hooks and hooks.on_node_start:
                 hooks.on_node_start(node_id)
 
             node_system_context = _context_for_node(
@@ -2579,11 +2585,12 @@ class Workflow:
                 if execution_services is not None:
                     from .execution_services import ExecutionTaskSpec
 
-                    parent_receipts = tuple(
-                        receipt_refs[parent_id]
-                        for parent_id in dependencies_map.get(node_id, [])
-                        if parent_id in receipt_refs
-                    )
+                    with receipt_refs_lock:
+                        parent_receipts = tuple(
+                            receipt_refs[parent_id]
+                            for parent_id in dependencies_map.get(node_id, [])
+                            if parent_id in receipt_refs
+                        )
                     result, receipt_ref, status_ref = executor.submit_with_services(
                         actual_fn,
                         execution_services,
@@ -2603,7 +2610,8 @@ class Workflow:
                         *resolved_args,
                         **resolved_kwargs,
                     )
-                    receipt_refs[node_id] = receipt_ref
+                    with receipt_refs_lock:
+                        receipt_refs[node_id] = receipt_ref
                     if is_ray_executor and status_ref is not None:
                         # Status is a same-task completion/failure marker. Keep
                         # receipts worker-side until terminal publication.
@@ -2627,7 +2635,7 @@ class Workflow:
                         **resolved_kwargs,
                     )
             except Exception as exc:
-                if hooks and hooks.on_node_failure:
+                if emit_hooks and hooks and hooks.on_node_failure:
                     hooks.on_node_failure(node_id, exc)
                 raise
 
@@ -2672,6 +2680,32 @@ class Workflow:
             # unwrap_result / driver boundary: convert internal handles back to
             # public AppendResult (payload fetch here is intentional).
             return _materialize_append_handles_for_driver(value, executor)
+
+        def complete_non_ray_node(
+            node_id: str,
+            node_ref: NodeFuture,
+            result: Any,
+        ) -> None:
+            try:
+                if hooks and (hooks.on_node_success or hooks.unwrap_result):
+                    resolved_val = resolve_submitted_result(node_ref, result)
+                    if hooks.unwrap_result:
+                        user_val = _unwrap_lineaged_tree(resolved_val)
+                        replacement = hooks.unwrap_result(node_id, user_val)
+                        result = _reattach_lineage(replacement, resolved_val)
+                    else:
+                        result = resolved_val
+                    if hooks.on_node_success:
+                        hooks.on_node_success(node_id)
+                result_refs[node_id] = result
+            except Exception as exc:
+                if hooks and hooks.on_node_failure:
+                    hooks.on_node_failure(node_id, exc)
+                raise
+
+        from runtime.executor import LocalExecutor
+
+        is_local_executor = isinstance(executor, LocalExecutor)
 
         observe_ray_completion = bool(
             is_ray_executor
@@ -2817,6 +2851,73 @@ class Workflow:
                     cancelled = True
             if cancelled:
                 raise CancelledError()
+        elif is_local_executor:
+            completed_nodes: set[str] = set()
+            remaining_nodes = list(execution_order)
+            pending_tasks: dict[Future[tuple[NodeFuture, Any]], str] = {}
+            primary_failure: Exception | None = None
+            cancelled = False
+
+            def dependencies_ready(node_id: str) -> bool:
+                return all(
+                    parent_id in completed_nodes
+                    for parent_id in dependencies_map.get(node_id, [])
+                )
+
+            with ThreadPoolExecutor(
+                max_workers=executor.max_workers,
+                thread_name_prefix=f"avalanche-local-{run_id}",
+            ) as pool:
+                while remaining_nodes or pending_tasks:
+                    if primary_failure is None and not cancelled:
+                        for node_id in list(remaining_nodes):
+                            if cancel_requested and cancel_requested():
+                                cancelled = True
+                                break
+                            if not dependencies_ready(node_id):
+                                continue
+
+                            if hooks and hooks.on_node_start:
+                                hooks.on_node_start(node_id)
+                            task = pool.submit(submit_node, node_id, emit_hooks=False)
+                            pending_tasks[task] = node_id
+                            remaining_nodes.remove(node_id)
+
+                    if not pending_tasks:
+                        if primary_failure is not None or cancelled:
+                            break
+                        if remaining_nodes:
+                            raise RuntimeError("Local workflow scheduler has no runnable nodes")
+                        break
+
+                    wait(tuple(pending_tasks), return_when=FIRST_COMPLETED)
+                    completed_tasks = [task for task in pending_tasks if task.done()]
+                    for task in completed_tasks:
+                        node_id = pending_tasks.pop(task)
+                        try:
+                            node_ref, result = task.result()
+                        except Exception as exc:
+                            if hooks and hooks.on_node_failure:
+                                hooks.on_node_failure(node_id, exc)
+                            if primary_failure is None:
+                                primary_failure = exc
+                            continue
+
+                        try:
+                            complete_non_ray_node(node_id, node_ref, result)
+                        except Exception as exc:
+                            if primary_failure is None:
+                                primary_failure = exc
+                        else:
+                            completed_nodes.add(node_id)
+
+                    if cancel_requested and cancel_requested():
+                        cancelled = True
+
+            if primary_failure is not None:
+                raise primary_failure
+            if cancelled:
+                raise CancelledError()
         else:
             for node_id in execution_order:
                 # Check cancellation before starting each node
@@ -2824,27 +2925,7 @@ class Workflow:
                     raise CancelledError()
 
                 node_ref, result = submit_node(node_id)
-                # For non-Ray executors, resolve refs immediately so
-                # on_node_success fires after actual completion (not just
-                # submission). This serializes execution but gives accurate
-                # per-node progress — the right tradeoff for the operator.
-                if hooks and (hooks.on_node_success or hooks.unwrap_result):
-                    # Wait for completion and resolve to actual value.
-                    # For multi-return nodes (num_returns > 1), result is
-                    # a tuple of refs; for single-return it's one ref/value.
-                    resolved_val = resolve_submitted_result(node_ref, result)
-                    # Unwrap side-channel data (e.g. logs from Ray workers).
-                    # Hooks see user-facing values; result_refs keeps the
-                    # lineage-preserving envelope for downstream dataflow.
-                    if hooks.unwrap_result:
-                        user_val = _unwrap_lineaged_tree(resolved_val)
-                        replacement = hooks.unwrap_result(node_id, user_val)
-                        result = _reattach_lineage(replacement, resolved_val)
-                    else:
-                        result = resolved_val
-                    if hooks.on_node_success:
-                        hooks.on_node_success(node_id)
-                result_refs[node_id] = result
+                complete_non_ray_node(node_id, node_ref, result)
 
         # If workflow doesn't return anything, wait for all nodes to complete.
         # Skip if hooks were active — we already resolved per-node above.

--- a/src/avalanche/iceberg/table.py
+++ b/src/avalanche/iceberg/table.py
@@ -16,11 +16,13 @@ All PyIceberg Table methods are accessible through this wrapper:
 """
 
 from collections.abc import Sequence
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 import polars as pl
 import pyarrow as pa
 from pydantic import BaseModel
+from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.schema import Schema as IcebergSchema
 from pyiceberg.table import ALWAYS_TRUE, EMPTY_DICT, BooleanExpression, Properties, Table
 from pyiceberg.types import NestedField, StringType, TimestampType
@@ -33,6 +35,8 @@ from .schema import normalize_schema
 
 if TYPE_CHECKING:
     from .namespace import IcebergAppendScan
+
+_APPEND_RETRIES = 3
 
 
 def _with_row_lineage_schema(schema: IcebergSchema) -> IcebergSchema:
@@ -80,6 +84,8 @@ def _reconnect_table(
     table._table_name = identifier
     table.row_lineage = row_lineage
     table.row_model = row_model
+    table._append_lock = Lock()
+
     table._reconnect_spec = (
         catalog_name,
         catalog_props,
@@ -138,6 +144,7 @@ class IcebergTable(StorageTable):
 
         self._table: Table | None = None
         self._reconnect_spec: tuple[str, dict, str, bool, type | None] | None = None
+        self._append_lock = Lock()
 
     def __reduce__(self) -> tuple[Any, tuple]:
         """Pickle as a reconnect recipe (catalog address + identifier).
@@ -245,11 +252,7 @@ class IcebergTable(StorageTable):
                 "Cannot append - table has not been created yet. Call namespace.push() first."
             )
 
-        # Refresh so cross-process commits (e.g. Ray workers) are on the latest
-        # metadata before this append; avoids committing from a stale snapshot.
-        self._refresh_table_metadata()
-
-        # Convert to PyArrow if needed
+        # Convert to PyArrow if needed.
         if isinstance(df, pl.DataFrame):
             arrow_data = df.to_arrow()
         else:
@@ -263,19 +266,31 @@ class IcebergTable(StorageTable):
                 context=get_current_run_context(),
             )
 
-        arrow_data = self._cast_to_table_schema(arrow_data)
+        # ``Table.refresh()`` mutates the PyIceberg handle. Serialize appends
+        # through this wrapper instance so each AppendResult retains its own
+        # committed snapshot ID; separate workers retry catalog conflicts below.
+        last_error: CommitFailedException | None = None
+        with self._append_lock:
+            for _ in range(_APPEND_RETRIES):
+                self._refresh_table_metadata()
+                attempt_data = self._cast_to_table_schema(arrow_data)
+                try:
+                    self._table.append(attempt_data)
+                except CommitFailedException as exc:
+                    last_error = exc
+                    continue
 
-        # Call underlying PyIceberg append
-        self._table.append(arrow_data)
+                snapshot_id = self.current_version_id
+                assert snapshot_id is not None
+                return AppendResult(
+                    data=attempt_data,
+                    snapshot_id=snapshot_id,
+                    table_identity=self.identifier,
+                    row_model=self.row_model,
+                )
 
-        snapshot_id = self.current_version_id
-        assert snapshot_id is not None
-        return AppendResult(
-            data=arrow_data,
-            snapshot_id=snapshot_id,
-            table_identity=self.identifier,
-            row_model=self.row_model,
-        )
+        assert last_error is not None
+        raise last_error
 
     def _cast_to_table_schema(self, arrow_data: pa.Table | pa.RecordBatch) -> pa.Table:
         """Align Arrow field types/nullability with the declared Iceberg schema."""

--- a/src/avalanche/iceberg/table.py
+++ b/src/avalanche/iceberg/table.py
@@ -16,7 +16,9 @@ All PyIceberg Table methods are accessible through this wrapper:
 """
 
 from collections.abc import Sequence
+from random import uniform
 from threading import Lock
+from time import monotonic, sleep
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 import polars as pl
@@ -36,7 +38,9 @@ from .schema import normalize_schema
 if TYPE_CHECKING:
     from .namespace import IcebergAppendScan
 
-_APPEND_RETRIES = 3
+_APPEND_RETRY_TIMEOUT_SECONDS = 30.0
+_APPEND_RETRY_INITIAL_DELAY_SECONDS = 0.01
+_APPEND_RETRY_MAX_DELAY_SECONDS = 0.25
 
 
 def _with_row_lineage_schema(schema: IcebergSchema) -> IcebergSchema:
@@ -239,6 +243,9 @@ class IcebergTable(StorageTable):
         Returns:
             AppendResult with data and snapshot_id
 
+        Raises:
+            CommitFailedException: If catalog conflicts persist for 30 seconds.
+
         Example:
             @ava.source
             def load_docs(*, documents=ns.documents):
@@ -268,16 +275,38 @@ class IcebergTable(StorageTable):
 
         # ``Table.refresh()`` mutates the PyIceberg handle. Serialize appends
         # through this wrapper instance so each AppendResult retains its own
-        # committed snapshot ID; separate workers retry catalog conflicts below.
-        last_error: CommitFailedException | None = None
+        # committed snapshot ID. Separate workers retry catalog conflicts until
+        # the bounded deadline expires.
         with self._append_lock:
-            for _ in range(_APPEND_RETRIES):
-                self._refresh_table_metadata()
+            deadline = monotonic() + _APPEND_RETRY_TIMEOUT_SECONDS
+            retry_delay = _APPEND_RETRY_INITIAL_DELAY_SECONDS
+            self._refresh_table_metadata()
+
+            while True:
+                observed_snapshot_id = self.current_version_id
                 attempt_data = self._cast_to_table_schema(arrow_data)
                 try:
                     self._table.append(attempt_data)
-                except CommitFailedException as exc:
-                    last_error = exc
+                except CommitFailedException:
+                    if monotonic() >= deadline:
+                        raise
+
+                    self._refresh_table_metadata()
+                    if self.current_version_id != observed_snapshot_id:
+                        # A sibling commit advanced the catalog. Retry promptly
+                        # against that newer snapshot instead of treating this
+                        # as repeated no-progress contention.
+                        retry_delay = _APPEND_RETRY_INITIAL_DELAY_SECONDS
+                    else:
+                        retry_delay = min(
+                            retry_delay * 2,
+                            _APPEND_RETRY_MAX_DELAY_SECONDS,
+                        )
+
+                    remaining = deadline - monotonic()
+                    if remaining <= 0:
+                        raise
+                    sleep(min(uniform(retry_delay / 2, retry_delay), remaining))
                     continue
 
                 snapshot_id = self.current_version_id
@@ -288,9 +317,6 @@ class IcebergTable(StorageTable):
                     table_identity=self.identifier,
                     row_model=self.row_model,
                 )
-
-        assert last_error is not None
-        raise last_error
 
     def _cast_to_table_schema(self, arrow_data: pa.Table | pa.RecordBatch) -> pa.Table:
         """Align Arrow field types/nullability with the declared Iceberg schema."""

--- a/src/avalanche/lance/table.py
+++ b/src/avalanche/lance/table.py
@@ -290,11 +290,17 @@ class LanceTable(Table):
                 context=get_current_run_context(),
             )
         arrow_data = arrow_data.cast(self.schema)
-        mode = "append" if self._dataset_exists() else "overwrite"
-        lance.write_dataset(arrow_data, self.location, mode=mode)
+        dataset_exists = self._dataset_exists()
+        try:
+            dataset = lance.write_dataset(arrow_data, self.location, mode="append")
+        except OSError:
+            # ``append`` creates a dataset when absent. If a sibling writer won
+            # that initial creation, retry against the dataset it committed.
+            if dataset_exists or not self._dataset_exists():
+                raise
+            dataset = lance.write_dataset(arrow_data, self.location, mode="append")
 
-        snapshot_id = self.current_version_id
-        assert snapshot_id is not None
+        snapshot_id = int(dataset.version)
         return AppendResult(
             data=arrow_data,
             snapshot_id=snapshot_id,

--- a/src/runtime/executor.py
+++ b/src/runtime/executor.py
@@ -268,6 +268,8 @@ class LocalExecutor:
     - Local development
     """
 
+    max_workers: int | None = None
+
     def __init__(self, *, max_workers: int | None = None) -> None:
         if max_workers is not None:
             if type(max_workers) is not int:

--- a/src/runtime/executor.py
+++ b/src/runtime/executor.py
@@ -1,9 +1,9 @@
 """
 Execution engines for Avalanche workflows.
 
-Provides abstract interface for different execution backends:
+Provides abstract interfaces for different execution backends:
 - RayExecutor: Distributed execution with Ray
-- LocalExecutor: Sequential execution for testing
+- LocalExecutor: Concurrent in-process workflow execution
 - (Future: DaskExecutor, etc.)
 """
 
@@ -255,17 +255,26 @@ class Executor(Protocol):
 
 class LocalExecutor:
     """
-    Sequential local executor for testing and development.
+    In-process executor for testing and local development.
 
-    Executes tasks synchronously in the current process.
-    Since execution is immediate, refs are just the actual values.
+    Direct ``submit`` calls execute synchronously and return materialized values.
+    ``Workflow.run`` uses ``max_workers`` to execute dependency-ready nodes in a
+    thread pool while preserving DAG ordering.
 
     Useful for:
     - Testing
     - Debugging
-    - Small workflows
+    - I/O-bound workflows
     - Local development
     """
+
+    def __init__(self, *, max_workers: int | None = None) -> None:
+        if max_workers is not None:
+            if type(max_workers) is not int:
+                raise TypeError("max_workers must be an integer or None")
+            if max_workers <= 0:
+                raise ValueError("max_workers must be greater than zero")
+        self.max_workers = max_workers
 
     def submit(
         self, fn: Callable, *args: Any, num_returns: int = 1, **kwargs: Any

--- a/src/runtime/operator/run_worker.py
+++ b/src/runtime/operator/run_worker.py
@@ -398,22 +398,39 @@ class _QueueLogHandler(logging.Handler):
 class _QueueStream:
     def __init__(self, event_queue: Any, node_id: str, level: int) -> None:
         self._queue = event_queue
-        self.node_id = node_id
+        self._default_node_id = node_id
         self._level = level
-        self._buffer = ""
+        self._local = threading.local()
+
+    def bind_node(self, node_id: str) -> tuple[bool, str]:
+        """Bind writes from the current worker thread to one node."""
+        had_binding = hasattr(self._local, "node_id")
+        previous = self._local.node_id if had_binding else self._default_node_id
+        self._local.node_id = node_id
+        return had_binding, previous
+
+    def reset_node(self, binding: tuple[bool, str]) -> None:
+        """Restore the current worker thread's prior node binding."""
+        had_binding, previous = binding
+        if had_binding:
+            self._local.node_id = previous
+        else:
+            del self._local.node_id
 
     def write(self, value: str) -> int:
-        self._buffer += value
-        while "\n" in self._buffer:
-            line, self._buffer = self._buffer.split("\n", 1)
+        buffer = getattr(self._local, "buffer", "") + value
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
             if line.strip():
                 self._emit(line.rstrip())
+        self._local.buffer = buffer
         return len(value)
 
     def flush(self) -> None:
-        if self._buffer.strip():
-            self._emit(self._buffer.rstrip())
-        self._buffer = ""
+        buffer = getattr(self._local, "buffer", "")
+        if buffer.strip():
+            self._emit(buffer.rstrip())
+        self._local.buffer = ""
 
     def isatty(self) -> bool:
         return False
@@ -432,7 +449,8 @@ class _QueueStream:
                 "type": "log",
                 "timestamp": time.time(),
                 "level": self._level,
-                "node_id": current_agent_log_node_id() or self.node_id,
+                "node_id": current_agent_log_node_id()
+                or getattr(self._local, "node_id", self._default_node_id),
                 "message": _bounded_event_text(message, 65_536),
             },
         )
@@ -462,31 +480,29 @@ def _with_node_streams(
 
         @wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-            old_stdout, old_stderr = stdout.node_id, stderr.node_id
-            stdout.node_id = name
-            stderr.node_id = name
+            stdout_binding = stdout.bind_node(name)
+            stderr_binding = stderr.bind_node(name)
             try:
                 return await fn(*args, **kwargs)
             finally:
                 stdout.flush()
                 stderr.flush()
-                stdout.node_id = old_stdout
-                stderr.node_id = old_stderr
+                stdout.reset_node(stdout_binding)
+                stderr.reset_node(stderr_binding)
 
         return async_wrapper
 
     @wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        old_stdout, old_stderr = stdout.node_id, stderr.node_id
-        stdout.node_id = name
-        stderr.node_id = name
+        stdout_binding = stdout.bind_node(name)
+        stderr_binding = stderr.bind_node(name)
         try:
             return fn(*args, **kwargs)
         finally:
             stdout.flush()
             stderr.flush()
-            stdout.node_id = old_stdout
-            stderr.node_id = old_stderr
+            stdout.reset_node(stdout_binding)
+            stderr.reset_node(stderr_binding)
 
     return wrapper
 

--- a/test/async_workflow_test.py
+++ b/test/async_workflow_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
@@ -124,6 +125,32 @@ async def test_local_executor_resolves_async_task_inside_existing_event_loop():
         return left + right
 
     assert executor.submit(add, 2, 3) == 5
+
+
+def test_local_executor_runs_independent_async_nodes_concurrently():
+    both_running = threading.Barrier(2)
+
+    async def left_impl() -> str:
+        await asyncio.sleep(0)
+        both_running.wait(timeout=2)
+        return "left"
+
+    async def right_impl() -> str:
+        await asyncio.sleep(0)
+        both_running.wait(timeout=2)
+        return "right"
+
+    left = ava.source(left_impl)
+    right = ava.source(right_impl)
+    join = ava.dest(lambda left_value, right_value: (left_value, right_value))
+
+    @ava.workflow
+    def parallel_workflow():
+        return (left() & right()) >> join()
+
+    assert parallel_workflow().run(executor=ava.LocalExecutor(max_workers=2)).result(
+        timeout=5
+    ) == ("left", "right")
 
 
 @pytest.mark.ray

--- a/test/execution_services_test.py
+++ b/test/execution_services_test.py
@@ -238,9 +238,9 @@ def test_local_service_input_lifecycle_receipts_and_fan_in():
     assert receipts[0].value["node"] == "join_1"
 
     opens = [event for event in events if event[1] == "open"]
-    assert [event[0] for event in opens] == ["typed_1", "selected_1", "join_1"]
-    assert opens[0][3] == ()
-    assert opens[1][3] == ()
+    assert {event[0] for event in opens[:2]} == {"typed_1", "selected_1"}
+    assert opens[2][0] == "join_1"
+    assert all(event[3] == () for event in opens[:2])
     assert [receipt["node"] for receipt in opens[2][3]] == ["typed_1", "selected_1"]
     for node_id in ("typed_1", "selected_1", "join_1"):
         assert [event[1] for event in events if event[0] == node_id] == [

--- a/test/executor_test.py
+++ b/test/executor_test.py
@@ -9,7 +9,7 @@ from runtime.executor import LocalExecutor, RayExecutor, get_default_executor
 
 
 class TestLocalExecutor:
-    """Test LocalExecutor for sequential execution."""
+    """Test LocalExecutor's synchronous call API and workflow worker configuration."""
 
     def test_local_executor_submit_executes_immediately(self):
         """Test that LocalExecutor executes functions immediately."""
@@ -66,6 +66,16 @@ class TestLocalExecutor:
 
         with pytest.raises(ValueError, match="expected to return 2 values"):
             executor.submit(return_triple, num_returns=2)
+
+    @pytest.mark.parametrize("max_workers", [0, -1])
+    def test_local_executor_rejects_non_positive_max_workers(self, max_workers):
+        with pytest.raises(ValueError, match="greater than zero"):
+            LocalExecutor(max_workers=max_workers)
+
+    @pytest.mark.parametrize("max_workers", [True, 1.5, "2"])
+    def test_local_executor_rejects_non_integer_max_workers(self, max_workers):
+        with pytest.raises(TypeError, match="integer or None"):
+            LocalExecutor(max_workers=max_workers)
 
 
 @pytest.mark.ray

--- a/test/iceberg/table_test.py
+++ b/test/iceberg/table_test.py
@@ -3,7 +3,9 @@
 from tempfile import TemporaryDirectory
 
 import dataframely as dy
+import polars as pl
 import pytest
+from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.schema import Schema as IcebergSchema
 from pyiceberg.types import NestedField, StringType
 
@@ -184,6 +186,27 @@ class TestIcebergTableDataOperations:
 
         # The actual append functionality is PyIceberg's responsibility
         # We're just testing that the proxy works
+
+    def test_append_stops_after_retry_timeout(self, namespace, monkeypatch):
+        table = namespace.test_table
+        assert table._table is not None
+        attempts = 0
+
+        def fail_append(_data):
+            nonlocal attempts
+            attempts += 1
+            raise CommitFailedException("conflict")
+
+        monkeypatch.setattr(table._table, "append", fail_append)
+        monkeypatch.setattr(
+            "avalanche.iceberg.table._APPEND_RETRY_TIMEOUT_SECONDS",
+            0.0,
+        )
+
+        with pytest.raises(CommitFailedException, match="conflict"):
+            table.append(pl.DataFrame({"id": ["1"], "name": ["one"], "value": [1]}))
+
+        assert attempts == 1
 
     def test_scan_via_proxy(self, namespace):
         """Test that scan is proxied to PyIceberg."""

--- a/test/operator_tests/test_hooks.py
+++ b/test/operator_tests/test_hooks.py
@@ -1,12 +1,14 @@
 """Tests for RunHooks — callbacks fired during Workflow.run()."""
 
+import queue
 import threading
-from concurrent.futures import CancelledError
+from concurrent.futures import CancelledError, ThreadPoolExecutor
 
 import pytest
 
 from avalanche import LocalExecutor, RayExecutor, dest, source, step, workflow
 from runtime.operator.hooks import RunHooks
+from runtime.operator.run_worker import _QueueStream, _with_node_streams
 
 
 class TestRunHooks:
@@ -47,6 +49,115 @@ class TestRunHooks:
             assert events[i][0] == "start"
             assert events[i + 1][0] == "success"
             assert events[i][1] == events[i + 1][1]
+
+    def test_local_parallel_hooks_observe_both_branches(self):
+        both_running = threading.Barrier(2)
+        events = []
+
+        @source
+        def left():
+            both_running.wait(timeout=2)
+            return "left"
+
+        @source
+        def right():
+            both_running.wait(timeout=2)
+            return "right"
+
+        @dest
+        def join(left_value, right_value):
+            return left_value, right_value
+
+        @workflow
+        def parallel_sources():
+            return (left() & right()) >> join()
+
+        result = (
+            parallel_sources()
+            .run(
+                executor=LocalExecutor(max_workers=2),
+                hooks=RunHooks(
+                    on_node_start=lambda node_id: events.append(("start", node_id)),
+                    on_node_success=lambda node_id: events.append(("success", node_id)),
+                ),
+            )
+            .result(timeout=5)
+        )
+
+        assert result == ("left", "right")
+        assert {node_id for event, node_id in events[:2] if event == "start"} == {
+            "left_1",
+            "right_1",
+        }
+        assert {node_id for event, node_id in events if event == "success"} == {
+            "left_1",
+            "right_1",
+            "join_1",
+        }
+        assert [event for event, _node_id in events[:2]] == ["start", "start"]
+
+    def test_local_parallel_failure_drains_sibling_and_skips_descendant(self):
+        both_running = threading.Barrier(2)
+        sibling_completed = threading.Event()
+        descendant_started = threading.Event()
+        failures = []
+
+        @source
+        def failing():
+            both_running.wait(timeout=2)
+            raise ValueError("boom")
+
+        @source
+        def sibling():
+            both_running.wait(timeout=2)
+            sibling_completed.set()
+            return "sibling"
+
+        @step
+        def descendant(_value):
+            descendant_started.set()
+
+        @workflow
+        def parallel_sources():
+            return (failing() >> descendant()) & sibling()
+
+        with pytest.raises(ValueError, match="boom"):
+            parallel_sources().run(
+                executor=LocalExecutor(max_workers=2),
+                hooks=RunHooks(
+                    on_node_failure=lambda node_id, error: failures.append((node_id, error))
+                ),
+            ).result(timeout=5)
+
+        assert sibling_completed.is_set()
+        assert not descendant_started.is_set()
+        assert [(node_id, str(error)) for node_id, error in failures] == [("failing_1", "boom")]
+
+    def test_queue_stream_keeps_parallel_node_output_separate(self):
+        event_queue = queue.Queue()
+        stdout = _QueueStream(event_queue, "operator", 20)
+        stderr = _QueueStream(event_queue, "operator", 40)
+        both_running = threading.Barrier(2)
+
+        def emit(label):
+            stdout.write(f"{label}-")
+            both_running.wait(timeout=2)
+            stdout.write("done\n")
+
+        left = _with_node_streams("left_1", lambda: emit("left"), stdout, stderr)
+        right = _with_node_streams("right_1", lambda: emit("right"), stdout, stderr)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            assert [future.result() for future in (pool.submit(left), pool.submit(right))] == [
+                None,
+                None,
+            ]
+
+        events = [event_queue.get_nowait(), event_queue.get_nowait()]
+        assert {(event["node_id"], event["message"]) for event in events} == {
+            ("left_1", "left-done"),
+            ("right_1", "right-done"),
+        }
 
     def test_hooks_none_is_backward_compatible(self):
         @source

--- a/test/operator_tests/test_workflow_results.py
+++ b/test/operator_tests/test_workflow_results.py
@@ -1704,18 +1704,24 @@ def test_worker_seals_asynchronous_output_after_provisional_success(tmp_path):
     workflow_path.write_text(
         """
 import threading
-import time
 
 import avalanche as ava
+import runtime.operator.run_worker as run_worker_module
 
 
 @ava.source
 def value():
-    def delayed_output():
-        time.sleep(0.2)
-        print("background output after result")
+    original_put_terminal = run_worker_module._put_terminal_run_event
 
-    threading.Thread(target=delayed_output).start()
+    def put_terminal_then_emit_output(event_queue, event):
+        original_put_terminal(event_queue, event)
+        background = threading.Thread(
+            target=lambda: print("background output after result"),
+        )
+        background.start()
+        background.join()
+
+    run_worker_module._put_terminal_run_event = put_terminal_then_emit_output
     return "complete"
 
 
@@ -1896,7 +1902,16 @@ def test_failed_and_cancelled_runs_remove_their_pending_result_bundles(
     client.cancel_run(cancelled_id)
     assert _wait_for_terminal(client, cancelled_id).status == RunStatus.CANCELLED
 
-    assert {path.name for path in operator._result_store.root.iterdir()} == before
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        remaining = {path.name for path in operator._result_store.root.iterdir()}
+        if remaining == before:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("Pending result bundle was not removed")
+
+    assert remaining == before
     assert failed_id not in operator._stored_results
     assert cancelled_id not in operator._stored_results
 

--- a/test/run_handle_test.py
+++ b/test/run_handle_test.py
@@ -38,7 +38,7 @@ def test_run_returns_active_handle_with_canonical_context_id():
     release.set()
     assert handle.result(timeout=5) == (
         "caller-run",
-        "avalanche-run-caller-run",
+        "avalanche-local-caller-run_0",
         False,
     )
     assert handle.done()

--- a/test/storage/test_stream_contracts.py
+++ b/test/storage/test_stream_contracts.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any
 
@@ -97,6 +99,20 @@ def _rows(*ids: int) -> pl.DataFrame:
 def _value_rows(values: list[str]) -> pl.DataFrame:
     ids = list(range(1, len(values) + 1))
     return pl.DataFrame({"id": ids, "value": values})
+
+
+def test_concurrent_appends_preserve_every_data_version(table):
+    barrier = threading.Barrier(2)
+
+    def append(row_id: int):
+        barrier.wait()
+        return table.append(_rows(row_id))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(append, (1, 2)))
+
+    assert len({result.snapshot_id for result in results}) == 2
+    assert table.read().sort("id")["id"].to_list() == [1, 2]
 
 
 def test_consume_stream_reads_one_data_version_at_a_time(table):

--- a/test/stream_serialization_test.py
+++ b/test/stream_serialization_test.py
@@ -62,18 +62,18 @@ def test_iceberg_table_pickle_roundtrip_reconnects(file_backed_namespace):
 
 def test_reconnected_iceberg_tables_append_concurrently(file_backed_namespace):
     table = file_backed_namespace.records
-    restored = pickle.loads(pickle.dumps(table))
-    barrier = threading.Barrier(2)
+    handles = [table, *(pickle.loads(pickle.dumps(table)) for _ in range(7))]
+    barrier = threading.Barrier(len(handles))
 
     def append(target: IcebergTable, row_id: int):
         barrier.wait()
         return target.append(pl.DataFrame({"id": [row_id], "value": [str(row_id)]}))
 
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        results = list(pool.map(append, (table, restored), (1, 2)))
+    with ThreadPoolExecutor(max_workers=len(handles)) as pool:
+        results = list(pool.map(append, handles, range(1, len(handles) + 1)))
 
-    assert len({result.snapshot_id for result in results}) == 2
-    assert table.read().sort("id")["id"].to_list() == [1, 2]
+    assert len({result.snapshot_id for result in results}) == len(handles)
+    assert table.read().sort("id")["id"].to_list() == list(range(1, len(handles) + 1))
 
 
 class RecordModel(BaseModel):

--- a/test/stream_serialization_test.py
+++ b/test/stream_serialization_test.py
@@ -8,6 +8,8 @@ handle must carry the recipe to reconnect instead.
 from __future__ import annotations
 
 import pickle
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import dataframely as dy
@@ -56,6 +58,22 @@ def test_iceberg_table_pickle_roundtrip_reconnects(file_backed_namespace):
     # The restored handle must support writes too (ProgressStore needs them)
     restored.append(pl.DataFrame({"id": [2], "value": ["b"]}))
     assert restored.read().sort("id")["id"].to_list() == [1, 2]
+
+
+def test_reconnected_iceberg_tables_append_concurrently(file_backed_namespace):
+    table = file_backed_namespace.records
+    restored = pickle.loads(pickle.dumps(table))
+    barrier = threading.Barrier(2)
+
+    def append(target: IcebergTable, row_id: int):
+        barrier.wait()
+        return target.append(pl.DataFrame({"id": [row_id], "value": [str(row_id)]}))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(append, (table, restored), (1, 2)))
+
+    assert len({result.snapshot_id for result in results}) == 2
+    assert table.read().sort("id")["id"].to_list() == [1, 2]
 
 
 class RecordModel(BaseModel):

--- a/test/workflow_execution_test.py
+++ b/test/workflow_execution_test.py
@@ -1,5 +1,7 @@
 """Integration tests for Workflow execution with Ray."""
 
+import threading
+
 import pytest
 
 from avalanche.dag import dest, source, step, workflow
@@ -50,6 +52,34 @@ class TestWorkflowExecution:
 
         print("✓ Workflow executed locally!")
         print(f"  Result: {result}")
+
+    def test_workflow_parallel_execution_with_local_executor(self):
+        """Independent ``&`` branches overlap and fan in with stable argument order."""
+        both_running = threading.Barrier(2)
+
+        @source
+        def left():
+            both_running.wait(timeout=2)
+            return "left"
+
+        @source
+        def right():
+            both_running.wait(timeout=2)
+            return "right"
+
+        @dest
+        def join(left_value, right_value):
+            return left_value, right_value
+
+        @workflow
+        def parallel_workflow():
+            return (left() & right()) >> join()
+
+        result = (
+            parallel_workflow().run(executor=LocalExecutor(max_workers=2)).result(timeout=5)
+        )
+
+        assert result == ("left", "right")
 
     @pytest.mark.ray
     def test_workflow_execution_with_ray_executor(self):


### PR DESCRIPTION
## Rationale

`LocalExecutor` submitted every workflow node synchronously, so independent branches described with `&` still ran one after another. Local workflows need dependency-aware concurrency without changing the existing materialized-value executor API or weakening fan-in ordering.

## Summary

`LocalExecutor` now runs dependency-ready nodes in a bounded, per-run thread pool. `max_workers` can limit concurrency or force serial execution with one worker. The workflow driver retains stable argument and receipt ordering, reports node lifecycle hooks from the driver, drains running siblings after a failure, and does not start dependent nodes after failure or cancellation.

Local operator output capture now keeps buffers and node attribution thread-local so simultaneous nodes cannot mix their logs. The cursor example keeps model computation parallel but sends both results to one downstream transaction, avoiding concurrent commits to the shared Iceberg table.

The DAG API, execution-service guidance, architecture notes, and changelog describe the new behavior, its thread-based limits, and the single-writer fan-in pattern for shared transactional resources.

## Test Plan

- [x] `uv run pytest test/executor_test.py test/workflow_execution_test.py test/async_workflow_test.py test/operator_tests/test_hooks.py test/execution_services_test.py -m 'not ray' -q`
- [x] `uv run pytest test/workflow_execution_test.py::TestWorkflowExecution::test_workflow_parallel_execution_with_local_executor test/async_workflow_test.py::test_local_executor_runs_independent_async_nodes_concurrently test/operator_tests/test_hooks.py::TestRunHooks::test_queue_stream_keeps_parallel_node_output_separate -q`
- [x] `uv run pytest 'test/example_smoke_test.py::test_canonical_example_executes[examples/cursor_pattern.py]' -q`
- [x] `make lint`
- [x] `uv run ruff check examples/cursor_pattern.py`
- [x] `make smoke-test`