### PR TITLE
Operator scan overhaul

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,14 @@ Useful runtime examples:
 
 ```bash
 uv run python examples/complex_dag_pattern.py
-uv run ava dev --flows examples
-uv run ava operator --flows examples --port 7433
+uv run ava dev examples
+uv run ava operator examples --port 7433
 uv run ava tui --connect localhost:7433
 uv run ava tui                            # mock TUI
 ```
 
-Avoid `--flows .`: operator discovery imports Python files recursively. Use a narrow file or directory.
+Avoid `ava operator .`: operator discovery imports Python files recursively. Use a
+narrow file or directory.
 
 ## Code Conventions & Common Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,11 @@ narrow file or directory.
 Every PR MUST add an entry under `## Unreleased` in `CHANGELOG.md` describing
 its user-facing change.
 
+Before drafting or updating a PR description, MUST inspect the complete diff
+against its base branch (`git diff origin/main...HEAD` for this repository) and
+describe every substantive change. Do not summarize only the most recent task or
+commit.
+
 Every PR description must be self-contained, use plain and direct language, and start with
 these sections in this order:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ or webhook-triggered runs, observability, or a UI:
 
 ```bash
 # From the repository root
-uv run ava operator --flows examples --port 7433
+uv run ava operator examples --port 7433
 
 # In another terminal
 uv run ava web --connect localhost:7433
@@ -95,9 +95,10 @@ uv run ava web --connect localhost:7433
 uv run ava tui --connect localhost:7433
 ```
 
-`ava dev --flows examples` is the browser-oriented convenience command. It
-starts an operator subprocess and a connected `ava web` subprocess; the browser
-UI listens on `http://127.0.0.1:7435` by default. It does not start the TUI.
+`ava dev examples` is the browser-oriented convenience command. One process
+owns discovery, the operator gRPC server, and the connected browser UI; it waits
+for gRPC readiness before starting the UI. The browser UI listens on
+`http://127.0.0.1:7435` by default. It does not start the TUI.
 
 ## Workflow authoring and runtime
 
@@ -198,9 +199,9 @@ storage default:
 
 ### Discovery catalog
 
-`WorkflowRegistry` receives configured `--flows` paths. A file target is one
-candidate; a directory target is recursively scanned for public `*.py` files.
-Private files beginning with `_` and hidden/generated directories are skipped.
+`WorkflowRegistry` receives resolved workflow targets. A file target is one
+candidate; a directory target is recursively scanned for public `*.py`
+files. Private files beginning with `_` and hidden/generated directories are skipped.
 Each candidate is discovered in a short-lived process, which:
 
 1. imports the module through its normal package path when applicable;
@@ -216,16 +217,22 @@ Python environment and source metadata. The cache contains descriptors and
 paths, never live workflow callables.
 
 Discovery imports arbitrary configured source. Workflow modules and builders
-must be import-safe and side-effect-light. Do not scan a repository root unless
-it is deliberately a flow-only tree:
+must be import-safe and side-effect-light. `ava operator` and `ava dev` use
+explicit existing file or directory targets when supplied. Otherwise they read
+`[tool.avalanche].flow_targets` from the nearest `pyproject.toml`; each relative
+path is resolved from that file's directory. Do not configure a repository root
+unless it is deliberately a flow-only tree:
 
 ```bash
-# Avoid from a repository root containing unrelated Python.
-uv run ava operator --flows .
+# Avoid in a mixed repository:
+uv run ava operator .
 
-# Prefer a specific module or flow directory.
-uv run ava operator --flows examples
+# Prefer an explicit specific module or flow directory:
+uv run ava operator examples
 ```
+
+An explicit target list replaces configured targets. If neither is present, the
+command fails before starting services; it never falls back to the current directory.
 
 ### Live reload and scheduled metadata
 
@@ -233,6 +240,10 @@ The live watcher observes only non-excluded Python files below resolved import
 roots. A changed workflow module or imported Python helper triggers targeted
 discovery; adding or deleting a Python candidate updates the catalog without
 reimporting unrelated candidates.
+
+Any discovery failure is terminal for the local operator. A failed targeted scan
+does not leave a stale catalog serving runs; startup or live reload exits with
+the discovery diagnostic.
 
 Live watching intentionally ignores non-Python changes. If a workflow reads an
 import-time resource such as JSON to define a cron expression, restart the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 ### Dependencies
 
 - Updated the operator web workspace's transitive `nanoid` package to 3.3.18.
+### Operator CLI
+
+- `ava operator` and `ava dev` now use `[tool.avalanche].flow_targets` when
+  positional flow targets are omitted. Explicit targets replace that configured
+  list, and commands without either source fail instead of scanning the current
+  directory.
+- Discovery failures now stop local operator and development services rather
+  than leaving a stale workflow catalog running.
+- `ava dev` starts the operator and browser UI under one lifecycle supervisor.
+- `ava init` now configures its starter workspace to scan `src/`, so
+  `uv run ava dev` discovers newly added starter workflows without a local wrapper.
 
 ## 0.2.0
 
@@ -260,8 +271,8 @@ toolkit.
 - Production auth, authorization, TLS, and multitenancy are out of scope.
 - One-click cloud deploy and schema migration CLI are not implemented.
 - Durable operator replay/recovery is limited to the current implementation.
-- `--flows .` from the repository root is unsafe because discovery imports Python
-  files; use a specific flow file or clean flow-only directory.
+- `ava operator .` from the repository root is unsafe because discovery imports
+  Python files; use a specific flow file or clean flow-only directory.
 - Some tests may be skipped when optional local services or terminal features are
   unavailable.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,9 @@ uv build
 
 - Document only commands that exist and are tested or clearly marked interactive.
 - Use `ava` for the CLI command. Do not document an `avalanche` console command.
-- Public CLI docs should say `flow` and `--flows`.
+- Public CLI docs should explain that `operator` and `dev` use explicit
+  positional flow targets or `[tool.avalanche].flow_targets`, not a `--flows`
+  flag or a current-directory default.
 - Keep historical or speculative material out of onboarding docs unless it is
   clearly marked as non-release context.
 

--- a/README.md
+++ b/README.md
@@ -160,39 +160,50 @@ $avalanche <Describe your wanted outcome here>
 
 ### Running the operator and Web UI
 
-The operator scans your code for workflows, then loads and runs them:
+In a workspace configured with `[tool.avalanche].flow_targets`, the operator
+scans that code for workflows, then loads and runs them:
 
 ```bash
 uv run ava operator
 ```
 
-The Web UI reflects the state of the oeprator:
+The Web UI reflects the state of the operator:
 
 ```bash
 uv run ava web
 ```
 
-Start the operator and Web UI together:
+Start the operator and Web UI together from a configured workspace:
 
 ```bash
 uv run ava dev
 ```
 
-You can pass `--flows` to `operator` or `dev` to point the operator scan to a certain file or directory:
+`ava init` writes this workspace configuration, so the starter command scans
+every Python workflow below `src/`:
 
-```bash
-uv run ava dev --flows ./flow.py
+```toml
+[tool.avalanche]
+flow_targets = ["src"]
 ```
 
-Otherwise, the scan defaults to the current working directory.
+`operator` and `dev` use `flow_targets` when positional `FLOW` values are
+omitted. Configuration paths are relative to that `pyproject.toml`. Passing one
+or more `FLOW` values replaces the configuration rather than adding to it:
+
+```bash
+uv run ava operator ./flows ./shared_flows --port 7433
+```
+
+Without explicit targets or a nonempty `flow_targets` setting, the command
+stops before starting services. It never scans the current directory by default.
 
 Discovery allows 60 seconds per scan by default. Pass `--discovery-timeout SECONDS`
 to `ava operator` or `ava dev` to set a different positive, finite limit.
 
 > [!WARNING]
-> `ava dev` or `ava operator` without `--flows` scans every eligible Python file below the current
-> working directory. Run it only from a dedicated flow workspace; otherwise pass
-> a specific flow file or flow-only directory with `--flows`.
+> Discovery imports eligible Python modules beneath each target. Use a specific
+> flow file or dedicated flow directory, not a mixed repository root.
 
 Similarily, you can pass `--connect` to the Web UI to change the operator url to connect to:
 

--- a/docs-site/build-workflows/build-with-skill.mdx
+++ b/docs-site/build-workflows/build-with-skill.mdx
@@ -35,7 +35,7 @@ Keep workflow modules in the workspace, then start the operator against a
 specific flow path:
 
 ```bash
-uv run ava dev --flows ./src/my_workflow/flow.py
+uv run ava dev ./src/my_workflow/flow.py
 ```
 
 The skill helps create workflow code; it does not replace review. Read the

--- a/docs-site/extend/executors.mdx
+++ b/docs-site/extend/executors.mdx
@@ -25,7 +25,7 @@ or pass `--ray` to the local operator:
 
 ```bash
 uv add "avalanche-ai[ray]"
-uv run ava dev --flows ./flows --ray
+uv run ava dev ./flows --ray
 ```
 
 ```python

--- a/docs-site/getting-started/existing-project.mdx
+++ b/docs-site/getting-started/existing-project.mdx
@@ -50,7 +50,7 @@ Put a workflow in a known module, then start the local operator against that
 module or a flow-only directory:
 
 ```bash
-uv run ava dev --flows ./flow.py
+uv run ava dev ./flow.py
 ```
 
 <Warning>

--- a/docs-site/getting-started/starter-project.mdx
+++ b/docs-site/getting-started/starter-project.mdx
@@ -40,6 +40,17 @@ uv run ava dev
 `http://127.0.0.1:7435`, select the included `binary_converter` workflow, and
 start a run.
 
+The initializer also writes this setting to `pyproject.toml`, so newly added
+workflows beneath `src/` are included without changing a local command wrapper:
+
+```toml
+[tool.avalanche]
+flow_targets = ["src"]
+```
+
+Pass `FLOW` values to `ava dev` only when you want to scan a different explicit
+set; they replace the configured `src/` target.
+
 ## What you should see
 
 The workflow appears in the local UI and progresses through its source, native

--- a/docs-site/reference/cli-reference.mdx
+++ b/docs-site/reference/cli-reference.mdx
@@ -22,24 +22,31 @@ configures them as editable dependencies.
 ## `operator`
 
 ```text
-ava operator [--flows PATH ...] [--port PORT] [--host HOST]
+ava operator [FLOW [FLOW ...]] [--port PORT] [--host HOST]
              [--webhook-port PORT] [--log-level LEVEL] [--ray]
              [--discovery-timeout SECONDS]
 ```
 
-Starts the local flow operator. `--flows` accepts one or more flow files or
-directories and defaults to the current directory. The defaults are gRPC port
-`7433`, loopback host `127.0.0.1`, webhook port `7434`, and `WARNING` log level.
+Starts the local flow operator. `FLOW` values are existing Python files or
+directories. When omitted, the command reads
+`[tool.avalanche].flow_targets` from the nearest `pyproject.toml`; configured
+relative paths resolve from that file. Explicit `FLOW` values replace configured
+targets. Without either, the command stops before services start and never
+scans the current directory by default. Defaults: gRPC port `7433`, loopback
+host `127.0.0.1`, webhook port `7434`, and `WARNING` log level. A discovery
+error stops the operator with its diagnostic.
 
 ## `dev`
 
 ```text
-ava dev [--flows PATH ...] [--port PORT] [--web-port PORT]
-        [--ray] [--discovery-timeout SECONDS]
+ava dev [FLOW [FLOW ...]] [--port PORT] [--web-port PORT] [--ray]
+        [--log-level LEVEL] [--discovery-timeout SECONDS]
 ```
 
-Starts an operator subprocess and connected browser UI. Defaults: operator port
-`7433`, browser UI port `7435`.
+Starts discovery, the local operator, and a connected browser UI under one
+supervisor. It resolves targets with the same explicit-or-workspace-configuration
+rules as `operator`. The UI starts only after the gRPC listener is ready.
+Defaults: operator port `7433`, browser UI port `7435`.
 
 ## `web`
 

--- a/docs-site/reference/examples.mdx
+++ b/docs-site/reference/examples.mdx
@@ -8,7 +8,7 @@ The repository's standalone examples are smoke-tested. Run them from the
 
 ```bash
 cd examples
-uv run ava dev
+uv run ava dev .
 ```
 
 ## Start here
@@ -53,7 +53,7 @@ workflow. It:
 Start it against its dedicated flow module:
 
 ```bash
-uv run ava dev --flows customer_feedback_review/flow.py
+uv run ava dev customer_feedback_review/flow.py
 ```
 
 Generated example artifacts land beneath `.avalanche/outputs/feedback_review/`

--- a/docs-site/run-observe/cli.mdx
+++ b/docs-site/run-observe/cli.mdx
@@ -9,13 +9,13 @@ description: Start local services, control operator runs, and retrieve results w
 
 ```bash
 # Discover flows and serve gRPC.
-uv run ava operator --flows ./flows
+uv run ava operator ./flows
 
 # Serve the browser UI for a running operator.
 uv run ava web --connect localhost:7433
 
 # Start both together.
-uv run ava dev --flows ./flows
+uv run ava dev ./flows
 ```
 
 Use `--ray` with `operator` or `dev` when the selected workflows should use the

--- a/docs-site/run-observe/operator.mdx
+++ b/docs-site/run-observe/operator.mdx
@@ -9,13 +9,23 @@ local run state, and serves the CLI, browser UI, and TUI over gRPC.
 Start it against a specific flow file or directory:
 
 ```bash
-uv run ava operator --flows ./flow.py
+uv run ava operator ./flow.py
 
 # Or a dedicated directory of flows:
-uv run ava operator --flows ./flows --port 7433
+uv run ava operator ./flows --port 7433
 ```
 
-The default listener is `127.0.0.1:7433`.
+For a normal workspace command without `FLOW`, configure the dedicated flow
+tree in `pyproject.toml`:
+
+```toml
+[tool.avalanche]
+flow_targets = ["src/workflows"]
+```
+
+Configured relative paths are resolved from that `pyproject.toml`. Explicit
+`FLOW` values replace this list; without either source, the command fails before
+starting services. The default listener is `127.0.0.1:7433`.
 
 ## Keep discovery narrow
 
@@ -25,13 +35,13 @@ scan a repository root containing unrelated Python:
 
 ```bash
 # Avoid in a mixed repository:
-uv run ava operator --flows .
+uv run ava operator .
 
 # Prefer:
-uv run ava operator --flows ./src/workflows
+uv run ava operator ./src/workflows
 ```
 
-`ava dev --flows PATH` starts this operator together with a connected browser
+`ava dev [FLOW [FLOW ...]]` starts this operator together with a connected browser
 UI. Use it for the normal local development loop.
 
 ## What the operator owns
@@ -45,7 +55,8 @@ nodes themselves.
 ## Reload and scheduled metadata
 
 The operator watches eligible Python source below configured roots. A changed
-workflow module or imported Python helper triggers targeted rediscovery.
+workflow module or imported Python helper triggers targeted rediscovery. A
+discovery error stops the local operator rather than retaining a stale catalog.
 Non-Python import-time configuration is not watched; restart the operator after
 changing it.
 

--- a/docs-site/run-observe/troubleshooting.mdx
+++ b/docs-site/run-observe/troubleshooting.mdx
@@ -8,7 +8,7 @@ description: Resolve the most common local discovery, provider, connection, and 
 Point discovery at a specific flow file or dedicated directory:
 
 ```bash
-uv run ava dev --flows ./src/my_workflow/flow.py
+uv run ava dev ./src/my_workflow/flow.py
 ```
 
 The operator imports candidate Python modules. Keep workflow builders
@@ -33,7 +33,7 @@ must be available to the process running the workflow.
 Confirm the operator is running at the address passed to `ava web`:
 
 ```bash
-uv run ava operator --flows ./flows --port 7433
+uv run ava operator ./flows --port 7433
 uv run ava web --connect localhost:7433 --port 7435
 ```
 

--- a/docs-site/run-observe/web-ui.mdx
+++ b/docs-site/run-observe/web-ui.mdx
@@ -10,7 +10,7 @@ the configured operator.
 ## Start the complete local loop
 
 ```bash
-uv run ava dev --flows ./flows
+uv run ava dev ./flows
 ```
 
 This starts an operator and a connected browser UI. The UI listens on

--- a/docs/dag-api.md
+++ b/docs/dag-api.md
@@ -295,8 +295,9 @@ needs workflow input; it is not restored from the source run.
   network calls, or data processing there.
 - Task enable/disable modifiers such as `.skip()` and `.only()` are not part of
   the current release-candidate API.
-- Operator/TUI discovery imports Python files. Point `--flows` to a flow file or
-  dedicated flow directory, not the repository root.
+- Operator/TUI discovery imports Python files. Pass positional flow targets to
+  `ava operator` or `ava dev`, or configure `[tool.avalanche].flow_targets` in
+  `pyproject.toml`; use a flow file or dedicated flow directory, not the repository root.
 
 See [`examples/complex_dag_pattern.py`](../examples/complex_dag_pattern.py) for a
 runnable DAG example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,11 +6,11 @@ are covered by `test/example_smoke_test.py`.
 Run the examples from this directory:
 
 ```bash
-uv run ava dev
+uv run ava dev .
 ```
 
-This starts the local operator and browser UI. The operator discovers the
-workflows in `examples/`; select any discovered workflow in the UI to start a
+This explicit target keeps discovery inside `examples/`. The local operator and
+browser UI start together; select any discovered workflow in the UI to start a
 run.
 
 ## Canonical Examples

--- a/examples/customer_feedback_review/README.md
+++ b/examples/customer_feedback_review/README.md
@@ -134,7 +134,7 @@ def feedback_review():
 We run the workflow with the dev command:
 
 ```bash
-uv run ava dev --flows customer_feedback_review/flow.py
+uv run ava dev customer_feedback_review/flow.py
 ```
 
 The resulting graph has 5 execution stages, with 7 total nodes, 3 ava.step and 4 ava.agent_step:

--- a/examples/operator_workflow.py
+++ b/examples/operator_workflow.py
@@ -4,7 +4,7 @@ Run directly:
     uv run python examples/operator_workflow.py
 
 Run through the operator:
-    uv run ava operator --flows examples/operator_workflow.py
+    uv run ava operator examples/operator_workflow.py
 """
 
 from __future__ import annotations

--- a/init.sh
+++ b/init.sh
@@ -348,7 +348,7 @@ main() {
     printf '.env contains %s and is ignored by Git.\n' "$credential_env"
   fi
   printf '\nStart the demo with:\n'
-  printf '  uv run ava dev --flows src/binary_converter/\n'
+  printf '  uv run ava dev\n'
 }
 
 main "$@"
@@ -376,24 +376,17 @@ Each direct child of `src/` is one workflow. Do not add a wrapper package such
 as `src/avalanche_workflows/`, and do not create a separate `pyproject.toml` or
 virtual environment for each workflow.
 
-## Starter flow
-
-Reconfigure the model provider at any time with:
+`pyproject.toml` configures `src/` as the workspace flow target. The normal
+command scans every flow beneath that dedicated directory:
 
 ```bash
-bash scripts/configure-provider.sh
+uv run ava dev
 ```
 
-The script stores API keys in the Git-ignored `.env` when needed. Do not place
-credentials in `src/binary_converter/flow.py`.
-
-## Execution boundary
-
-Flows execute through Avalanche's operator. This workspace contains flow
-declarations only. From the workspace root, start the starter flow with:
+To scan one flow instead of the configured workspace target:
 
 ```bash
-uv run ava dev --flows src/binary_converter/
+uv run ava dev src/binary_converter/flow.py
 ```
 EOF
 
@@ -444,6 +437,12 @@ EOF
 
   cat >>"$staging_root/pyproject.toml" <<'EOF'
 
+[tool.avalanche]
+flow_targets = ["src"]
+EOF
+
+  cat >>"$staging_root/pyproject.toml" <<'EOF'
+
 [project.optional-dependencies]
 codex-lm = ["predict-rlm[codex-lm]"]
 EOF
@@ -470,9 +469,9 @@ EOF
 EOF
   chmod 600 "$staging_root/.env"
 
+  write_starter_flow
   uv sync --no-dev --directory "$staging_root"
 
-  write_starter_flow
   write_provider_configurator
   write_workspace_guidance
 }
@@ -482,6 +481,7 @@ verify_workspace() {
   (
     cd "$root"
     .venv/bin/python -B -c 'import avalanche; print(avalanche.__file__)'
+    uv run ava dev --help >/dev/null
 
     if [[ "$use_editable_dependencies" == true ]]; then
       .venv/bin/python -B -c '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ examples = [
     "openpyxl>=3.1,<4",
 ]
 
+[tool.avalanche]
+flow_targets = ["examples/operator_workflow.py"]
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-rP --testdox"

--- a/skills/avalanche/SKILL.md
+++ b/skills/avalanche/SKILL.md
@@ -435,35 +435,39 @@ the TUI is an optional terminal alternative.
 
 See more details in the usage reference [usage.md](references/usage.md)
 
-For the combined local path, use:
+For the combined local path, use a specific target or workspace configuration:
 
 ```bash
-uv run ava dev --flows <flow-file-or-clean-flow-directory>
+uv run ava dev [<flow-file-or-clean-flow-directory> ...]
 ```
 
-`ava dev` starts the local operator and browser UI. Its flags are:
+`ava dev` starts the local operator and browser UI. When no `FLOW` is supplied,
+it reads `[tool.avalanche].flow_targets` from the nearest `pyproject.toml`;
+relative entries resolve from that file. Explicit `FLOW` values replace the
+configured list. Without either, the command fails before services start and
+never scans the current directory by default. Its flags are:
 
-- `--flows PATH [PATH ...]`: one or more flow files or directories to scan;
 - `--port PORT`: operator gRPC port, default `7433`;
 - `--web-port PORT`: browser UI HTTP port, default `7435`; it must differ from
   `--port`;
 - `--ray`: use the Ray executor.
 
-Use a specific flow file or a clean flow-only directory; never use `--flows .`.
+Use a specific flow file or a clean configured flow-only directory; never pass
+a mixed repository root.
 
 For separate processes or a custom browser-listener host, start them in separate
 terminals:
 
 ```bash
-uv run ava operator --flows <flow-file-or-clean-flow-directory> \
+uv run ava operator [<flow-file-or-clean-flow-directory> ...] \
   --host 127.0.0.1 --port 7433 --webhook-port 7434 --log-level WARNING
 uv run ava web --connect localhost:7433 --host 127.0.0.1 --port 7435
 ```
 
-`ava operator` also accepts `--ray`. Its `--log-level` accepts `DEBUG`, `INFO`,
-`WARNING`, or `ERROR`. `ava web` connects with `--connect HOST:PORT`; use
-`--trusted-proxy` only for non-loopback traffic protected by a trusted,
-authenticated proxy.
+`ava operator` resolves targets with the same explicit-or-configured rule. It
+also accepts `--ray`. Its `--log-level` accepts `DEBUG`, `INFO`, `WARNING`, or
+`ERROR`. `ava web` connects with `--connect HOST:PORT`; use `--trusted-proxy`
+only for non-loopback traffic protected by a trusted, authenticated proxy.
 
 Start a discovered workflow with:
 

--- a/skills/avalanche/references/usage.md
+++ b/skills/avalanche/references/usage.md
@@ -62,19 +62,21 @@ attribute names—read `.completion` for the signature above, not `.summary`.
 Use this when the user asks to start a local operator and browser UI together:
 
 ```bash
-uv run ava dev --flows path/to/flow.py
+uv run ava dev path/to/flow.py
 ```
 
 `ava dev` starts the operator on `127.0.0.1:7433` and a browser UI connected to
 it at `http://127.0.0.1:7435` by default.
 
 ```text
-uv run ava dev [--flows PATH [PATH ...]] [--port PORT] [--web-port PORT] [--ray]
+uv run ava dev [FLOW [FLOW ...]] [--port PORT] [--web-port PORT] [--ray]
 ```
 
-- `--flows PATH [PATH ...]`: one or more flow files or clean flow-only
-  directories. It defaults to the current directory, but use a narrow target;
-  never pass `--flows .`.
+- `FLOW [FLOW ...]`: optional flow files or clean flow-only directories. When
+  omitted, the command uses `[tool.avalanche].flow_targets` in the nearest
+  `pyproject.toml`; relative paths resolve from that file.
+- Explicit `FLOW` values replace configured targets. Without either source, the
+  command fails before starting services; there is no current-directory default.
 - `--port PORT`: operator gRPC port, default `7433`.
 - `--web-port PORT`: browser UI HTTP port, default `7435`. It must differ from
   `--port`.
@@ -90,7 +92,7 @@ custom browser-listener settings:
 
 ```bash
 # terminal 1
-uv run ava operator --flows path/to/flow.py --port 7433
+uv run ava operator path/to/flow.py --port 7433
 
 # terminal 2
 uv run ava web --connect localhost:7433
@@ -100,12 +102,13 @@ uv run ava web --connect localhost:7433
 separately.
 
 ```text
-uv run ava operator [--flows PATH [PATH ...]] [--host HOST] [--port PORT]
+uv run ava operator [FLOW [FLOW ...]] [--host HOST] [--port PORT]
                         [--webhook-port PORT] [--log-level LEVEL] [--ray]
 ```
 
-- `--flows PATH [PATH ...]`: flow discovery targets; use narrow paths, never
-  `.`.
+- `FLOW [FLOW ...]`: optional flow discovery targets. Without them, the command
+  uses `[tool.avalanche].flow_targets` from the nearest `pyproject.toml`; explicit
+  targets replace it. Use narrow paths, never a mixed repository root.
 - `--host HOST`: gRPC listen host, default `127.0.0.1`. Non-loopback exposure
   requires an external trusted, authenticated boundary.
 - `--port PORT`: gRPC port, default `7433`.

--- a/src/ava_cli/app.py
+++ b/src/ava_cli/app.py
@@ -1401,11 +1401,10 @@ def _run_dev(args: argparse.Namespace) -> int:
     grpc_server = None
     browser_server = None
     exit_code = 0
-    stop_requested = threading.Event()
     previous_handlers = {}
 
     def request_shutdown(_signum, _frame) -> None:
-        stop_requested.set()
+        raise KeyboardInterrupt
 
     if threading.current_thread() is threading.main_thread():
         for signum in (signal.SIGINT, signal.SIGTERM):
@@ -1421,8 +1420,6 @@ def _run_dev(args: argparse.Namespace) -> int:
             discovery_timeout=args.discovery_timeout,
             executor_backend="ray" if args.ray else "local",
         )
-        if stop_requested.is_set():
-            raise KeyboardInterrupt
         workflow_count = len(operator.get_catalog().workflows)
         print(
             f"  Discovered {workflow_count} workflow"
@@ -1438,8 +1435,6 @@ def _run_dev(args: argparse.Namespace) -> int:
         finally:
             channel.close()
         print(f"  Operator ready: grpc://{operator_address}")
-        if stop_requested.is_set():
-            raise KeyboardInterrupt
 
         stage = "web UI startup"
         browser_server = start_browser_server(operator_address, port=args.web_port)
@@ -1448,11 +1443,10 @@ def _run_dev(args: argparse.Namespace) -> int:
         print("Ready. Press Ctrl-C to stop.")
 
         stage = "workflow watching"
-        while not stop_requested.is_set():
+        while True:
             failure = operator.wait_for_failure(timeout=0.1)
             if failure is not None:
                 raise failure
-        print("Stopping Avalanche dev...")
     except KeyboardInterrupt:
         print("Stopping Avalanche dev...")
     except WorkflowDiscoveryError as exc:

--- a/src/ava_cli/app.py
+++ b/src/ava_cli/app.py
@@ -7,12 +7,15 @@ import ctypes
 import errno
 import hashlib
 import json
+import logging
 import math
 import os
 import re
+import signal
 import stat
 import subprocess
 import sys
+import threading
 import time
 import webbrowser
 from collections.abc import Sequence
@@ -20,7 +23,12 @@ from importlib.resources import as_file, files
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
-from runtime.operator.discovery import DEFAULT_DISCOVERY_TIMEOUT, validate_discovery_timeout
+from runtime.operator.discovery import (
+    DEFAULT_DISCOVERY_TIMEOUT,
+    WorkflowDiscoveryError,
+    validate_discovery_timeout,
+)
+from runtime.operator.workspace_config import format_scan_targets, select_workflow_targets
 
 _RENAME_NOREPLACE = 1
 _RENAME_EXCL = 0x00000004
@@ -28,6 +36,8 @@ _STAGED_OUTPUT_NAME = "result"
 _MAX_STAGED_OUTPUT_ENTRIES = 2048
 _MAX_STAGED_OUTPUT_DEPTH = 8
 _MAX_PARENT_IDENTITY_SCAN = 4096
+
+_OPERATOR_READY_TIMEOUT_SECONDS = 5.0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -38,6 +48,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command in {"dev", "operator"}:
         try:
             validate_discovery_timeout(args.discovery_timeout)
+            if args.command == "dev":
+                selection = select_workflow_targets(args.flows)
+                args.flows = list(selection.paths)
+                args.flow_target_selection = selection
         except ValueError as exc:
             parser.error(str(exc))
     if not hasattr(args, "handler"):
@@ -70,11 +84,10 @@ def _build_parser() -> argparse.ArgumentParser:
         allow_abbrev=False,
     )
     operator.add_argument(
-        "--flows",
-        nargs="+",
-        default=["."],
-        metavar="PATH",
-        help="flow file or directory to scan (default: current directory)",
+        "flows",
+        nargs="*",
+        metavar="FLOW",
+        help="workflow Python file or directory; uses workspace configuration when omitted",
     )
     operator.add_argument("--port", type=int, default=7433, help="operator gRPC port")
     operator.add_argument(
@@ -239,15 +252,21 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Start a local operator and wait until it stops.",
     )
     dev.add_argument(
-        "--flows",
-        nargs="+",
-        default=["."],
-        metavar="PATH",
-        help="flow file or directory to scan (default: current directory)",
+        "flows",
+        nargs="*",
+        metavar="FLOW",
+        help="workflow Python file or directory; uses workspace configuration when omitted",
     )
     dev.add_argument("--port", type=int, default=7433, help="operator gRPC port")
     dev.add_argument("--web-port", type=int, default=7435, help="browser UI HTTP port")
     dev.add_argument("--ray", action="store_true", help="use the Ray executor")
+    dev.add_argument(
+        "--log-level",
+        type=str.upper,
+        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+        default="WARNING",
+        help="terminal log level (default: WARNING)",
+    )
     dev.add_argument(
         "--discovery-timeout",
         type=float,
@@ -274,7 +293,6 @@ def _run_init(args: argparse.Namespace) -> int:
 
 def _run_operator(args: argparse.Namespace) -> int:
     runtime_args = [
-        "--flows",
         *args.flows,
         "--host",
         args.host,
@@ -303,20 +321,7 @@ def _run_web(args: argparse.Namespace) -> int:
     )
     print(f"Avalanche web UI: {server.endpoint}")
     try:
-        try:
-            opened = webbrowser.open(server.endpoint, new=2)
-        except webbrowser.Error as exc:
-            print(
-                f"Could not open a browser automatically ({exc}); "
-                f"open {server.endpoint} manually.",
-                file=sys.stderr,
-            )
-        else:
-            if not opened:
-                print(
-                    f"Could not open a browser automatically; open {server.endpoint} manually.",
-                    file=sys.stderr,
-                )
+        _open_browser(server.endpoint)
         server.wait()
     except KeyboardInterrupt:
         return 0
@@ -1383,47 +1388,140 @@ def _launch_tui(argv: Sequence[str]) -> None:
 
 
 def _run_dev(args: argparse.Namespace) -> int:
-    port = args.port
-    web_port = args.web_port
-    operator_process = _start_operator_process(
-        args.flows, port, args.ray, args.discovery_timeout
-    )
-    web_process = None
+    import grpc
+
+    from runtime.operator.operator import Operator
+    from runtime.operator.server import serve as serve_operator
+    from runtime.operator.web import start_browser_server
+
+    _configure_terminal_logging(args.log_level)
+    started = time.monotonic()
+    stage = "discovery"
+    operator = None
+    grpc_server = None
+    browser_server = None
+    exit_code = 0
+    stop_requested = threading.Event()
+    previous_handlers = {}
+
+    def request_shutdown(_signum, _frame) -> None:
+        stop_requested.set()
+
+    if threading.current_thread() is threading.main_thread():
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signum] = signal.getsignal(signum)
+            signal.signal(signum, request_shutdown)
     try:
-        web_process = _start_web_process(f"127.0.0.1:{port}", web_port)
-        return operator_process.wait()
+        print("Avalanche dev")
+        for line in format_scan_targets(args.flow_target_selection):
+            print(line)
+        print("  Discovering workflows...")
+        operator = Operator(
+            args.flows,
+            discovery_timeout=args.discovery_timeout,
+            executor_backend="ray" if args.ray else "local",
+        )
+        if stop_requested.is_set():
+            raise KeyboardInterrupt
+        workflow_count = len(operator.get_catalog().workflows)
+        print(
+            f"  Discovered {workflow_count} workflow"
+            f"{'' if workflow_count == 1 else 's'} in {time.monotonic() - started:.2f}s"
+        )
+
+        stage = "operator startup"
+        grpc_server = serve_operator(operator, port=args.port, block=False)
+        operator_address = f"127.0.0.1:{args.port}"
+        channel = grpc.insecure_channel(operator_address)
+        try:
+            grpc.channel_ready_future(channel).result(timeout=_OPERATOR_READY_TIMEOUT_SECONDS)
+        finally:
+            channel.close()
+        print(f"  Operator ready: grpc://{operator_address}")
+        if stop_requested.is_set():
+            raise KeyboardInterrupt
+
+        stage = "web UI startup"
+        browser_server = start_browser_server(operator_address, port=args.web_port)
+        print(f"  Web UI ready: {browser_server.endpoint}")
+        _open_browser(browser_server.endpoint)
+        print("Ready. Press Ctrl-C to stop.")
+
+        stage = "workflow watching"
+        while not stop_requested.is_set():
+            failure = operator.wait_for_failure(timeout=0.1)
+            if failure is not None:
+                raise failure
+        print("Stopping Avalanche dev...")
+    except KeyboardInterrupt:
+        print("Stopping Avalanche dev...")
+    except WorkflowDiscoveryError as exc:
+        _report_dev_failure(stage, exc)
+        exit_code = 1
+    except Exception as exc:
+        _report_dev_failure(stage, exc)
+        exit_code = 1
     finally:
-        if web_process is not None:
-            _stop_operator_process(web_process)
-        _stop_operator_process(operator_process)
+        cleanup_error: Exception | None = None
+        if browser_server is not None:
+            try:
+                browser_server.close()
+            except Exception as exc:
+                cleanup_error = exc
+        if grpc_server is not None:
+            try:
+                grpc_server.stop(grace=1.0).wait(timeout=2.0)
+            except Exception as exc:
+                cleanup_error = cleanup_error or exc
+        if operator is not None:
+            try:
+                operator.close()
+            except Exception as exc:
+                cleanup_error = cleanup_error or exc
+        if cleanup_error is not None:
+            _report_dev_failure("shutdown", cleanup_error)
+            exit_code = 1
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+    if exit_code == 0:
+        print("Stopped.")
+    return exit_code
 
 
-def _start_operator_process(
-    flows: list[str],
-    port: int,
-    use_ray: bool,
-    discovery_timeout: float,
-) -> subprocess.Popen:
-    cmd = [
-        sys.executable,
-        "-m",
-        "runtime.operator",
-        "--flows",
-        *flows,
-        "--port",
-        str(port),
-        "--discovery-timeout",
-        str(discovery_timeout),
-    ]
-    if use_ray:
-        cmd.append("--ray")
-    return subprocess.Popen(cmd)
-
-
-def _start_web_process(address: str, port: int) -> subprocess.Popen:
-    return subprocess.Popen(
-        [sys.executable, "-m", "ava_cli", "web", "--connect", address, "--port", str(port)]
+def _configure_terminal_logging(level_name: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level_name),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        force=True,
     )
+
+
+def _open_browser(endpoint: str) -> None:
+    try:
+        opened = webbrowser.open(endpoint, new=2)
+    except webbrowser.Error as exc:
+        print(
+            f"Could not open a browser automatically ({exc}); open {endpoint} manually.",
+            file=sys.stderr,
+        )
+    else:
+        if not opened:
+            print(
+                f"Could not open a browser automatically; open {endpoint} manually.",
+                file=sys.stderr,
+            )
+
+
+def _report_dev_failure(stage: str, error: Exception) -> None:
+    print(f"error: Avalanche dev failed during {stage}", file=sys.stderr)
+    if isinstance(error, WorkflowDiscoveryError):
+        for diagnostic in error.diagnostics:
+            print(
+                f"  {diagnostic.path}: {diagnostic.kind}: {diagnostic.message}",
+                file=sys.stderr,
+            )
+        return
+    print(f"  {type(error).__name__}: {error}", file=sys.stderr)
 
 
 def _make_provider(address: str):

--- a/src/runtime/operator/__init__.py
+++ b/src/runtime/operator/__init__.py
@@ -1,5 +1,8 @@
 """Avalanche Operator — workflow orchestration and execution."""
 
+import signal
+import threading
+
 from .models import (
     CatalogView,
     WorkflowDescriptor,
@@ -29,11 +32,7 @@ __all__ = [
 
 def _report_workflow_scan(operator: Operator) -> None:
     workflows = operator.get_catalog().workflows
-    if not workflows:
-        print("Workflow scan complete: 0 workflows loaded")
-        return
-    selectors = ", ".join(workflow.selector for workflow in workflows)
-    print(f"Workflow scan complete: {len(workflows)} workflows loaded: {selectors}")
+    print(f"  Discovered {len(workflows)} workflow" f"{'' if len(workflows) == 1 else 's'}")
 
 
 def serve(
@@ -44,12 +43,38 @@ def serve(
     webhook_port: int = 7434,
     **kwargs,
 ) -> None:
-    """Start the local operator daemon."""
+    """Start the local operator daemon and fail on any lifecycle error."""
     from .server import serve as _serve
 
     op = Operator(workflow_paths, webhook_port=webhook_port, **kwargs)
     _report_workflow_scan(op)
+    server = None
+    stop_requested = threading.Event()
+    previous_handlers = {}
+
+    def request_shutdown(_signum, _frame) -> None:
+        stop_requested.set()
+
+    if threading.current_thread() is threading.main_thread():
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signum] = signal.getsignal(signum)
+            signal.signal(signum, request_shutdown)
+
     try:
-        _serve(op, port=port, block=True, host=host)
+        server = _serve(op, port=port, block=False, host=host)
+        print(f"  Operator ready: grpc://{host}:{port}")
+        print("Ready. Press Ctrl-C to stop.")
+        while not stop_requested.is_set():
+            failure = op.wait_for_failure(timeout=0.1)
+            if failure is not None:
+                raise failure
+    except KeyboardInterrupt:
+        pass
     finally:
-        op.close()
+        try:
+            if server is not None:
+                server.stop(grace=1.0).wait(timeout=2.0)
+        finally:
+            op.close()
+            for signum, handler in previous_handlers.items():
+                signal.signal(signum, handler)

--- a/src/runtime/operator/__main__.py
+++ b/src/runtime/operator/__main__.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
 from collections.abc import Sequence
 
-from .discovery import DEFAULT_DISCOVERY_TIMEOUT, validate_discovery_timeout
+from .discovery import (
+    DEFAULT_DISCOVERY_TIMEOUT,
+    WorkflowDiscoveryError,
+    validate_discovery_timeout,
+)
+from .workspace_config import format_scan_targets, select_workflow_targets
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -16,11 +22,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         allow_abbrev=False,
     )
     parser.add_argument(
-        "--flows",
-        nargs="+",
-        default=["."],
-        metavar="PATH",
-        help="flow file or directory to scan (default: current directory)",
+        "flows",
+        nargs="*",
+        metavar="FLOW",
+        help="workflow Python file or directory; uses workspace configuration when omitted",
     )
     parser.add_argument("--port", type=int, default=7433, help="operator gRPC port")
     parser.add_argument(
@@ -52,31 +57,42 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(list(argv) if argv is not None else None)
     try:
         validate_discovery_timeout(args.discovery_timeout)
+        selection = select_workflow_targets(args.flows)
     except ValueError as exc:
         parser.error(str(exc))
+    args.flows = list(selection.paths)
     logging.basicConfig(
         level=getattr(logging, args.log_level),
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
         force=True,
     )
 
-    if args.ray:
-        print("Executor: Ray")
-    else:
-        print("Executor: Local")
+    print("Avalanche operator")
+    for line in format_scan_targets(selection):
+        print(line)
+    print(f"  Executor: {'Ray' if args.ray else 'Local'}")
+    print("  Discovering workflows...")
 
     from . import serve
 
-    print(f"Avalanche operator starting on {args.host}:{args.port}")
-    print(f"Scanning flows: {', '.join(args.flows)}")
-    serve(
-        args.flows,
-        port=args.port,
-        host=args.host,
-        webhook_port=args.webhook_port,
-        discovery_timeout=args.discovery_timeout,
-        executor_backend="ray" if args.ray else "local",
-    )
+    try:
+        serve(
+            args.flows,
+            port=args.port,
+            host=args.host,
+            webhook_port=args.webhook_port,
+            discovery_timeout=args.discovery_timeout,
+            executor_backend="ray" if args.ray else "local",
+        )
+    except WorkflowDiscoveryError as exc:
+        print("error: Avalanche operator discovery failed", file=sys.stderr)
+        for diagnostic in exc.diagnostics:
+            print(
+                f"  {diagnostic.path}: {diagnostic.kind}: {diagnostic.message}",
+                file=sys.stderr,
+            )
+        return 1
+    print("Stopped.")
     return 0
 
 

--- a/src/runtime/operator/discovery.py
+++ b/src/runtime/operator/discovery.py
@@ -61,6 +61,31 @@ DEFAULT_DISCOVERY_TIMEOUT = 60.0
 _DISCOVERY_TERMINATE_GRACE = 1.0
 
 
+class WorkflowDiscoveryError(RuntimeError):
+    """Raised when discovery cannot produce a usable catalog."""
+
+    def __init__(self, diagnostics: tuple[WorkflowDiscoveryDiagnostic, ...]) -> None:
+        if not diagnostics:
+            raise ValueError("Workflow discovery failure requires a diagnostic")
+        self.diagnostics = diagnostics
+        super().__init__(
+            "; ".join(f"{item.kind} {item.path}: {item.message}" for item in diagnostics)
+        )
+
+
+class WorkflowDiscoveryTimeoutError(WorkflowDiscoveryError):
+    """Raised when one discovery worker exceeds its configured deadline."""
+
+
+def raise_for_discovery_diagnostics(
+    diagnostics: tuple[WorkflowDiscoveryDiagnostic, ...],
+) -> None:
+    """Raise when catalog diagnostics make discovery unusable."""
+    failures = tuple(item for item in diagnostics if item.kind != "skipped")
+    if failures:
+        raise WorkflowDiscoveryError(failures)
+
+
 def validate_discovery_timeout(timeout: float) -> None:
     """Raise when a discovery timeout cannot bound one scan."""
     if not math.isfinite(timeout) or timeout <= 0:
@@ -68,12 +93,29 @@ def validate_discovery_timeout(timeout: float) -> None:
 
 
 def configure_roots(paths: list[str]) -> tuple[ConfiguredRoot, ...]:
-    """Normalize configured file/directory inputs and deterministic aliases."""
+    """Normalize explicit file/directory inputs and deterministic aliases."""
+    if not paths:
+        raise ValueError("At least one workflow target is required")
+
     pending: list[tuple[str | None, Path, Path]] = []
     for value in paths:
         explicit_alias, raw_path = _split_alias(value)
-        target = Path(raw_path).expanduser().resolve()
-        root = target if target.is_dir() else target.parent
+        configured_path = Path(raw_path).expanduser()
+        if not configured_path.exists():
+            raise ValueError(f"Workflow target does not exist: {raw_path}")
+        target = configured_path.resolve()
+        if target.is_file():
+            if target.suffix != ".py":
+                raise ValueError(f"Workflow file target must end in .py: {raw_path}")
+            if not os.access(target, os.R_OK):
+                raise ValueError(f"Workflow file target is not readable: {raw_path}")
+            root = target.parent
+        elif target.is_dir():
+            if not os.access(target, os.R_OK | os.X_OK):
+                raise ValueError(f"Workflow directory target is not readable: {raw_path}")
+            root = target
+        else:
+            raise ValueError(f"Workflow target must be a Python file or directory: {raw_path}")
         pending.append((explicit_alias, root, target))
 
     targets = [target for _, _, target in pending]
@@ -164,7 +206,9 @@ def discover_files(
                         "incomplete scan results were discarded",
                         timeout,
                     )
-                    return (), (_discovery_failure(f"Discovery exceeded {timeout:.1f}s"),)
+                    raise WorkflowDiscoveryTimeoutError(
+                        (_discovery_failure(f"Discovery exceeded {timeout:.1f}s"),)
+                    ) from None
                 finally:
                     _terminate_discovery_process(process, windows_job)
                     terminated = True
@@ -179,7 +223,9 @@ def discover_files(
             captured = _bounded_diagnostic(stderr.read() or stdout.read())
 
         if process.returncode != 0:
-            return (), (_discovery_failure(captured or "Discovery worker failed"),)
+            raise WorkflowDiscoveryError(
+                (_discovery_failure(captured or "Discovery worker failed"),)
+            )
         try:
             result = json.loads(result_path.read_text())
             files = tuple(
@@ -201,9 +247,9 @@ def discover_files(
                 WorkflowDiscoveryDiagnostic(**item) for item in result["diagnostics"]
             )
         except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
-            return (), (
-                _discovery_failure(f"Invalid discovery result: {_format_exception(exc)}"),
-            )
+            raise WorkflowDiscoveryError(
+                (_discovery_failure(f"Invalid discovery result: {_format_exception(exc)}"),)
+            ) from exc
         return files, diagnostics
 
 

--- a/src/runtime/operator/operator.py
+++ b/src/runtime/operator/operator.py
@@ -26,7 +26,10 @@ from typing import Any, Callable, Literal, TypeAlias
 from uuid import uuid4
 
 from ..executor import LocalExecutor, RayExecutor
-from .discovery import DEFAULT_DISCOVERY_TIMEOUT
+from .discovery import (
+    DEFAULT_DISCOVERY_TIMEOUT,
+    raise_for_discovery_diagnostics,
+)
 from .models import (
     AgentEvent,
     AgentEventAppended,
@@ -333,6 +336,7 @@ class Operator:
         initial_view = None
         if self._workflow_paths:
             initial_view = self._registry.scan(self._workflow_paths, validate=routes_for)
+            raise_for_discovery_diagnostics(initial_view.diagnostics)
         self._subscriber_queue_capacity = subscriber_queue_capacity
         self._mp = multiprocessing.get_context("spawn")
         self._runs: dict[str, RunState] = {}
@@ -368,6 +372,8 @@ class Operator:
         self._watcher_stop = threading.Event()
         self._watcher_ready = threading.Event()
         self._watcher_thread: threading.Thread | None = None
+        self._fatal_error: Exception | None = None
+        self._fatal_error_ready = threading.Event()
         self._result_cleanup_stop = threading.Event()
         self._result_cleanup_thread: threading.Thread | None = None
         self._closed = False
@@ -408,6 +414,17 @@ class Operator:
     def current_sequence(self) -> int:
         with self._lock:
             return self._sequence
+
+    @property
+    def fatal_error(self) -> Exception | None:
+        """Return the terminal watcher failure, if discovery can no longer continue."""
+        with self._lock:
+            return self._fatal_error
+
+    def wait_for_failure(self, timeout: float | None = None) -> Exception | None:
+        """Wait for a fatal operator failure without consuming it."""
+        self._fatal_error_ready.wait(timeout)
+        return self.fatal_error
 
     def update_history_bounds(self) -> tuple[int, int]:
         """Return the retained lifecycle update interval for V2 cursor validation."""
@@ -1624,15 +1641,18 @@ class Operator:
             self._watcher_stop.set()
             self._watcher_thread.join(timeout=2.0)
             raise RuntimeError("Workflow watcher did not become ready")
+        failure = self.wait_for_failure(timeout=0)
+        if failure is not None:
+            raise failure
 
     def _watch_loop(self) -> None:
         from watchfiles import watch
 
-        locators = tuple(descriptor.locator for descriptor in self._registry.descriptors())
-        source_roots = resolve_watch_roots(self._registry.configured_roots, locators)
-        watch_dirs = tuple(str(path) for path in source_roots)
-        logger.info("Workflow watcher started: roots=%s", watch_dirs)
         try:
+            locators = tuple(descriptor.locator for descriptor in self._registry.descriptors())
+            source_roots = resolve_watch_roots(self._registry.configured_roots, locators)
+            watch_dirs = tuple(str(path) for path in source_roots)
+            logger.info("Workflow watcher started: roots=%s", watch_dirs)
             for changes in watch(
                 *watch_dirs,
                 stop_event=self._watcher_stop,
@@ -1645,8 +1665,20 @@ class Operator:
                     continue
                 changed_files = tuple(sorted(path for _, path in changes))
                 self._refresh_workflows(changed_files)
+        except Exception as exc:
+            self._record_fatal_error(exc)
+            logger.error("Workflow watcher failed: %s", exc)
         finally:
+            self._watcher_ready.set()
             logger.info("Workflow watcher stopped")
+
+    def _record_fatal_error(self, error: Exception) -> None:
+        with self._lock:
+            if self._closed or self._fatal_error is not None:
+                return
+            self._fatal_error = error
+            self._fatal_error_ready.set()
+        self._watcher_stop.set()
 
     def _refresh_workflows(self, changed_files: tuple[str, ...] = ()) -> None:
         self._publish_workflow_reload_status(reloading=True)
@@ -1671,21 +1703,12 @@ class Operator:
                 if changed_files
                 else self._registry.rescan(validate=routes_for)
             )
-            failed_diagnostics = tuple(
-                diagnostic for diagnostic in view.diagnostics if diagnostic.kind != "skipped"
-            )
-            if failed_diagnostics:
-                logger.warning(
-                    "Workflow reload failed; retaining catalog revision %d: %s",
-                    previous.revision,
-                    _summarize_reload_diagnostics(failed_diagnostics),
-                )
+            raise_for_discovery_diagnostics(view.diagnostics)
             if view is previous:
-                if not failed_diagnostics:
-                    logger.info(
-                        "Workflow reload unchanged: revision=%d",
-                        previous.revision,
-                    )
+                logger.info(
+                    "Workflow reload unchanged: revision=%d",
+                    previous.revision,
+                )
                 return
             try:
                 self._scheduler.reconcile(view.by_id.values())
@@ -1694,22 +1717,19 @@ class Operator:
                 self._registry.restore_view(view, previous)
                 self._scheduler.reconcile(previous.by_id.values())
                 self._reconcile_webhooks(previous.by_id.values())
-                error = _bound_reload_log_text(f"{type(exc).__name__}: {exc}")
-                logger.warning(
-                    "Workflow reload reconciliation failed; retaining catalog "
-                    "revision %d: %s",
-                    previous.revision,
-                    error,
+                message = (
+                    "Workflow reload reconciliation failed: "
+                    f"{_bound_reload_log_text(f'{type(exc).__name__}: {exc}')}"
                 )
-                return
+                logger.error("%s", message)
+                raise RuntimeError(message) from exc
         self._publish_catalog(view)
-        if not failed_diagnostics:
-            logger.info(
-                "Workflow reload succeeded: revision=%d->%d workflows=%d",
-                previous.revision,
-                view.revision,
-                len(view.by_id),
-            )
+        logger.info(
+            "Workflow reload succeeded: revision=%d->%d workflows=%d",
+            previous.revision,
+            view.revision,
+            len(view.by_id),
+        )
 
     def _reconcile_webhooks(self, descriptors) -> None:
         routes = routes_for(tuple(descriptors))

--- a/src/runtime/operator/registry.py
+++ b/src/runtime/operator/registry.py
@@ -18,6 +18,7 @@ from .discovery import (
     DEFAULT_DISCOVERY_TIMEOUT,
     ConfiguredRoot,
     FileDiscoveryResult,
+    WorkflowDiscoveryError,
     candidate_files,
     configure_roots,
     discover_files,
@@ -192,6 +193,7 @@ class WorkflowRegistry:
         self._file_rollback: (
             tuple[CatalogView, dict[tuple[str, Path], FileDiscoveryResult]] | None
         ) = None
+        self._requires_full_rescan = False
 
     @property
     def view(self) -> CatalogView:
@@ -234,6 +236,7 @@ class WorkflowRegistry:
             self._scan_paths = tuple(paths)
             self._roots = roots
             self._cache = cache
+            self._requires_full_rescan = False
         cached_files = cache.load()
         if cached_files is not None:
             view, accepted = self._install_files(roots, cached_files, (), validate=validate)
@@ -254,9 +257,10 @@ class WorkflowRegistry:
         """Refresh affected configured sources while preserving the last valid catalog."""
         with self._lock:
             roots = self._roots
+            requires_full_rescan = self._requires_full_rescan
         if not roots:
             return self.view
-        if not changed_files:
+        if not changed_files or requires_full_rescan:
             return self._scan_roots(roots, validate=validate)
         if any(Path(path).suffix != ".py" for path in changed_files):
             return self._scan_roots(roots, validate=validate)
@@ -310,11 +314,16 @@ class WorkflowRegistry:
             return self.view
 
         if affected:
-            discovered, diagnostics = discover_files(
-                roots,
-                targets=target_keys,
-                timeout=self._discovery_timeout,
-            )
+            try:
+                discovered, diagnostics = discover_files(
+                    roots,
+                    targets=target_keys,
+                    timeout=self._discovery_timeout,
+                )
+            except WorkflowDiscoveryError:
+                with self._lock:
+                    self._requires_full_rescan = True
+                raise
         else:
             discovered, diagnostics = (), ()
         discovered_by_key = {
@@ -342,6 +351,9 @@ class WorkflowRegistry:
         view, accepted = self._install_files(roots, files, diagnostics, validate=validate)
         if accepted:
             self._commit_files(view, files)
+        else:
+            with self._lock:
+                self._requires_full_rescan = True
         rescanned_workflow_ids = previous_workflow_ids | {
             descriptor.workflow_id
             for file_result in discovered
@@ -374,10 +386,20 @@ class WorkflowRegistry:
                 for file_result in self._discovery_files.values()
                 for descriptor in file_result.descriptors
             }
-        files, diagnostics = discover_files(roots, timeout=self._discovery_timeout)
+        try:
+            files, diagnostics = discover_files(roots, timeout=self._discovery_timeout)
+        except WorkflowDiscoveryError:
+            with self._lock:
+                self._requires_full_rescan = True
+            raise
         view, accepted = self._install_files(roots, files, diagnostics, validate=validate)
         if accepted:
             self._commit_files(view, files)
+            with self._lock:
+                self._requires_full_rescan = False
+        else:
+            with self._lock:
+                self._requires_full_rescan = True
         rescanned_workflow_ids = previous_workflow_ids | {
             descriptor.workflow_id
             for file_result in files

--- a/src/runtime/operator/server.py
+++ b/src/runtime/operator/server.py
@@ -23,6 +23,7 @@ DEFAULT_PORT = 7433
 DEFAULT_HOST = "127.0.0.1"
 TRACE_CHUNK_BYTES = 1024 * 1024
 
+
 def serve(
     operator: Operator,
     port: int = DEFAULT_PORT,
@@ -53,9 +54,7 @@ def serve(
         # server_v2 reuses helpers from this module.
         from .server_v2 import OperatorV2Servicer
 
-        pb_grpc.add_OperatorServiceV2Servicer_to_server(
-            OperatorV2Servicer(operator), server
-        )
+        pb_grpc.add_OperatorServiceV2Servicer_to_server(OperatorV2Servicer(operator), server)
         listen_address = _listen_address(host, port)
         if not _is_loopback_host(host):
             logger.warning(
@@ -77,6 +76,27 @@ def serve(
 
     if block:
         previous_handlers: dict[int, Any] = {}
+        monitor_stop = threading.Event()
+        fatal_error: list[Exception] = []
+        failure_monitor: threading.Thread | None = None
+
+        if isinstance(operator, Operator):
+
+            def stop_for_fatal_operator_error() -> None:
+                while not monitor_stop.is_set():
+                    failure = operator.wait_for_failure(timeout=0.1)
+                    if failure is None:
+                        continue
+                    fatal_error.append(failure)
+                    server.stop(grace=0)
+                    return
+
+            failure_monitor = threading.Thread(
+                target=stop_for_fatal_operator_error,
+                name="avalanche-operator-failure-monitor",
+                daemon=True,
+            )
+            failure_monitor.start()
 
         def request_shutdown(signum, _frame) -> None:
             logger.info("Received signal %s; shutting down", signum)
@@ -91,12 +111,17 @@ def serve(
         except KeyboardInterrupt:
             request_shutdown(signal.SIGINT, None)
         finally:
+            monitor_stop.set()
+            if failure_monitor is not None:
+                failure_monitor.join(timeout=1.0)
             try:
                 server.stop(grace=1.0).wait(timeout=2.0)
             finally:
                 operator.close()
                 for signum, handler in previous_handlers.items():
                     signal.signal(signum, handler)
+        if fatal_error:
+            raise fatal_error[0]
 
     return server
 

--- a/src/runtime/operator/workspace_config.py
+++ b/src/runtime/operator/workspace_config.py
@@ -1,0 +1,141 @@
+"""Workspace-scoped default flow target resolution for local CLI commands."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, StrictStr, ValidationError
+
+from .discovery import ConfiguredRoot, configure_roots
+
+
+class _AvalancheToolConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    flow_targets: list[StrictStr] | None = None
+
+
+class _ToolConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    avalanche: _AvalancheToolConfig | None = None
+
+
+class _PyprojectConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    tool: _ToolConfig | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowTargetSelection:
+    """Validated workflow targets and the workspace configuration that supplied them."""
+
+    paths: tuple[str, ...]
+    roots: tuple[ConfiguredRoot, ...]
+    config_path: Path | None = None
+
+
+def format_scan_targets(selection: WorkflowTargetSelection) -> tuple[str, ...]:
+    """Render the validated absolute targets that discovery will scan."""
+    source = (
+        "command line"
+        if selection.config_path is None
+        else f"workspace config: {selection.config_path}"
+    )
+    return (
+        f"  Scan targets ({source}):",
+        *(
+            f"    - {root.target} " f"({'directory' if root.target.is_dir() else 'file'})"
+            for root in selection.roots
+        ),
+    )
+
+
+def select_workflow_targets(
+    explicit_paths: list[str], *, working_directory: Path | None = None
+) -> WorkflowTargetSelection:
+    """Resolve explicit targets or safe workspace defaults without a CWD fallback."""
+    if explicit_paths:
+        roots = configure_roots(explicit_paths)
+        return WorkflowTargetSelection(paths=tuple(explicit_paths), roots=roots)
+
+    directory = (working_directory or Path.cwd()).resolve()
+    config_path = _nearest_pyproject(directory)
+    if config_path is None:
+        raise ValueError(
+            "No workflow targets configured. Pass FLOW [FLOW ...], or set "
+            "[tool.avalanche].flow_targets in pyproject.toml."
+        )
+
+    config = _load_workspace_config(config_path)
+    if config is None or not config.flow_targets:
+        raise ValueError(
+            "No workflow targets configured. Pass FLOW [FLOW ...], or set "
+            "[tool.avalanche].flow_targets in pyproject.toml."
+        )
+
+    paths = tuple(
+        _workspace_target_path(value, config_path.parent) for value in config.flow_targets
+    )
+    try:
+        roots = configure_roots(list(paths))
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid [tool.avalanche].flow_targets in {config_path}: {exc}"
+        ) from exc
+    return WorkflowTargetSelection(paths=paths, roots=roots, config_path=config_path)
+
+
+def _nearest_pyproject(directory: Path) -> Path | None:
+    for candidate_directory in (directory, *directory.parents):
+        candidate = candidate_directory / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_workspace_config(config_path: Path) -> _AvalancheToolConfig | None:
+    try:
+        with config_path.open("rb") as config_file:
+            document = tomllib.load(config_file)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(
+            f"Could not parse workspace configuration {config_path}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise ValueError(
+            f"Could not read workspace configuration {config_path}: {exc}"
+        ) from exc
+    try:
+        config = _PyprojectConfig.model_validate(document)
+    except ValidationError as exc:
+        raise ValueError(
+            f"Invalid [tool.avalanche] configuration in {config_path}: {exc}"
+        ) from exc
+    if config.tool is None:
+        return None
+    return config.tool.avalanche
+
+
+def _workspace_target_path(value: str, workspace_root: Path) -> str:
+    alias, raw_path = _split_alias(value)
+    if not raw_path.strip():
+        raise ValueError("Workspace flow target must not be empty")
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = workspace_root / path
+    if alias is None:
+        return str(path)
+    return f"{alias}={path}"
+
+
+def _split_alias(value: str) -> tuple[str | None, str]:
+    if "=" not in value:
+        return None, value
+    alias, path = value.split("=", 1)
+    if alias and path:
+        return alias, path
+    return None, value

--- a/src/runtime/operator/workspace_config.py
+++ b/src/runtime/operator/workspace_config.py
@@ -124,7 +124,12 @@ def _workspace_target_path(value: str, workspace_root: Path) -> str:
     alias, raw_path = _split_alias(value)
     if not raw_path.strip():
         raise ValueError("Workspace flow target must not be empty")
-    path = Path(raw_path).expanduser()
+    try:
+        path = Path(raw_path).expanduser()
+    except RuntimeError as exc:
+        raise ValueError(
+            f"Workspace flow target has an unresolved home directory: {raw_path}"
+        ) from exc
     if not path.is_absolute():
         path = workspace_root / path
     if alias is None:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1920,6 +1920,27 @@ def test_ava_dev_starts_services_after_operator_readiness(monkeypatch, capsys):
     assert "Scan targets (command line)" in output
     assert f"{Path('examples').resolve()} (directory)" in output
 
+@pytest.mark.parametrize("signum", (signal.SIGINT, signal.SIGTERM))
+def test_ava_dev_interrupts_blocking_discovery(monkeypatch, signum):
+    from ava_cli import app
+    from runtime.operator import operator as operator_module
+
+    installed_handlers = {}
+
+    def record_handler(registered_signum, handler):
+        installed_handlers[registered_signum] = handler
+
+    class BlockingOperator:
+        def __init__(self, *_args, **_kwargs):
+            installed_handlers[signum](signum, None)
+            pytest.fail("Discovery continued after its shutdown signal")
+
+    monkeypatch.setattr(app, "_configure_terminal_logging", lambda _level: None)
+    monkeypatch.setattr(app.signal, "signal", record_handler)
+    monkeypatch.setattr(operator_module, "Operator", BlockingOperator)
+
+    assert app.main(["dev", "examples"]) == 0
+
 
 def test_ava_dev_reports_discovery_failure_without_starting_services(monkeypatch, capsys):
     from ava_cli import app

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -102,11 +102,14 @@ if [ "$1" = "sync" ]; then
         fi
         shift
     done
+    test -f "$directory/src/binary_converter/flow.py" || exit 1
     mkdir -p "$directory/.venv/bin"
     printf '#!/bin/sh\nexit 0\n' > "$directory/.venv/bin/python"
     entrypoint="$directory/.venv/bin/ava"
     printf '#!/bin/sh\n[ -x "%s/.venv/bin/python" ] || exit 1\n' "$directory" > "$entrypoint"
     chmod +x "$directory/.venv/bin/python" "$directory/.venv/bin/ava"
+elif [ "$1" = "run" ] && [ "$2" = "ava" ] && [ "$3" = "dev" ]; then
+    test -f src/binary_converter/flow.py || exit 1
 fi
 """,
         encoding="utf-8",
@@ -131,15 +134,18 @@ fi
     assert (workspace_root / ".agent" / "skills" / "avalanche" / "SKILL.md").is_file()
     workspace = tomllib.loads((workspace_root / "pyproject.toml").read_text())
     assert workspace["project"]["dependencies"] == ["avalanche-ai", "predict-rlm"]
+    assert workspace["tool"]["avalanche"]["flow_targets"] == ["src"]
+    assert "scripts" not in workspace["project"]
+    assert not (workspace_root / "src" / "binary_converter" / "dev.py").exists()
     guidance = (workspace_root / "AGENTS.md").read_text()
-    assert "uv run ava dev --flows src/binary_converter/" in guidance
-    assert "ava operator --flows src/binary_converter/ --web" not in guidance
+    assert "uv run ava dev" in guidance
+    assert "--flows" not in guidance
 
     ava = workspace_root / ".venv" / "bin" / "ava"
     assert subprocess.run([str(ava), "run", "--help"], check=False).returncode == 0
 
 
-def test_ava_operator_delegates_to_runtime_operator_with_flows(monkeypatch):
+def test_ava_operator_delegates_to_runtime_operator_with_targets(monkeypatch):
     from ava_cli import app
 
     calls = []
@@ -154,7 +160,6 @@ def test_ava_operator_delegates_to_runtime_operator_with_flows(monkeypatch):
         app.main(
             [
                 "operator",
-                "--flows",
                 "examples",
                 "--port",
                 "17777",
@@ -167,7 +172,6 @@ def test_ava_operator_delegates_to_runtime_operator_with_flows(monkeypatch):
     )
     assert calls == [
         [
-            "--flows",
             "examples",
             "--host",
             "127.0.0.1",
@@ -184,15 +188,113 @@ def test_ava_operator_delegates_to_runtime_operator_with_flows(monkeypatch):
     ]
 
 
-def test_ava_operator_defaults_flows_to_current_directory(monkeypatch):
+def test_ava_operator_accepts_multiple_file_targets(monkeypatch):
     from ava_cli import app
 
     calls = []
     monkeypatch.setattr(app, "_operator_main", lambda argv: calls.append(argv) or 0)
 
-    assert app.main(["operator"]) == 0
-    assert calls[0][:2] == ["--flows", "."]
-    assert calls[0][-2:] == ["--discovery-timeout", "60.0"]
+    assert (
+        app.main(
+            [
+                "operator",
+                "examples/operator_workflow.py",
+                "test/fixtures/sample_workflows.py",
+            ]
+        )
+        == 0
+    )
+    assert calls[0][:2] == [
+        "examples/operator_workflow.py",
+        "test/fixtures/sample_workflows.py",
+    ]
+
+
+def test_ava_operator_requires_configured_or_explicit_workflow_targets(capsys):
+    from ava_cli import app
+
+    with pytest.raises(SystemExit) as exc_info:
+        app.main(["operator"])
+
+    assert exc_info.value.code == 2
+    assert "No workflow targets configured" in capsys.readouterr().err
+
+
+def test_ava_dev_uses_workspace_configured_targets(monkeypatch, tmp_path):
+    from ava_cli import app
+
+    workspace = tmp_path / "workspace"
+    flows = workspace / "src"
+    flows.mkdir(parents=True)
+    (workspace / "pyproject.toml").write_text('[tool.avalanche]\nflow_targets = ["src"]\n')
+    calls = []
+    monkeypatch.chdir(workspace)
+    monkeypatch.setattr(
+        app,
+        "_run_dev",
+        lambda args: calls.append((args.flows, args.flow_target_selection)) or 0,
+    )
+
+    assert app.main(["dev"]) == 0
+
+    assert calls[0][0] == [str(flows)]
+    assert calls[0][1].config_path == workspace / "pyproject.toml"
+
+
+def test_ava_dev_explicit_target_overrides_workspace_configuration(monkeypatch, tmp_path):
+    from ava_cli import app
+
+    workspace = tmp_path / "workspace"
+    flows = workspace / "src"
+    flows.mkdir(parents=True)
+    explicit_flow = workspace / "single.py"
+    explicit_flow.write_text("import avalanche as ava\n")
+    (workspace / "pyproject.toml").write_text('[tool.avalanche]\nflow_targets = ["src"]\n')
+    calls = []
+    monkeypatch.chdir(workspace)
+    monkeypatch.setattr(
+        app,
+        "_run_dev",
+        lambda args: calls.append((args.flows, args.flow_target_selection)) or 0,
+    )
+
+    assert app.main(["dev", str(explicit_flow)]) == 0
+
+    assert calls[0][0] == [str(explicit_flow)]
+    assert calls[0][1].config_path is None
+
+
+def test_ava_operator_rejects_legacy_flow_flag(capsys):
+    from ava_cli import app
+
+    with pytest.raises(SystemExit) as exc_info:
+        app.main(["operator", "--flows", "examples"])
+
+    assert exc_info.value.code == 2
+    assert "unrecognized arguments: --flows" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("target_name", "expected_error"),
+    [
+        ("missing.py", "Workflow target does not exist"),
+        ("not-a-flow.txt", "Workflow file target must end in .py"),
+    ],
+)
+def test_ava_operator_rejects_invalid_workflow_target(
+    tmp_path, capsys, target_name, expected_error
+):
+    from ava_cli import app
+
+    target = tmp_path / target_name
+    if target_name == "not-a-flow.txt":
+        target.write_text("not a workflow")
+
+    with pytest.raises(SystemExit) as exc_info:
+        app.main(["operator", str(target)])
+
+    assert exc_info.value.code == 2
+    assert expected_error in capsys.readouterr().err
 
 
 def test_ava_operator_forwards_case_insensitive_log_level(monkeypatch):
@@ -201,7 +303,7 @@ def test_ava_operator_forwards_case_insensitive_log_level(monkeypatch):
     calls = []
     monkeypatch.setattr(app, "_operator_main", lambda argv: calls.append(argv) or 0)
 
-    assert app.main(["operator", "--flows", "examples", "--log-level", "info"]) == 0
+    assert app.main(["operator", "examples", "--log-level", "info"]) == 0
     assert calls[0][-4:] == ["--log-level", "INFO", "--discovery-timeout", "60.0"]
 
 
@@ -222,9 +324,7 @@ def test_runtime_operator_configures_logging_before_serve(monkeypatch):
     )
 
     assert (
-        operator_main.main(
-            ["--flows", "examples", "--log-level", "info", "--discovery-timeout", "45"]
-        )
+        operator_main.main(["examples", "--log-level", "info", "--discovery-timeout", "45"])
         == 0
     )
     assert lifecycle[0] == (
@@ -239,20 +339,40 @@ def test_runtime_operator_configures_logging_before_serve(monkeypatch):
     assert lifecycle[1][1][1]["discovery_timeout"] == 45.0
 
 
-def test_runtime_operator_defaults_flows_to_current_directory(monkeypatch):
+def test_runtime_operator_requires_configured_or_explicit_workflow_targets(capsys):
+    from runtime.operator import __main__ as operator_main
+
+    with pytest.raises(SystemExit) as exc_info:
+        operator_main.main([])
+
+    assert exc_info.value.code == 2
+    assert "No workflow targets configured" in capsys.readouterr().err
+
+
+def test_runtime_operator_uses_workspace_configured_targets(monkeypatch, tmp_path, capsys):
     import runtime.operator as runtime_operator
     from runtime.operator import __main__ as operator_main
 
+    workspace = tmp_path / "workspace"
+    flows = workspace / "src"
+    flows.mkdir(parents=True)
+    config_path = workspace / "pyproject.toml"
+    config_path.write_text('[tool.avalanche]\nflow_targets = ["src"]\n')
     calls = []
+    monkeypatch.chdir(workspace)
+    monkeypatch.setattr(operator_main.logging, "basicConfig", lambda **_kwargs: None)
     monkeypatch.setattr(
         runtime_operator,
         "serve",
-        lambda flows, **kwargs: calls.append((flows, kwargs)),
+        lambda paths, **kwargs: calls.append((paths, kwargs)),
     )
 
     assert operator_main.main([]) == 0
-    assert calls[0][0] == ["."]
-    assert calls[0][1]["discovery_timeout"] == 60.0
+
+    assert calls[0][0] == [str(flows)]
+    output = capsys.readouterr().out
+    assert f"Scan targets (workspace config: {config_path})" in output
+    assert f"{flows.resolve()} (directory)" in output
 
 
 @pytest.mark.parametrize("timeout", ("0", "nan", "inf"))
@@ -260,37 +380,78 @@ def test_runtime_operator_rejects_invalid_discovery_timeout(capsys, timeout):
     from runtime.operator import __main__ as operator_main
 
     with pytest.raises(SystemExit) as exc_info:
-        operator_main.main(["--discovery-timeout", timeout])
+        operator_main.main(["examples", "--discovery-timeout", timeout])
 
     assert exc_info.value.code == 2
     assert "Discovery timeout must be positive and finite" in capsys.readouterr().err
 
 
-def test_runtime_operator_reports_loaded_workflows(monkeypatch, capsys):
+def test_runtime_operator_reports_loaded_workflows(capsys):
     import runtime.operator as runtime_operator
-    from runtime.operator import server as operator_server
 
     class FakeWorkflow:
-        def __init__(self, selector):
-            self.selector = selector
+        pass
 
     class FakeCatalog:
-        workflows = (FakeWorkflow("first"), FakeWorkflow("second"))
+        workflows = (FakeWorkflow(), FakeWorkflow())
 
     class FakeOperator:
         def get_catalog(self):
             return FakeCatalog()
 
+    runtime_operator._report_workflow_scan(FakeOperator())
+
+    assert capsys.readouterr().out == "  Discovered 2 workflows\n"
+
+
+def test_runtime_operator_stops_server_when_watcher_fails(monkeypatch):
+    import runtime.operator as runtime_operator
+    from runtime.operator import server as operator_server
+
+    events = []
+    failure = RuntimeError("workflow watcher failed")
+
+    class FakeCatalog:
+        workflows = ()
+
+    class FakeOperator:
+        def get_catalog(self):
+            return FakeCatalog()
+
+        def wait_for_failure(self, *, timeout):
+            events.append(("watch", timeout))
+            return failure
+
         def close(self):
-            pass
+            events.append("operator-close")
 
-    monkeypatch.setattr(runtime_operator, "Operator", lambda *args, **kwargs: FakeOperator())
-    monkeypatch.setattr(operator_server, "serve", lambda *args, **kwargs: None)
+    class FakeServer:
+        def stop(self, *, grace):
+            events.append(("server-stop", grace))
+            return self
 
-    runtime_operator.serve(["examples"])
+        def wait(self, *, timeout):
+            events.append(("server-wait", timeout))
 
-    expected = "Workflow scan complete: 2 workflows loaded: first, second\n"
-    assert capsys.readouterr().out == expected
+    monkeypatch.setattr(runtime_operator, "Operator", lambda *_args, **_kwargs: FakeOperator())
+    monkeypatch.setattr(
+        operator_server,
+        "serve",
+        lambda *_args, **kwargs: events.append(("server-start", kwargs)) or FakeServer(),
+    )
+    monkeypatch.setattr(runtime_operator.threading, "current_thread", lambda: object())
+    monkeypatch.setattr(runtime_operator.threading, "main_thread", lambda: object())
+
+    with pytest.raises(RuntimeError, match="workflow watcher failed"):
+        runtime_operator.serve(["examples"])
+
+    assert events == [
+        ("server-start", {"port": 7433, "block": False, "host": "127.0.0.1"}),
+        ("watch", 0.1),
+        ("server-stop", 1.0),
+        ("server-wait", 2.0),
+        "operator-close",
+    ]
 
 
 def test_ava_web_starts_remote_browser_proxy_and_opens_browser(monkeypatch):
@@ -1644,38 +1805,81 @@ def test_ava_run_preserves_ambiguity_candidates_on_stderr(monkeypatch, capsys):
     assert "right/flow.py::shared" in error
 
 
-def test_ava_dev_starts_web_without_waiting_for_operator_readiness(monkeypatch):
+def test_ava_dev_starts_services_after_operator_readiness(monkeypatch, capsys):
+    import grpc
+
     from ava_cli import app
+    from runtime.operator import operator as operator_module
+    from runtime.operator import server as operator_server
+    from runtime.operator import web as operator_web
 
     events = []
 
-    class FakeProcess:
-        def terminate(self):
-            events.append("terminate")
+    class FakeOperator:
+        def __init__(self, flows, **kwargs):
+            events.append(("operator", flows, kwargs))
 
-        def wait(self, timeout=None):
-            events.append(("wait", timeout))
-            return 0
+        def get_catalog(self):
+            return type("Catalog", (), {"workflows": ("flow",)})()
 
-        def kill(self):
-            events.append("kill")
+        def wait_for_failure(self, *, timeout):
+            events.append(("watch", timeout))
+            raise KeyboardInterrupt
 
-    def fake_start_operator_process(flows, port, use_ray, discovery_timeout):
-        events.append(("start", flows, port, use_ray, discovery_timeout))
-        return FakeProcess()
+        def close(self):
+            events.append("operator-close")
 
-    def fake_start_web_process(address, port):
-        events.append(("web", address, port))
-        return FakeProcess()
+    class FakeGrpcServer:
+        def stop(self, *, grace):
+            events.append(("grpc-stop", grace))
+            return self
 
-    monkeypatch.setattr(app, "_start_operator_process", fake_start_operator_process)
-    monkeypatch.setattr(app, "_start_web_process", fake_start_web_process)
+        def wait(self, *, timeout):
+            events.append(("grpc-wait", timeout))
+
+    class FakeChannel:
+        def close(self):
+            events.append("channel-close")
+
+    class FakeReady:
+        def result(self, *, timeout):
+            events.append(("ready", timeout))
+
+    class FakeBrowserServer:
+        endpoint = "http://127.0.0.1:8444"
+
+        def close(self):
+            events.append("web-close")
+
+    monkeypatch.setattr(app, "_configure_terminal_logging", lambda level: None)
+    monkeypatch.setattr(operator_module, "Operator", FakeOperator)
+    monkeypatch.setattr(
+        operator_server,
+        "serve",
+        lambda operator, **kwargs: events.append(("grpc-start", kwargs)) or FakeGrpcServer(),
+    )
+    monkeypatch.setattr(
+        operator_web,
+        "start_browser_server",
+        lambda address, **kwargs: events.append(("web-start", address, kwargs))
+        or FakeBrowserServer(),
+    )
+    monkeypatch.setattr(
+        grpc,
+        "insecure_channel",
+        lambda address: events.append(("channel", address)) or FakeChannel(),
+    )
+    monkeypatch.setattr(grpc, "channel_ready_future", lambda channel: FakeReady())
+    monkeypatch.setattr(
+        app.webbrowser,
+        "open",
+        lambda endpoint, *, new: events.append(("browser-open", endpoint, new)) or True,
+    )
 
     assert (
         app.main(
             [
                 "dev",
-                "--flows",
                 "examples",
                 "--ray",
                 "--port",
@@ -1689,14 +1893,151 @@ def test_ava_dev_starts_web_without_waiting_for_operator_readiness(monkeypatch):
         == 0
     )
     assert events == [
-        ("start", ["examples"], 8443, True, 45.0),
-        ("web", "127.0.0.1:8443", 8444),
-        ("wait", None),
-        "terminate",
-        ("wait", 5),
-        "terminate",
-        ("wait", 5),
+        (
+            "operator",
+            ["examples"],
+            {"discovery_timeout": 45.0, "executor_backend": "ray"},
+        ),
+        ("grpc-start", {"port": 8443, "block": False}),
+        ("channel", "127.0.0.1:8443"),
+        ("ready", 5.0),
+        "channel-close",
+        ("web-start", "127.0.0.1:8443", {"port": 8444}),
+        ("browser-open", "http://127.0.0.1:8444", 2),
+        ("watch", 0.1),
+        "web-close",
+        ("grpc-stop", 1.0),
+        ("grpc-wait", 2.0),
+        "operator-close",
     ]
+    output = capsys.readouterr().out
+    assert "Scan targets (command line)" in output
+    assert f"{Path('examples').resolve()} (directory)" in output
+
+
+def test_ava_dev_reports_discovery_failure_without_starting_services(monkeypatch, capsys):
+    from ava_cli import app
+    from runtime.operator import operator as operator_module
+    from runtime.operator.discovery import WorkflowDiscoveryError
+    from runtime.operator.models import WorkflowDiscoveryDiagnostic
+
+    starts = []
+
+    class FailingOperator:
+        def __init__(self, *_args, **_kwargs):
+            raise WorkflowDiscoveryError(
+                (
+                    WorkflowDiscoveryDiagnostic(
+                        path="flow.py",
+                        kind="import_error",
+                        message="No module named 'missing_helper'",
+                    ),
+                )
+            )
+
+    monkeypatch.setattr(app, "_configure_terminal_logging", lambda level: None)
+    monkeypatch.setattr(operator_module, "Operator", FailingOperator)
+    monkeypatch.setattr(
+        "runtime.operator.server.serve", lambda *_args, **_kwargs: starts.append("grpc")
+    )
+    monkeypatch.setattr(
+        "runtime.operator.web.start_browser_server",
+        lambda *_args, **_kwargs: starts.append("web"),
+    )
+
+    assert app.main(["dev", "examples"]) == 1
+    assert starts == []
+    error = capsys.readouterr().err
+    assert "Avalanche dev failed during discovery" in error
+    assert "No module named 'missing_helper'" in error
+
+
+def test_ava_dev_reports_operator_start_failure(monkeypatch, capsys):
+    from ava_cli import app
+    from runtime.operator import operator as operator_module
+    from runtime.operator import server as operator_server
+    from runtime.operator import web as operator_web
+
+    events = []
+
+    class FakeOperator:
+        def get_catalog(self):
+            return type("Catalog", (), {"workflows": ()})()
+
+        def close(self):
+            events.append("operator-close")
+
+    monkeypatch.setattr(app, "_configure_terminal_logging", lambda level: None)
+    monkeypatch.setattr(operator_module, "Operator", lambda *_args, **_kwargs: FakeOperator())
+    monkeypatch.setattr(
+        operator_server,
+        "serve",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("port is occupied")),
+    )
+    monkeypatch.setattr(
+        operator_web,
+        "start_browser_server",
+        lambda *_args, **_kwargs: events.append("web-start"),
+    )
+
+    assert app.main(["dev", "examples"]) == 1
+    assert events == ["operator-close"]
+    assert "Avalanche dev failed during operator startup" in capsys.readouterr().err
+
+
+def test_ava_dev_reports_web_start_failure(monkeypatch, capsys):
+    import grpc
+
+    from ava_cli import app
+    from runtime.operator import operator as operator_module
+    from runtime.operator import server as operator_server
+    from runtime.operator import web as operator_web
+
+    events = []
+
+    class FakeOperator:
+        def get_catalog(self):
+            return type("Catalog", (), {"workflows": ()})()
+
+        def close(self):
+            events.append("operator-close")
+
+    class FakeServer:
+        def stop(self, *, grace):
+            events.append(("grpc-stop", grace))
+            return self
+
+        def wait(self, *, timeout):
+            events.append(("grpc-wait", timeout))
+
+    class FakeChannel:
+        def close(self):
+            events.append("channel-close")
+
+    class FakeReady:
+        def result(self, *, timeout):
+            events.append(("ready", timeout))
+
+    monkeypatch.setattr(app, "_configure_terminal_logging", lambda level: None)
+    monkeypatch.setattr(operator_module, "Operator", lambda *_args, **_kwargs: FakeOperator())
+    monkeypatch.setattr(operator_server, "serve", lambda *_args, **_kwargs: FakeServer())
+    monkeypatch.setattr(grpc, "insecure_channel", lambda _address: FakeChannel())
+    monkeypatch.setattr(grpc, "channel_ready_future", lambda _channel: FakeReady())
+    monkeypatch.setattr(
+        operator_web,
+        "start_browser_server",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("web port is occupied")),
+    )
+
+    assert app.main(["dev", "examples"]) == 1
+    assert events == [
+        ("ready", 5.0),
+        "channel-close",
+        ("grpc-stop", 1.0),
+        ("grpc-wait", 2.0),
+        "operator-close",
+    ]
+    assert "Avalanche dev failed during web UI startup" in capsys.readouterr().err
 
 
 def test_ava_dev_rejects_colliding_operator_and_browser_ports(monkeypatch, capsys):
@@ -1705,58 +2046,17 @@ def test_ava_dev_rejects_colliding_operator_and_browser_ports(monkeypatch, capsy
     monkeypatch.setattr(app, "_run_dev", lambda args: 0)
 
     with pytest.raises(SystemExit) as exc_info:
-        app.main(["dev", "--port", "7435"])
+        app.main(["dev", "examples", "--port", "7435"])
 
     assert exc_info.value.code == 2
     assert "--port and --web-port must differ" in capsys.readouterr().err
 
 
-def test_ava_dev_defaults_flows_to_current_directory(monkeypatch):
+def test_ava_dev_requires_configured_or_explicit_workflow_targets(capsys):
     from ava_cli import app
 
-    calls = []
-    monkeypatch.setattr(
-        app,
-        "_run_dev",
-        lambda args: calls.append((args.flows, args.discovery_timeout)) or 0,
-    )
+    with pytest.raises(SystemExit) as exc_info:
+        app.main(["dev"])
 
-    assert app.main(["dev"]) == 0
-    assert calls == [(["."], 60.0)]
-
-
-def test_ava_dev_stops_operator_when_wait_is_interrupted(monkeypatch):
-    from ava_cli import app
-
-    events = []
-
-    class FakeProcess:
-        def terminate(self):
-            events.append("terminate")
-
-        def wait(self, timeout=None):
-            events.append(("wait", timeout))
-            if timeout is None:
-                raise KeyboardInterrupt
-            return 0
-
-        def kill(self):
-            events.append("kill")
-
-    monkeypatch.setattr(
-        app,
-        "_start_operator_process",
-        lambda flows, port, use_ray, discovery_timeout: FakeProcess(),
-    )
-    monkeypatch.setattr(app, "_start_web_process", lambda address, port: FakeProcess())
-
-    with pytest.raises(KeyboardInterrupt):
-        app.main(["dev", "--flows", "examples"])
-
-    assert events == [
-        ("wait", None),
-        "terminate",
-        ("wait", 5),
-        "terminate",
-        ("wait", 5),
-    ]
+    assert exc_info.value.code == 2
+    assert "No workflow targets configured" in capsys.readouterr().err

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -210,9 +210,12 @@ def test_ava_operator_accepts_multiple_file_targets(monkeypatch):
     ]
 
 
-def test_ava_operator_requires_configured_or_explicit_workflow_targets(capsys):
+def test_ava_operator_requires_configured_or_explicit_workflow_targets(
+    capsys, monkeypatch, tmp_path
+):
     from ava_cli import app
 
+    monkeypatch.chdir(tmp_path)
     with pytest.raises(SystemExit) as exc_info:
         app.main(["operator"])
 
@@ -339,9 +342,12 @@ def test_runtime_operator_configures_logging_before_serve(monkeypatch):
     assert lifecycle[1][1][1]["discovery_timeout"] == 45.0
 
 
-def test_runtime_operator_requires_configured_or_explicit_workflow_targets(capsys):
+def test_runtime_operator_requires_configured_or_explicit_workflow_targets(
+    capsys, monkeypatch, tmp_path
+):
     from runtime.operator import __main__ as operator_main
 
+    monkeypatch.chdir(tmp_path)
     with pytest.raises(SystemExit) as exc_info:
         operator_main.main([])
 
@@ -2052,9 +2058,12 @@ def test_ava_dev_rejects_colliding_operator_and_browser_ports(monkeypatch, capsy
     assert "--port and --web-port must differ" in capsys.readouterr().err
 
 
-def test_ava_dev_requires_configured_or_explicit_workflow_targets(capsys):
+def test_ava_dev_requires_configured_or_explicit_workflow_targets(
+    capsys, monkeypatch, tmp_path
+):
     from ava_cli import app
 
+    monkeypatch.chdir(tmp_path)
     with pytest.raises(SystemExit) as exc_info:
         app.main(["dev"])
 

--- a/test/operator_tests/test_grpc_v2.py
+++ b/test/operator_tests/test_grpc_v2.py
@@ -367,9 +367,7 @@ def test_discover_flows_continuation_keeps_its_catalog_snapshot(contract_stub, m
     monkeypatch.setattr(
         operator,
         "start_run",
-        lambda workflow_id, *, triggered_by: scheduled_runs.append(
-            (workflow_id, triggered_by)
-        ),
+        lambda workflow_id, *, triggered_by: scheduled_runs.append((workflow_id, triggered_by)),
     )
     first = service.DiscoverFlows(pb.DiscoverFlowsRequestV2(page_size=1))
 

--- a/test/operator_tests/test_operator.py
+++ b/test/operator_tests/test_operator.py
@@ -15,6 +15,7 @@ from avalanche import LocalExecutor, RayExecutor
 from avalanche._agent_evidence import emit_agent_evidence
 from runtime.operator import Operator
 from runtime.operator import operator as operator_module
+from runtime.operator.discovery import WorkflowDiscoveryError
 from runtime.operator.models import (
     NodeState,
     NodeStatus,
@@ -298,7 +299,16 @@ class TestOperatorLifecycle:
         finally:
             operator.close()
 
-    def test_refresh_invalid_file_retains_descriptor_and_schedule(self, tmp_path, caplog):
+    def test_initial_discovery_error_aborts_operator_start(self, tmp_path):
+        workflow_file = tmp_path / "broken.py"
+        workflow_file.write_text("invalid Python !!!\n")
+
+        with pytest.raises(WorkflowDiscoveryError) as exc_info:
+            Operator(workflow_paths=[str(workflow_file)], schedule=False, watch=False)
+
+        assert exc_info.value.diagnostics[0].kind == "import_error"
+
+    def test_refresh_invalid_file_raises_and_preserves_descriptor_and_schedule(self, tmp_path):
         workflow_file = tmp_path / "scheduled.py"
         workflow_file.write_text(
             "import avalanche as ava\n"
@@ -313,16 +323,49 @@ class TestOperatorLifecycle:
         assert len(operator._scheduler.list_schedules()) == 1
 
         workflow_file.write_text("invalid Python !!!\n")
-        caplog.set_level("INFO", logger="runtime.operator.operator")
-        operator._refresh_workflows()
+
+        with pytest.raises(WorkflowDiscoveryError):
+            operator._refresh_workflows()
 
         assert [item.workflow_id for item in operator.list_workflows()] == [
             "scheduled.py::scheduled"
         ]
         assert len(operator._scheduler.list_schedules()) == 1
         assert [item.kind for item in operator.list_diagnostics()] == ["import_error"]
-        assert "Workflow reload failed; retaining catalog revision" in caplog.text
-        assert "import_error" in caplog.text
+
+    def test_watcher_records_discovery_failure_for_process_supervision(
+        self, tmp_path, monkeypatch
+    ):
+        workflow_file = tmp_path / "flow.py"
+        workflow_file.write_text(
+            "import avalanche as ava\n" "@ava.workflow\n" "def flow():\n" "    return None\n"
+        )
+        operator = Operator(workflow_paths=[str(workflow_file)], schedule=False, watch=False)
+        failure = WorkflowDiscoveryError(
+            (
+                WorkflowDiscoveryDiagnostic(
+                    path=str(workflow_file),
+                    kind="import_error",
+                    message="No module named 'missing_helper'",
+                ),
+            )
+        )
+
+        def fake_watch(*_paths, **_kwargs):
+            yield {("modified", str(workflow_file))}
+
+        monkeypatch.setattr("watchfiles.watch", fake_watch)
+        monkeypatch.setattr(
+            operator,
+            "_refresh_workflows",
+            lambda _changed_files: (_ for _ in ()).throw(failure),
+        )
+        try:
+            operator._watch_loop()
+
+            assert operator.wait_for_failure(timeout=0) is failure
+        finally:
+            operator.close()
 
     def test_reload_diagnostic_summary_bounds_complete_rendered_text(self):
         diagnostic = WorkflowDiscoveryDiagnostic(
@@ -372,7 +415,8 @@ class TestOperatorLifecycle:
                 "def flow():\n"
                 "    return None\n"
             )
-            operator._refresh_workflows()
+            with pytest.raises(RuntimeError, match="Workflow reload reconciliation failed"):
+                operator._refresh_workflows()
 
             assert operator._registry.view is previous
             assert "Workflow reload reconciliation failed" in caplog.text

--- a/test/operator_tests/test_operator_tmux.py
+++ b/test/operator_tests/test_operator_tmux.py
@@ -19,9 +19,9 @@ import pytest
 TMUX = shutil.which("tmux")
 SESSION = "pytest-operator"
 FIXTURES = os.path.join(os.path.dirname(os.path.dirname(__file__)), "fixtures")
-OPERATOR_CMD = f"uv run ava operator --flows {FIXTURES}"
+OPERATOR_CMD = f"uv run ava operator {FIXTURES}"
 TUI_CMD = "uv run ava tui --connect localhost:17434"
-OPERATOR_PORT_CMD = f"uv run ava operator --flows {FIXTURES} --port 17434"
+OPERATOR_PORT_CMD = f"uv run ava operator {FIXTURES} --port 17434"
 
 
 def tmux_run(*args: str) -> str:

--- a/test/operator_tests/test_registry.py
+++ b/test/operator_tests/test_registry.py
@@ -12,7 +12,12 @@ import pytest
 
 import avalanche as ava
 from avalanche.dag import Workflow
-from runtime.operator.discovery import FileDiscoveryResult, _worker, configure_roots
+from runtime.operator.discovery import (
+    FileDiscoveryResult,
+    WorkflowDiscoveryTimeoutError,
+    _worker,
+    configure_roots,
+)
 from runtime.operator.discovery_cache import DiscoveryCache
 from runtime.operator.models import WorkflowDiscoveryDiagnostic
 from runtime.operator.registry import (
@@ -358,7 +363,9 @@ class TestWorkflowRegistry:
         assert [item.workflow_id for item in registry.descriptors()] == ["flow.py::scheduled"]
         assert registry.list_diagnostics()[0].kind == "import_error"
 
-    def test_discovery_timeout_retains_current_view(self, tmp_path, caplog):
+    def test_discovery_timeout_raises_typed_error_and_preserves_current_view(
+        self, tmp_path, caplog
+    ):
         workflow_file = tmp_path / "flow.py"
         workflow_file.write_text(
             "import avalanche as ava\n"
@@ -374,11 +381,13 @@ class TestWorkflowRegistry:
         workflow_file.write_text("while True:\n    pass\n")
         registry._discovery_timeout = 0.2
         started = time.monotonic()
-        registry.rescan()
+
+        with pytest.raises(WorkflowDiscoveryTimeoutError) as exc_info:
+            registry.rescan()
 
         assert time.monotonic() - started < 2.0
         assert [item.workflow_id for item in registry.descriptors()] == ["flow.py::scheduled"]
-        assert "exceeded 0.2s" in registry.list_diagnostics()[0].message
+        assert "exceeded 0.2s" in exc_info.value.diagnostics[0].message
         timeout_warnings = [
             record
             for record in caplog.records
@@ -674,7 +683,37 @@ class TestWorkflowRegistry:
         registry.rescan((str(helper),))
         assert registry.resolve("dependent").cron == "2 * * * *"
         assert registry.list_diagnostics() == []
-        assert unrelated_counter.read_text() == "1"
+        assert unrelated_counter.read_text() == "2"
+
+    def test_missing_dependency_recovery_forces_a_complete_rescan(self, tmp_path):
+        source_root = tmp_path / "flows"
+        source_root.mkdir()
+        flow = source_root / "flow.py"
+        helper = source_root / "_schedule.py"
+        flow.write_text(
+            "import avalanche as ava\n"
+            "@ava.workflow(cron='1 * * * *')\n"
+            "def scheduled():\n"
+            "    return None\n"
+        )
+        registry = WorkflowRegistry()
+        registry.scan([str(source_root)])
+
+        flow.write_text(
+            "import avalanche as ava\n"
+            "from _schedule import CRON\n"
+            "@ava.workflow(cron=CRON)\n"
+            "def scheduled():\n"
+            "    return None\n"
+        )
+        registry.rescan((str(flow),))
+        assert [item.kind for item in registry.list_diagnostics()] == ["import_error"]
+
+        helper.write_text('CRON = "2 * * * *"\n')
+        registry.rescan((str(helper),))
+
+        assert registry.resolve("scheduled").cron == "2 * * * *"
+        assert registry.list_diagnostics() == []
 
     def test_added_and_deleted_workflow_do_not_reimport_unchanged_files(self, tmp_path):
         source_root = tmp_path / "flows"

--- a/test/operator_tests/test_workspace_config.py
+++ b/test/operator_tests/test_workspace_config.py
@@ -1,0 +1,65 @@
+"""Tests for workspace-configured workflow targets."""
+
+import pytest
+
+from runtime.operator.workspace_config import format_scan_targets, select_workflow_targets
+
+
+def test_workspace_targets_resolve_relative_to_nearest_pyproject(tmp_path):
+    workspace = tmp_path / "workspace"
+    flows = workspace / "src"
+    flows.mkdir(parents=True)
+    nested = flows / "nested"
+    nested.mkdir()
+    config_path = workspace / "pyproject.toml"
+    config_path.write_text('[tool.avalanche]\nflow_targets = ["src"]\n')
+
+    selection = select_workflow_targets([], working_directory=nested)
+
+    assert selection.config_path == config_path
+    assert selection.paths == (str(flows),)
+    assert selection.roots[0].target == flows.resolve()
+    assert format_scan_targets(selection) == (
+        f"  Scan targets (workspace config: {config_path}):",
+        f"    - {flows.resolve()} (directory)",
+    )
+
+
+def test_explicit_targets_do_not_read_workspace_configuration(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    flow = workspace / "flow.py"
+    flow.write_text("import avalanche as ava\n")
+    (workspace / "pyproject.toml").write_text("not valid TOML")
+
+    selection = select_workflow_targets([str(flow)], working_directory=workspace)
+
+    assert selection.config_path is None
+    assert selection.paths == (str(flow),)
+    assert selection.roots[0].target == flow.resolve()
+
+
+@pytest.mark.parametrize(
+    "contents",
+    (
+        "[project]\nname = 'workspace'\n",
+        "[tool.avalanche]\nflow_targets = []\n",
+    ),
+)
+def test_missing_workspace_targets_requires_explicit_flow(tmp_path, contents):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text(contents)
+
+    with pytest.raises(ValueError, match="No workflow targets configured"):
+        select_workflow_targets([], working_directory=workspace)
+
+
+def test_invalid_workspace_target_identifies_its_configuration(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_path = workspace / "pyproject.toml"
+    config_path.write_text('[tool.avalanche]\nflow_targets = ["missing.py"]\n')
+
+    with pytest.raises(ValueError, match=str(config_path)):
+        select_workflow_targets([], working_directory=workspace)

--- a/test/operator_tests/test_workspace_config.py
+++ b/test/operator_tests/test_workspace_config.py
@@ -1,5 +1,7 @@
 """Tests for workspace-configured workflow targets."""
 
+from pathlib import Path
+
 import pytest
 
 from runtime.operator.workspace_config import format_scan_targets, select_workflow_targets
@@ -62,4 +64,22 @@ def test_invalid_workspace_target_identifies_its_configuration(tmp_path):
     config_path.write_text('[tool.avalanche]\nflow_targets = ["missing.py"]\n')
 
     with pytest.raises(ValueError, match=str(config_path)):
+        select_workflow_targets([], working_directory=workspace)
+
+
+def test_unresolved_workspace_home_directory_target_is_a_validation_error(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text(
+        '[tool.avalanche]\nflow_targets = ["~missing-user/flow.py"]\n'
+    )
+
+    def raise_unresolved_home_directory(_path: Path) -> Path:
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(Path, "expanduser", raise_unresolved_home_directory)
+
+    with pytest.raises(ValueError, match="unresolved home directory"):
         select_workflow_targets([], working_directory=workspace)

--- a/test/rerun_test.py
+++ b/test/rerun_test.py
@@ -57,6 +57,7 @@ EXECUTOR_FACTORIES = [
     pytest.param(ava.RayExecutor, marks=pytest.mark.ray),
 ]
 
+
 @pytest.fixture(scope="module")
 def _shared_ray_runtime():
     ray = pytest.importorskip("ray")

--- a/test/tui_tmux_test.py
+++ b/test/tui_tmux_test.py
@@ -22,6 +22,7 @@ TMUX = shutil.which("tmux")
 SESSION = "pytest-tui"
 TUI_CMD = "uv run ava tui"
 
+
 def tmux(*args: str, input: str | None = None) -> str:
     """Run a tmux command and return stdout."""
     result = subprocess.run(
@@ -81,9 +82,9 @@ def start_tui(args: str = "", *, width: int = 100, height: int = 40) -> None:
         SESSION,
         "#{window_width}x#{window_height}",
     ).strip()
-    assert actual_size == f"{width}x{height}", (
-        f"tmux session has size {actual_size!r}, expected {width}x{height}"
-    )
+    assert (
+        actual_size == f"{width}x{height}"
+    ), f"tmux session has size {actual_size!r}, expected {width}x{height}"
     subprocess.run(
         ["tmux", "respawn-pane", "-k", "-t", SESSION, command],
         check=True,


### PR DESCRIPTION
## Rationale

Local workflow discovery needs a deliberate workspace boundary. Scanning the current directory can import unrelated Python, while generated starter wrappers hide what source is actually scanned. Discovery errors also need to stop local services instead of leaving a stale catalog available for runs.

## Summary

- Replace the `--flows` default with optional positional `FLOW` targets for `ava operator` and `ava dev`. When omitted, commands read `[tool.avalanche].flow_targets` from the nearest `pyproject.toml`, resolve relative entries from that file, and fail before starting services when neither source is available. Explicit targets replace configured targets.
- Add validated workspace-target parsing and report every resolved absolute scan target with whether it came from the command line or workspace configuration. Configure this repository to scan `examples/operator_workflow.py` by default.
- Move `ava dev` under one lifecycle supervisor: it creates the operator, waits for gRPC readiness before starting the browser UI, reports startup stages, and closes the browser server, gRPC server, and operator in reverse order on shutdown or failure.
- Make discovery failures terminal across startup and live reload. Discovery now raises typed errors, validates file and directory targets, propagates watcher failures through the operator and blocking gRPC server, and forces a complete rescan after failed targeted discovery so a repaired dependency can recover.
- Update the starter workspace to configure `src/` in `pyproject.toml` and remove its local `uv run dev` wrapper. Update CLI, architecture, starter, example, and authoring documentation for configured targets and positional overrides.
- Add regression coverage for workspace target resolution, target reporting, failure propagation, reload recovery, and the starter layout. Isolate no-configuration CLI tests from this repository's configured default target.
- Require PR descriptions to be based on a complete diff against the base branch rather than only recent commits.

## Test Plan

- [x] Started `uv run ava dev --port 17443 --web-port 17444` without `FLOW`; verified discovery of the configured example and the browser UI response.
- [x] Reviewed the complete branch diff against `origin/main`.
- [x] CI: `uv lock --check`, dependency sync, Ruff, and non-tmux/non-Ray pytest suite.
- [x] CI: Ray tests, tmux TUI tests, browser UI tests, generated web assets, and browser performance check.
